### PR TITLE
fix: layout

### DIFF
--- a/src/components/collection-view/collection-view.tsx
+++ b/src/components/collection-view/collection-view.tsx
@@ -35,6 +35,7 @@ export function CollectionView() {
   const { isOpen, width, isResizing, handlePointerDown } = useResizablePanel({
     storageKey: 'collection-view-width',
     defaultWidth: 256,
+    minWidth: 200,
     isOpen: isCollectionViewOpen,
     setIsOpen: (open: boolean) => {
       setCurrentCollectionPath((prev) => (open ? prev : null))
@@ -45,6 +46,9 @@ export function CollectionView() {
   )
 
   useEffect(() => {
+    if (!isOpen) {
+      return
+    }
     if (tab?.path) {
       dirname(tab.path)
         .then((folderPath) => {
@@ -54,7 +58,8 @@ export function CollectionView() {
           console.error('Failed to get directory path from tab:', error)
         })
     }
-  }, [tab?.path, setCurrentCollectionPath])
+  }, [tab?.path, setCurrentCollectionPath, isOpen])
+
   const isFileExplorerOpen = useUIStore((state) => state.isFileExplorerOpen)
   const { deleteEntries, renameNoteWithAI } = useWorkspaceStore(
     useShallow((state) => ({

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -11,6 +11,8 @@ import {
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { cn } from '@/lib/utils'
 import { useTabStore } from '@/store/tab-store'
+import { useUIStore } from '@/store/ui-store'
+import { useWorkspaceStore } from '@/store/workspace-store'
 import { HistoryNavigation } from './header/history-navigation'
 import { MoreButton } from './header/more-button'
 import { Tab } from './header/tab'
@@ -23,6 +25,10 @@ import {
 
 export function Editor() {
   const tab = useTabStore((s) => s.tab)
+  const isFileExplorerOpen = useUIStore((s) => s.isFileExplorerOpen)
+  const currentCollectionPath = useWorkspaceStore(
+    (s) => s.currentCollectionPath
+  )
   const editor = useMemo(() => {
     return createSlateEditor({
       plugins: EditorKit,
@@ -39,12 +45,23 @@ export function Editor() {
   return (
     <div className="relative flex-1 flex flex-col bg-background">
       <div
-        className="h-12 flex items-center justify-between px-2"
+        className="w-full h-12 flex items-center justify-center px-2 relative"
         data-tauri-drag-region
       >
-        <HistoryNavigation />
+        <div
+          className={cn(
+            'absolute',
+            !isFileExplorerOpen && currentCollectionPath === null
+              ? 'left-30 pl-2 border-l'
+              : 'left-2'
+          )}
+        >
+          <HistoryNavigation />
+        </div>
         <Tab />
-        <MoreButton />
+        <div className="absolute right-2">
+          <MoreButton />
+        </div>
       </div>
       <div className="font-scale-scope flex-1 overflow-hidden">
         <EditorContent key={tab.id} path={tab.path} value={value} />

--- a/src/components/editor/header/history-navigation.tsx
+++ b/src/components/editor/header/history-navigation.tsx
@@ -68,7 +68,7 @@ function HistoryButton({
           aria-label={ariaLabel}
           variant="ghost"
           size="icon"
-          className="text-foreground/70 disabled:hover:text-muted-foreground"
+          className="text-foreground/70 disabled:opacity-50"
           disabled={disabled}
           data-tauri-drag-region="no-drag"
           onClick={onClick}


### PR DESCRIPTION
- Added minimum width to the collection view panel.
- Updated effect dependencies in the collection view for better responsiveness.
- Adjusted layout of the editor header to improve positioning of navigation and buttons based on file explorer state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens collection panel min width and tab-sync behavior when closed, and repositions editor header controls with refined disabled styling.
> 
> - **UI/Layout**
>   - **Editor header (`src/components/editor/editor.tsx`)**: Centers header content; positions `HistoryNavigation` absolutely on the left (offset varies by file explorer and collection state) and `MoreButton` on the right.
> - **Collection View (`src/components/collection-view/collection-view.tsx`)**
>   - Adds `minWidth: 200` to resizable panel.
>   - Gates folder-path sync by `isOpen` and updates effect dependencies to include `isOpen`.
> - **Styling**
>   - **History nav buttons (`src/components/editor/header/history-navigation.tsx`)**: Disabled state now uses `opacity-50`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f51203a62c3cc8ca2a591e199e3fb25395d81c24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->