### PR TITLE
feat: add tauri-plugin-window-state for window state management

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2647,6 +2647,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "tiktoken-rs",
  "trash",
  "walkdir",
@@ -5236,6 +5237,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.10.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ blake3 = "1"
 ollama-rs = "0.3.2"
 tiktoken-rs = "0.5"
 tauri-plugin-clipboard = "2.1.11"
+tauri-plugin-window-state = "2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "fs:read-all",
     "fs:write-all",
     "clipboard:read-all",
+    "window-state:default",
     {
       "identifier": "fs:scope",
       "allow": [

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod migrations;
 use std::fs::File;
 use std::io::Read;
 use trash;
+use tauri_plugin_window_state::Builder as WindowStateBuilder;
 
 #[tauri::command]
 fn move_to_trash(path: String) {
@@ -108,6 +109,7 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_clipboard::init())
+        .plugin(WindowStateBuilder::default().build())
         .invoke_handler(tauri::generate_handler![
             move_to_trash,
             move_many_to_trash,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,10 +15,10 @@
       {
         "title": "Mdit",
         "titleBarStyle": "Overlay",
-        "maximized": true,
         "hiddenTitle": true,
         "dragDropEnabled": true,
         "transparent": true,
+        "visible": false,
         "windowEffects": {
           "effects": ["hudWindow", "blur"]
         },


### PR DESCRIPTION
* Added tauri-plugin-window-state dependency to Cargo.toml and Cargo.lock.
* Integrated window state management into the application by updating the main plugin initialization in lib.rs.
* Updated default.json capabilities to include window-state support.
* Removed maximized property from tauri.conf.json for improved window handling.