### PR TITLE
fix: update context menu selection behavior

### DIFF
--- a/src/components/collection-view/hooks/use-collection-context-menu.ts
+++ b/src/components/collection-view/hooks/use-collection-context-menu.ts
@@ -106,6 +106,10 @@ export function useCollectionContextMenu({
 
       if (isSelected) {
         selectionTargets = Array.from(selectedEntryPaths)
+      } else if (selectedEntryPaths.size === 1) {
+        // Special case: if exactly one item is selected and user opens context menu
+        // on a different entry, don't modify selection and only delete the context menu entry
+        selectionTargets = [entry.path]
       } else {
         const nextSelection = new Set(selectedEntryPaths)
         const hadSelection = nextSelection.size > 0

--- a/src/components/file-explorer/hooks/use-context-menus.ts
+++ b/src/components/file-explorer/hooks/use-context-menus.ts
@@ -224,6 +224,10 @@ export const useFileExplorerMenus = ({
 
       if (isSelected) {
         selectionTargets = Array.from(selectedEntryPaths)
+      } else if (selectedEntryPaths.size === 1) {
+        // Special case: if exactly one item is selected and user opens context menu
+        // on a different entry, don't modify selection and only delete the context menu entry
+        selectionTargets = [entry.path]
       } else {
         const nextSelection = new Set(selectedEntryPaths)
         const hadSelection = nextSelection.size > 0


### PR DESCRIPTION
- Added a special case for context menu interactions when exactly one item is selected, ensuring that the selection remains unchanged when the menu is opened on a different entry.

resolves: #204 