### PR TITLE
feat: add window menu with New Note and Open Note

### DIFF
--- a/src/components/window-menu/menu/file-menu.ts
+++ b/src/components/window-menu/menu/file-menu.ts
@@ -1,0 +1,27 @@
+import { MenuItem, Submenu } from '@tauri-apps/api/menu'
+
+export async function createFileMenu({
+  newNote,
+  openNote,
+}: {
+  newNote: () => void
+  openNote: () => void
+}) {
+  return await Submenu.new({
+    text: 'File',
+    items: [
+      await MenuItem.new({
+        id: 'new-note',
+        text: 'New Note',
+        accelerator: 'CmdOrCtrl+N',
+        action: () => newNote(),
+      }),
+      await MenuItem.new({
+        id: 'open-note',
+        text: 'Open Note',
+        accelerator: 'CmdOrCtrl+O',
+        action: () => openNote(),
+      }),
+    ],
+  })
+}

--- a/src/components/window-menu/menu/index.ts
+++ b/src/components/window-menu/menu/index.ts
@@ -1,0 +1,22 @@
+import { Menu } from '@tauri-apps/api/menu'
+import { createFileMenu } from './file-menu'
+import { createMditMenu } from './mdit-menu'
+
+export async function installWindowMenu({
+  newNote,
+  openNote,
+}: {
+  newNote: () => void
+  openNote: () => void
+}) {
+  const menu = await Menu.new({
+    items: [
+      await createMditMenu(),
+      await createFileMenu({
+        newNote,
+        openNote,
+      }),
+    ],
+  })
+  menu.setAsAppMenu()
+}

--- a/src/components/window-menu/menu/mdit-menu.ts
+++ b/src/components/window-menu/menu/mdit-menu.ts
@@ -1,0 +1,13 @@
+import { PredefinedMenuItem, Submenu } from '@tauri-apps/api/menu'
+
+export async function createMditMenu() {
+  return await Submenu.new({
+    text: 'Mdit',
+    items: [
+      await PredefinedMenuItem.new({
+        text: 'Quit',
+        item: 'Quit',
+      }),
+    ],
+  })
+}

--- a/src/components/window-menu/window-menu.tsx
+++ b/src/components/window-menu/window-menu.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import { useTabContext } from '@/contexts/tab-context'
+import { installWindowMenu } from './menu'
+
+export function WindowMenu() {
+  const { newNote, openNote } = useTabContext()
+
+  useEffect(() => {
+    installWindowMenu({
+      newNote,
+      openNote,
+    })
+  }, [newNote, openNote])
+
+  return null
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client'
 import { Toaster } from '@/ui/sonner'
 import { App } from './app'
 import { Updater } from './components/updater/updater'
+import { WindowMenu } from './components/window-menu/window-menu'
 import { TabProvider } from './contexts/tab-context'
 import { ThemeProvider } from './contexts/theme-context'
 
@@ -11,6 +12,7 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <ThemeProvider>
       <TabProvider>
         <App />
+        <WindowMenu />
       </TabProvider>
     </ThemeProvider>
     <Updater />


### PR DESCRIPTION
Before:
<img width="361" height="72" alt="Screenshot 2025-08-28 at 11 02 21" src="https://github.com/user-attachments/assets/e8493dbc-5236-4641-a0f9-bb8a9d42a6a7" />

After:
<img width="260" height="85" alt="Screenshot 2025-08-28 at 12 15 24" src="https://github.com/user-attachments/assets/f02cdfd0-647b-4790-a538-9598a84b904f" />

because I customized the window menu, the default menus were removed, and I’ll have to manually add them back later.
