### PR TITLE
fix: hotkey interception for popover inputs

### DIFF
--- a/src/components/editor/ui/ai-menu-add-command.tsx
+++ b/src/components/editor/ui/ai-menu-add-command.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/ui/select'
 import { Textarea } from '@/ui/textarea'
 import type { Command } from '../hooks/use-ai-commands'
+import { interceptPopoverHotkeys } from '../utils/intercept-popover-hotkeys'
 import {
   DEFAULT_SELECTION_COMMAND_TEMPLATE_MAP,
   DEFAULT_SELECTION_COMMAND_TEMPLATES,
@@ -122,6 +123,9 @@ export function AIMenuAddCommand({ onAdd, onClose }: Props) {
                     autoComplete="off"
                     spellCheck="false"
                     autoFocus
+                    onKeyDown={(event) => {
+                      interceptPopoverHotkeys(event)
+                    }}
                   />
                 </Field>
               )}
@@ -138,6 +142,9 @@ export function AIMenuAddCommand({ onAdd, onClose }: Props) {
                     placeholder="Summarize the selected text in 3 bullet points"
                     autoComplete="off"
                     spellCheck="false"
+                    onKeyDown={(event) => {
+                      interceptPopoverHotkeys(event)
+                    }}
                   />
                 </Field>
               )}

--- a/src/components/editor/ui/ai-menu-content.tsx
+++ b/src/components/editor/ui/ai-menu-content.tsx
@@ -3,6 +3,7 @@ import { Loader2Icon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Command, CommandList } from '@/ui/command'
 import type { Command as TCommand } from '../hooks/use-ai-commands'
+import { interceptPopoverHotkeys } from '../utils/intercept-popover-hotkeys'
 import { AIMenuItems } from './ai-menu-items'
 import { AIModelSelector } from './ai-model-selector'
 
@@ -76,7 +77,10 @@ export function AIMenuContent({
             )}
             data-plate-focus
             onClick={onInputClick}
-            onKeyDown={onInputKeyDown}
+            onKeyDown={(event) => {
+              interceptPopoverHotkeys(event)
+              onInputKeyDown(event)
+            }}
             onValueChange={onInputChange}
             placeholder={
               chatConfig

--- a/src/components/editor/utils/intercept-popover-hotkeys.ts
+++ b/src/components/editor/utils/intercept-popover-hotkeys.ts
@@ -1,0 +1,77 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
+
+function haltEvent(event: ReactKeyboardEvent<Element>) {
+  event.preventDefault()
+  event.stopPropagation()
+
+  const nativeEvent = event.nativeEvent
+  if ('stopImmediatePropagation' in nativeEvent) {
+    nativeEvent.stopImmediatePropagation()
+  }
+}
+
+// The popover lives inside the editor tree, so we hijack these hotkeys and
+// emulate the native select-all and cut behaviours without bubbling upward.
+export function interceptPopoverHotkeys(event: ReactKeyboardEvent<Element>) {
+  const isMetaCombo = event.metaKey || event.ctrlKey
+  const key = event.key.toLowerCase()
+
+  if (!isMetaCombo || (key !== 'a' && key !== 'x')) {
+    return
+  }
+
+  const target =
+    event.target instanceof HTMLInputElement ||
+    event.target instanceof HTMLTextAreaElement
+      ? (event.target as HTMLInputElement | HTMLTextAreaElement)
+      : null
+
+  haltEvent(event)
+
+  if (!target) {
+    return
+  }
+
+  if (key === 'a') {
+    target.select()
+    return
+  }
+
+  const selectionStart = target.selectionStart ?? 0
+  const selectionEnd = target.selectionEnd ?? selectionStart
+
+  if (selectionStart === selectionEnd) {
+    return
+  }
+
+  const selectedText = target.value.slice(selectionStart, selectionEnd)
+
+  if (selectedText) {
+    try {
+      if (navigator.clipboard?.writeText) {
+        navigator.clipboard.writeText(selectedText)
+      } else {
+        document.execCommand('copy')
+      }
+    } catch {
+      try {
+        document.execCommand('copy')
+      } catch {
+        // ignore clipboard errors
+      }
+    }
+  }
+
+  const nextValue =
+    target.value.slice(0, selectionStart) + target.value.slice(selectionEnd)
+
+  if (nextValue === target.value) {
+    return
+  }
+
+  target.value = nextValue
+
+  target.setSelectionRange(selectionStart, selectionStart)
+
+  target.dispatchEvent(new Event('input', { bubbles: true }))
+}

--- a/src/ui/input.tsx
+++ b/src/ui/input.tsx
@@ -6,7 +6,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'file:text-foreground placeholder:text-muted-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[1px]',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         className


### PR DESCRIPTION
- Added a utility function to intercept and handle hotkeys (Ctrl+A and Ctrl+X) within popover inputs, allowing for native select-all and cut functionalities.
- Updated AI menu components to utilize the new hotkey interception, enhancing user experience by preventing event bubbling and ensuring clipboard operations work seamlessly.