### PR TITLE
fix: top menu ui positions in fullscreen

### DIFF
--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -9,6 +9,7 @@ import {
   usePlateEditor,
 } from 'platejs/react'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useIsFullscreen } from '@/hooks/use-is-fullscreen'
 import { cn } from '@/lib/utils'
 import { useTabStore } from '@/store/tab-store'
 import { useUIStore } from '@/store/ui-store'
@@ -35,6 +36,7 @@ export function Editor() {
     (s) => s.currentCollectionPath !== null
   )
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)
+  const isFullscreen = useIsFullscreen()
 
   const editor = useMemo(() => {
     return createSlateEditor({
@@ -69,11 +71,11 @@ export function Editor() {
           className={cn(
             'absolute',
             !isFileExplorerOpen && !isCollectionViewOpen
-              ? isMac()
+              ? isMac() && !isFullscreen
                 ? 'left-30'
                 : 'left-12'
               : 'left-2',
-            !workspacePath && (isMac() ? 'left-20' : 'left-2')
+            !workspacePath && (isMac() && !isFullscreen ? 'left-20' : 'left-2')
           )}
         >
           <HistoryNavigation />

--- a/src/components/file-explorer/ui/top-menu.tsx
+++ b/src/components/file-explorer/ui/top-menu.tsx
@@ -1,3 +1,4 @@
+import { useIsFullscreen } from '@/hooks/use-is-fullscreen'
 import { cn } from '@/lib/utils'
 import { isMac } from '@/utils/platform'
 import { SearchButton } from './search-button'
@@ -17,7 +18,8 @@ export function TopMenu({
   setFileExplorerOpen: (isOpen: boolean) => void
 }) {
   const isMacOS = isMac()
-  const closedWidth = isMacOS ? 120 : 48
+  const isFullscreen = useIsFullscreen()
+  const closedWidth = isMacOS ? (isFullscreen ? 48 : 120) : 48
 
   return (
     <div

--- a/src/hooks/use-is-fullscreen.ts
+++ b/src/hooks/use-is-fullscreen.ts
@@ -1,0 +1,74 @@
+import { getCurrentWindow } from '@tauri-apps/api/window'
+import { useEffect, useState } from 'react'
+import { isMac } from '@/utils/platform'
+
+/**
+ * Hook to detect if the window is currently in fullscreen mode.
+ * Only works on macOS - returns false on other platforms.
+ *
+ * Listens to window resize events and checks fullscreen status with debouncing
+ * to avoid excessive API calls during window resizing.
+ *
+ * @param debounceMs - Debounce delay in milliseconds (default: 150ms)
+ * @returns boolean indicating if the window is in fullscreen mode
+ *
+ * @example
+ * ```tsx
+ * const isFullscreen = useIsFullscreen()
+ * const leftOffset = isFullscreen ? 'left-2' : 'left-30'
+ * ```
+ */
+export function useIsFullscreen(debounceMs = 600) {
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const isMacOS = isMac()
+
+  useEffect(() => {
+    // Only check fullscreen on macOS
+    if (!isMacOS) {
+      setIsFullscreen(false)
+      return
+    }
+
+    const currentWindow = getCurrentWindow()
+    let debounceTimer: NodeJS.Timeout | null = null
+
+    /**
+     * Checks the current fullscreen status from Tauri window API
+     */
+    const checkFullscreen = async () => {
+      try {
+        const fullscreen = await currentWindow.isFullscreen()
+        setIsFullscreen(fullscreen)
+      } catch (error) {
+        console.error('Failed to check fullscreen status:', error)
+      }
+    }
+
+    /**
+     * Debounced resize handler to avoid excessive API calls
+     */
+    const handleResize = () => {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer)
+      }
+      debounceTimer = setTimeout(() => {
+        checkFullscreen()
+      }, debounceMs)
+    }
+
+    // Check initial fullscreen status immediately
+    checkFullscreen()
+
+    // Listen to window resize events
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+      if (debounceTimer) {
+        clearTimeout(debounceTimer)
+      }
+    }
+  }, [isMacOS, debounceMs])
+
+  return isFullscreen
+}


### PR DESCRIPTION
- Introduced a new `useIsFullscreen` hook to detect fullscreen mode on macOS, enhancing UI responsiveness.
- Updated the `Editor` component to adjust layout based on fullscreen status.
- Modified the `TopMenu` component to change closed width dynamically when in fullscreen mode.