### PR TITLE
enhance: integrate pulldown-cmark for chunking v2

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2633,6 +2633,7 @@ dependencies = [
  "blake3",
  "include_dir",
  "ollama-rs",
+ "pulldown-cmark",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3708,6 +3709,24 @@ dependencies = [
  "quote",
  "syn 2.0.110",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+dependencies = [
+ "bitflags 2.10.0",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pxfm"
@@ -5833,6 +5852,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ ollama-rs = "0.3.2"
 tiktoken-rs = "0.5"
 tauri-plugin-clipboard = "2.1.11"
 tauri-plugin-window-state = "2"
+pulldown-cmark = { version = "0.13.0", default-features = false, features = ["simd"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/src/indexing/chunking/tests.rs
+++ b/src-tauri/src/indexing/chunking/tests.rs
@@ -1,0 +1,122 @@
+use super::{split_major_sections, split_section_by_tokens};
+
+const GFM_MARKDOWN: &str = r#"---
+title: Sample Doc
+tags:
+  - demo
+---
+
+# Overview
+Welcome to **Mdit**.
+
+## TODOs
+- [ ] Outline pulldown flow
+- [x] Wire chunk tests
+
+---
+
+# Data
+| Column | Type |
+| ------ | ---- |
+| id | number |
+| title | text |
+
+```rust
+fn main() {
+    println!("hello gfm");
+}
+```
+"#;
+
+const RULE_IN_CODE_BLOCK: &str = r#"# Section
+
+```
+---
+```
+
+## After
+Still content here
+"#;
+
+#[test]
+fn splits_gfm_sections_with_headings_and_tables() {
+    let chunks = split_major_sections(GFM_MARKDOWN);
+    let expected = vec![
+        "---\ntitle: Sample Doc\ntags:\n  - demo\n---",
+        "# Overview\nWelcome to **Mdit**.",
+        "## TODOs\n- [ ] Outline pulldown flow\n- [x] Wire chunk tests",
+        "# Data",
+        "| Column | Type |\n| ------ | ---- |\n| id | number |\n| title | text |",
+        "```rust\nfn main() {\n    println!(\"hello gfm\");\n}\n```",
+    ]
+    .into_iter()
+    .map(|section| section.to_string())
+    .collect::<Vec<_>>();
+
+    assert_eq!(chunks, expected);
+}
+
+#[test]
+fn code_blocks_split_into_separate_sections_and_ignore_rules() {
+    let chunks = split_major_sections(RULE_IN_CODE_BLOCK);
+    assert_eq!(chunks.len(), 3);
+    assert_eq!(chunks[0], "# Section");
+    assert!(
+        chunks[1].contains("```"),
+        "code block section should contain fenced code block"
+    );
+    assert!(
+        chunks[1].contains("---"),
+        "code block section should keep literal dashes inside code block"
+    );
+    assert_eq!(chunks[2], "## After\nStill content here");
+}
+
+#[test]
+fn splits_h3_headings_into_sections() {
+    let markdown = r#"# Title
+
+Intro
+
+### Details
+More data here
+
+### Extra
+Closing thoughts
+"#;
+
+    let chunks = split_major_sections(markdown);
+    assert_eq!(chunks.len(), 3);
+    assert_eq!(chunks[0], "# Title\n\nIntro");
+    assert_eq!(chunks[1], "### Details\nMore data here");
+    assert_eq!(chunks[2], "### Extra\nClosing thoughts");
+}
+
+#[test]
+fn splits_long_sections_by_paragraph_before_tokens() {
+    let section = "alpha beta gamma delta\n\nepsilon zeta eta theta\n\niota kappa lambda mu";
+    let chunks = split_section_by_tokens(section, 7);
+
+    assert_eq!(chunks.len(), 3, "paragraph boundaries should be respected");
+    assert_eq!(chunks[0], "alpha beta gamma delta");
+    assert_eq!(chunks[1], "epsilon zeta eta theta");
+    assert_eq!(chunks[2], "iota kappa lambda mu");
+}
+
+#[test]
+fn falls_back_to_token_split_for_single_large_paragraph() {
+    let section = "Rep".repeat(60);
+    let chunks = split_section_by_tokens(&section, 10);
+
+    assert!(chunks.len() > 1, "single oversized paragraph should be token split");
+}
+
+#[test]
+fn keeps_tables_together_even_with_blank_lines() {
+    let section = "| Column | Type |\n| ------ | ---- |\n\n| id | number |\n| title | text |";
+    let chunks = split_section_by_tokens(section, 200);
+
+    assert_eq!(chunks.len(), 1, "tables should remain atomic");
+    assert!(chunks[0].contains("| Column | Type |"));
+    assert!(chunks[0].contains("| title | text |"));
+}

--- a/src-tauri/src/indexing/mod.rs
+++ b/src-tauri/src/indexing/mod.rs
@@ -27,7 +27,7 @@ use files::collect_markdown_files;
 pub(crate) use search::{search_notes_for_query, SemanticNoteEntry};
 use sync::sync_documents;
 
-const TARGET_CHUNKING_VERSION: i64 = 1;
+const TARGET_CHUNKING_VERSION: i64 = 2;
 
 /// Human readable summary of what happened during an indexing run.
 #[derive(Debug, Default, Serialize)]


### PR DESCRIPTION
* Added pulldown-cmark dependency to Cargo.toml and Cargo.lock.
* Updated chunking logic to support new chunking version and improved Markdown section splitting.
* Introduced tests for section splitting and token management to ensure robust handling of Markdown content.