### PR TITLE
ux: delay API key password prompt until AIMenu is opened

### DIFF
--- a/src/components/editor/ui/ai-menu.tsx
+++ b/src/components/editor/ui/ai-menu.tsx
@@ -76,9 +76,8 @@ export function AIMenu() {
   const [anchorElement, setAnchorElement] = useState<HTMLElement | null>(null)
   const [modelPopoverOpen, setModelPopoverOpen] = useState(false)
 
-  // Load connected providers from localStorage on mount
   useEffect(() => {
-    if (isConfigLoaded && !open) return
+    if (isConfigLoaded || !open) return
     const loadConnectedProviders = async () => {
       try {
         const stored = localStorage.getItem('mdit-connected-providers')

--- a/src/components/editor/ui/ai-menu.tsx
+++ b/src/components/editor/ui/ai-menu.tsx
@@ -68,6 +68,7 @@ export function AIMenu() {
   } | null>(null)
   const [showApiKeyInput, setShowApiKeyInput] = useState(false)
   const [apiKeyInput, setApiKeyInput] = useState('')
+  const [isConfigLoaded, setIsConfigLoaded] = useState(false)
 
   const chat = useChat(chatConfig)
 
@@ -77,6 +78,7 @@ export function AIMenu() {
 
   // Load connected providers from localStorage on mount
   useEffect(() => {
+    if (isConfigLoaded && !open) return
     const loadConnectedProviders = async () => {
       try {
         const stored = localStorage.getItem('mdit-connected-providers')
@@ -112,11 +114,13 @@ export function AIMenu() {
       } catch {
         // Failed to load from localStorage
         setConnectedProviders([])
+      } finally {
+        setIsConfigLoaded(true)
       }
     }
 
     loadConnectedProviders()
-  }, [])
+  }, [isConfigLoaded, open])
 
   // Helper function to load API key and set config
   const loadApiKeyAndSetConfig = async (provider: string, model: string) => {


### PR DESCRIPTION
This PR defers the API key password prompt until the **AI Menu** is explicitly opened. It supports our ongoing push to reduce intrusive modals in the editor flow.

## Changes
- Gate initial configuration and provider-loading behind a new `isConfigLoaded` flag so we don’t immediately prompt on note mount.
- Update the `useEffect` that loads connected providers:
  - Early return when `isConfigLoaded || !open`, so loading (and any downstream prompt) won’t run until the menu is opened.
  - Add `open` to the dependency array to ensure the load runs when the menu is opened, not on note mount.
  - Set `isConfigLoaded` to `true` in `finally` to avoid repeated loads.
- Net effect: configuration loading and the password prompt for retrieving API keys are delayed to first interaction with the AI Menu, improving initial note-open UX and reducing surprise prompts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Defers loading connected providers and default API key/config until the AI menu is opened, avoiding early password prompts and repeated loads.
> 
> - **AI Menu (`src/components/editor/ui/ai-menu.tsx`)**:
>   - Gate initial provider/config loading behind `isConfigLoaded` and `open`.
>     - Add `isConfigLoaded` state; early-return in `useEffect` if already loaded or menu not open.
>     - Move `setIsConfigLoaded(true)` to `finally` to prevent repeated loads.
>     - Update `useEffect` deps to `[isConfigLoaded, open]` so loading runs on first open, not on mount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fef6032bb7a4e30d172f80bbcd85d4af76754e08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->