### PR TITLE
feat: add reveal in finder to file context menu

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -29,7 +29,10 @@
       "allow": [
         { "cmd": "grep", "name": "grep", "args": true },
         { "cmd": "git", "name": "git", "args": true },
-        { "cmd": "findstr", "name": "findstr", "args": true }
+        { "cmd": "findstr", "name": "findstr", "args": true },
+        { "cmd": "open", "name": "open", "args": true },
+        { "cmd": "xdg-open", "name": "xdg-open", "args": true },
+        { "cmd": "explorer.exe", "name": "explorer.exe", "args": true }
       ]
     }
   ]

--- a/src/components/file-explorer/hooks/use-context-menus.ts
+++ b/src/components/file-explorer/hooks/use-context-menus.ts
@@ -1,13 +1,19 @@
-import { Menu, MenuItem } from '@tauri-apps/api/menu'
+import { Menu, MenuItem, PredefinedMenuItem } from '@tauri-apps/api/menu'
 import {
   type Dispatch,
   type MouseEvent,
   type SetStateAction,
   useCallback,
 } from 'react'
+import {
+  getRevealInFileManagerLabel,
+  revealInFileManager,
+} from '@/components/file-explorer/utils/file-manager'
 import type { ChatConfig } from '@/store/ai-settings-store'
 import type { WorkspaceEntry } from '@/store/workspace-store'
 import { normalizePathSeparators } from '@/utils/path-utils'
+
+const REVEAL_LABEL = getRevealInFileManagerLabel()
 
 type UseFileExplorerMenusProps = {
   renameConfig: ChatConfig | null
@@ -51,7 +57,24 @@ export const useFileExplorerMenus = ({
   const showEntryMenu = useCallback(
     async (entry: WorkspaceEntry, selectionPaths: string[]) => {
       try {
-        const itemPromises: Promise<MenuItem>[] = []
+        const itemPromises: Promise<MenuItem | PredefinedMenuItem>[] = []
+
+        itemPromises.push(
+          MenuItem.new({
+            id: `reveal-${entry.path}`,
+            text: REVEAL_LABEL,
+            action: async () => {
+              await revealInFileManager(entry.path, entry.isDirectory)
+            },
+          })
+        )
+
+        itemPromises.push(
+          PredefinedMenuItem.new({
+            text: 'Separator',
+            item: 'Separator',
+          })
+        )
 
         if (entry.name.toLowerCase().endsWith('.md')) {
           itemPromises.push(
@@ -149,6 +172,17 @@ export const useFileExplorerMenus = ({
             action: async () => {
               beginNewFolder(directoryPath)
             },
+          }),
+          await MenuItem.new({
+            id: `reveal-directory-${normalizedDirectoryPath}`,
+            text: REVEAL_LABEL,
+            action: async () => {
+              await revealInFileManager(directoryPath, true)
+            },
+          }),
+          await PredefinedMenuItem.new({
+            text: 'Separator',
+            item: 'Separator',
           }),
           await MenuItem.new({
             id: `pin-directory-${normalizedDirectoryPath}`,

--- a/src/components/file-explorer/utils/file-manager.ts
+++ b/src/components/file-explorer/utils/file-manager.ts
@@ -1,0 +1,63 @@
+import { Command } from '@tauri-apps/plugin-shell'
+import { normalizePathSeparators } from '@/utils/path-utils'
+import { getPlatform } from '@/utils/platform'
+
+const PLATFORM = getPlatform()
+
+export function getRevealInFileManagerLabel(): string {
+  if (PLATFORM === 'windows') {
+    return 'Show in File Explorer'
+  }
+
+  if (PLATFORM === 'linux') {
+    return 'Show in File Manager'
+  }
+
+  return 'Reveal in Finder'
+}
+
+const toWindowsPath = (path: string) =>
+  normalizePathSeparators(path).replace(/\//g, '\\')
+
+const getDirectoryPath = (path: string) => {
+  const normalized = normalizePathSeparators(path)
+  const lastSlashIndex = normalized.lastIndexOf('/')
+  if (lastSlashIndex <= 0) {
+    return normalized
+  }
+  return normalized.slice(0, lastSlashIndex)
+}
+
+/**
+ * Opens the given path in the native file manager and, when possible,
+ * highlights the file entry. Platform-aware implementation for macOS, Windows, and Linux.
+ */
+export async function revealInFileManager(
+  path: string,
+  isDirectory: boolean
+): Promise<void> {
+  try {
+    if (PLATFORM === 'windows') {
+      const windowsPath = toWindowsPath(path)
+      const args = isDirectory ? [windowsPath] : ['/select,', windowsPath]
+      await Command.create('explorer.exe', args).execute()
+      return
+    }
+
+    if (PLATFORM === 'linux') {
+      const directoryToOpen = isDirectory ? path : getDirectoryPath(path)
+      await Command.create('xdg-open', [
+        normalizePathSeparators(directoryToOpen),
+      ]).execute()
+      return
+    }
+
+    // macOS
+    const args = isDirectory
+      ? [normalizePathSeparators(path)]
+      : ['-R', normalizePathSeparators(path)]
+    await Command.create('open', args).execute()
+  } catch (error) {
+    console.error('Failed to reveal entry in file manager:', error)
+  }
+}


### PR DESCRIPTION
- Introduced functionality to reveal files and directories in the native file manager through context menus in the file explorer.
- Added utility functions for platform-specific file manager commands and labels.
- Updated context menu hooks to include new options for revealing entries, enhancing user interaction with the file system.