### PR TITLE
feat: implement previous code block language application

### DIFF
--- a/src/components/editor/plugins/autoformat-kit.tsx
+++ b/src/components/editor/plugins/autoformat-kit.tsx
@@ -12,6 +12,7 @@ import {
 import { insertEmptyCodeBlock } from '@platejs/code-block'
 import { toggleList } from '@platejs/list'
 import { KEYS } from 'platejs'
+import { applyPreviousCodeBlockLanguage } from '../utils/code-block-language'
 
 const autoformatMarks: AutoformatRule[] = [
   {
@@ -127,9 +128,12 @@ const autoformatBlocks: AutoformatRule[] = [
     mode: 'block',
     type: KEYS.codeBlock,
     format: (editor) => {
-      insertEmptyCodeBlock(editor, {
-        defaultType: KEYS.p,
-        insertNodesOptions: { select: true },
+      editor.tf.withoutNormalizing(() => {
+        insertEmptyCodeBlock(editor, {
+          defaultType: KEYS.p,
+          insertNodesOptions: { select: true },
+        })
+        applyPreviousCodeBlockLanguage(editor)
       })
     },
   },

--- a/src/components/editor/ui/node-slash.tsx
+++ b/src/components/editor/ui/node-slash.tsx
@@ -27,6 +27,7 @@ import { PlateElement } from 'platejs/react'
 import YAML from 'yaml'
 import { useTabStore } from '@/store/tab-store'
 import { FRONTMATTER_KEY } from '../plugins/frontmatter-kit'
+import { applyPreviousCodeBlockLanguage } from '../utils/code-block-language'
 import { insertBlock, insertInlineElement } from '../utils/transforms'
 import {
   InlineCombobox,
@@ -301,7 +302,12 @@ const groups: Group[] = [
     ].map((item) => ({
       ...item,
       onSelect: (editor, value) => {
-        insertBlock(editor, value)
+        editor.tf.withoutNormalizing(() => {
+          insertBlock(editor, value)
+          if (value === KEYS.codeBlock) {
+            applyPreviousCodeBlockLanguage(editor)
+          }
+        })
       },
     })),
   },

--- a/src/components/editor/utils/code-block-language.ts
+++ b/src/components/editor/utils/code-block-language.ts
@@ -1,0 +1,51 @@
+import {
+  KEYS,
+  type Path,
+  PathApi,
+  type SlateEditor,
+  type TCodeBlockElement,
+} from 'platejs'
+
+function getCurrentCodeBlockEntry(editor: SlateEditor) {
+  const options = {
+    block: true,
+    mode: 'lowest' as const,
+    match: { type: editor.getType(KEYS.codeBlock) },
+  }
+
+  if (!editor.selection) {
+    return editor.api.node<TCodeBlockElement>(options)
+  }
+
+  return editor.api.node<TCodeBlockElement>({
+    ...options,
+    at: editor.selection,
+  })
+}
+
+function getPreviousCodeBlockEntry(editor: SlateEditor, currentPath: Path) {
+  return editor.api.previous<TCodeBlockElement>({
+    at: currentPath,
+    block: true,
+    mode: 'lowest',
+    match: { type: editor.getType(KEYS.codeBlock) },
+  })
+}
+
+export function applyPreviousCodeBlockLanguage(editor: SlateEditor) {
+  const currentEntry = getCurrentCodeBlockEntry(editor)
+  if (!currentEntry) return
+
+  const [currentNode, path] = currentEntry
+  const previousEntry = getPreviousCodeBlockEntry(editor, path)
+  if (!previousEntry) return
+
+  const [previousNode, previousPath] = previousEntry
+  if (PathApi.equals(previousPath, path)) return
+
+  const lang = previousNode.lang?.trim()
+  if (!lang) return
+  if (currentNode.lang === lang) return
+
+  editor.tf.setNodes<TCodeBlockElement>({ lang }, { at: path })
+}


### PR DESCRIPTION
- Added a utility function to apply the language of the previous code block when inserting a new code block or selecting a code block in the editor.
- Updated the autoformat and node-slash plugins to utilize the new functionality for maintaining code block language consistency.