### PR TITLE
feat: rename on enter key

### DIFF
--- a/src/components/file-explorer/file-explorer.tsx
+++ b/src/components/file-explorer/file-explorer.tsx
@@ -15,8 +15,11 @@ import { Button } from '@/ui/button'
 import { SettingsMenu } from './ui/settings-menu'
 import { TreeNode } from './ui/tree-node'
 import { WorkspaceDropdown } from './ui/workspace-dropdown'
+import { useEntryMap } from './hooks/use-entry-map'
+import { useEnterToRename } from './hooks/use-enter-to-rename'
 
 export function FileExplorer() {
+  const fileExplorerRef = useRef<HTMLElement | null>(null)
   const { isOpen, width, isResizing, handlePointerDown } =
     useFileExplorerResize()
   // const { licenseStatus, openLicenseDialog } = useLicenseStore()
@@ -92,6 +95,7 @@ export function FileExplorer() {
     })
     return map
   }, [visibleEntryPaths])
+  const entryMap = useEntryMap(entries)
 
   // Setup workspace root as a drop target
   const { setNodeRef: setWorkspaceDropRef, isOver: isOverWorkspace } =
@@ -197,6 +201,14 @@ export function FileExplorer() {
     },
     [renameEntry]
   )
+
+  useEnterToRename({
+    containerRef: fileExplorerRef,
+    selectionAnchorPath,
+    renamingEntryPath,
+    beginRenaming,
+    entryMap,
+  })
 
   const handleDeleteEntries = useCallback(
     async (paths: string[]) => {
@@ -530,6 +542,7 @@ export function FileExplorer() {
 
   return (
     <aside
+      ref={fileExplorerRef}
       className={cn(
         'font-scale-scope relative shrink-0 flex flex-col bg-muted border-r',
         !isResizing && 'transition-[width] duration-200',

--- a/src/components/file-explorer/hooks/use-enter-to-rename.ts
+++ b/src/components/file-explorer/hooks/use-enter-to-rename.ts
@@ -1,0 +1,73 @@
+import { useEffect } from 'react'
+
+import type { WorkspaceEntry } from '@/store/workspace-store'
+
+type UseEnterToRenameOptions = {
+  containerRef: React.RefObject<HTMLElement | null>
+  selectionAnchorPath: string | null
+  renamingEntryPath: string | null
+  beginRenaming: (entry: WorkspaceEntry) => void
+  entryMap: Map<string, WorkspaceEntry>
+}
+
+export function useEnterToRename({
+  containerRef,
+  selectionAnchorPath,
+  renamingEntryPath,
+  beginRenaming,
+  entryMap,
+}: UseEnterToRenameOptions) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Enter' || event.defaultPrevented || event.repeat) {
+        return
+      }
+
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+        return
+      }
+
+      const target = event.target as HTMLElement | null
+      if (!target) {
+        return
+      }
+
+      if (containerRef.current && !containerRef.current.contains(target)) {
+        return
+      }
+
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable
+      ) {
+        return
+      }
+
+      if (!selectionAnchorPath || renamingEntryPath) {
+        return
+      }
+
+      const entry = entryMap.get(selectionAnchorPath)
+      if (!entry) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+      beginRenaming(entry)
+    }
+
+    window.addEventListener('keydown', handleKeyDown, true)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown, true)
+    }
+  }, [
+    beginRenaming,
+    containerRef,
+    entryMap,
+    renamingEntryPath,
+    selectionAnchorPath,
+  ])
+}
+

--- a/src/components/file-explorer/hooks/use-entry-map.ts
+++ b/src/components/file-explorer/hooks/use-entry-map.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react'
+
+import type { WorkspaceEntry } from '@/store/workspace-store'
+
+export function useEntryMap(entries: WorkspaceEntry[]) {
+  return useMemo(() => {
+    const map = new Map<string, WorkspaceEntry>()
+
+    const traverse = (nodes: WorkspaceEntry[]) => {
+      for (const node of nodes) {
+        map.set(node.path, node)
+        if (node.children?.length) {
+          traverse(node.children)
+        }
+      }
+    }
+
+    traverse(entries)
+    return map
+  }, [entries])
+}
+


### PR DESCRIPTION
- Introduced `useEntryMap` hook to create a map of workspace entries for efficient access.
- Added `useEnterToRename` hook to handle renaming entries via the Enter key, improving user interaction.
- Updated `FileExplorer` component to integrate these hooks, enhancing its functionality and user experience.