### PR TITLE
fix command menu selection restore hook

### DIFF
--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -19,6 +19,7 @@ import { HistoryNavigation } from './header/history-navigation'
 import { MoreButton } from './header/more-button'
 import { Tab } from './header/tab'
 import { useAutoRenameOnSave } from './hooks/use-auto-rename-on-save'
+import { useCommandMenuSelectionRestore } from './hooks/use-command-menu-selection-restore'
 import { useLinkedTabName } from './hooks/use-linked-tab-name'
 import { EditorKit } from './plugins/editor-kit'
 import {
@@ -138,6 +139,7 @@ function EditorContent({ path, value }: { path: string; value: Value }) {
     editor.tf.focus()
   }, [editor])
 
+  useCommandMenuSelectionRestore(editor)
   useLinkedTabName(path, value)
 
   return (

--- a/src/components/editor/hooks/use-command-menu-selection-restore.ts
+++ b/src/components/editor/hooks/use-command-menu-selection-restore.ts
@@ -1,0 +1,37 @@
+import type { PlateEditor } from 'platejs/react'
+import { useEffect, useRef } from 'react'
+import { useUIStore } from '@/store/ui-store'
+
+/**
+ * Save and restore editor selection when command menu opens/closes.
+ * When the command menu opens, saves the current selection.
+ * When it closes, restores the saved selection.
+ */
+export function useCommandMenuSelectionRestore(editor: PlateEditor) {
+  const savedSelectionRef = useRef<typeof editor.selection>(null)
+  const isCommandMenuOpen = useUIStore((s) => s.isCommandMenuOpen)
+
+  useEffect(() => {
+    if (isCommandMenuOpen) {
+      // Save selection when command menu opens
+      if (editor.selection) {
+        savedSelectionRef.current = editor.selection
+      }
+    } else if (savedSelectionRef.current) {
+      // Restore selection when command menu closes
+      // Use setTimeout to ensure the editor is ready after the menu closes
+      const selectionToRestore = savedSelectionRef.current
+      savedSelectionRef.current = null
+      setTimeout(() => {
+        try {
+          if (selectionToRestore) {
+            editor.tf.select(selectionToRestore)
+            editor.tf.focus()
+          }
+        } catch {
+          // Selection might be invalid if content changed, ignore
+        }
+      }, 0)
+    }
+  }, [isCommandMenuOpen, editor])
+}


### PR DESCRIPTION
- Introduced `useCommandMenuSelectionRestore` hook to save and restore editor selection when the command menu opens and closes, enhancing user experience during text editing.