### PR TITLE
feat: scroll to new entry in collection view

### DIFF
--- a/src/components/collection-view/collection-view.tsx
+++ b/src/components/collection-view/collection-view.tsx
@@ -15,6 +15,7 @@ import { useCollectionEntries } from './hooks/use-collection-entries'
 import { useCollectionRename } from './hooks/use-collection-rename'
 import { useCollectionSelection } from './hooks/use-collection-selection'
 import { useCollectionSort } from './hooks/use-collection-sort'
+import { useScrollToNewEntry } from './hooks/use-scroll-to-new-entry'
 import { useEntryUpdateOnSave } from './hooks/use-entry-update-on-save'
 import { usePreviewCache } from './hooks/use-preview-cache'
 import { CollectionResizer } from './ui/collection-resizer'
@@ -179,6 +180,13 @@ export function CollectionView() {
     setSelectionAnchorPath,
     resetSelection,
     invalidatePreview,
+  })
+
+  useScrollToNewEntry({
+    currentCollectionPath,
+    sortedEntries,
+    tabPath: tab?.path,
+    virtualizer,
   })
 
   return (

--- a/src/components/collection-view/hooks/use-scroll-to-new-entry.ts
+++ b/src/components/collection-view/hooks/use-scroll-to-new-entry.ts
@@ -1,0 +1,53 @@
+import type { Virtualizer } from '@tanstack/react-virtual'
+import { useEffect, useRef } from 'react'
+import type { WorkspaceEntry } from '@/store/workspace-store'
+
+type Params = {
+  currentCollectionPath: string | null
+  sortedEntries: WorkspaceEntry[]
+  tabPath?: string
+  virtualizer: Virtualizer<HTMLDivElement, Element>
+}
+
+/**
+ * When notes are added to the current collection, scrolls to the new item
+ * so it is visible (prefers the active tab's path when available).
+ */
+export function useScrollToNewEntry({
+  currentCollectionPath,
+  sortedEntries,
+  tabPath,
+  virtualizer,
+}: Params) {
+  const previousPathsRef = useRef<string[]>([])
+  const previousCollectionPathRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const isCollectionChanged =
+      previousCollectionPathRef.current !== currentCollectionPath
+    const previousPaths = isCollectionChanged ? [] : previousPathsRef.current
+    const currentPaths = sortedEntries.map((entry) => entry.path)
+    const newlyAddedPaths = currentPaths.filter(
+      (path) => !previousPaths.includes(path)
+    )
+
+    previousCollectionPathRef.current = currentCollectionPath
+    previousPathsRef.current = currentPaths
+
+    if (isCollectionChanged || newlyAddedPaths.length === 0) {
+      return
+    }
+
+    const targetPath =
+      tabPath && newlyAddedPaths.includes(tabPath)
+        ? tabPath
+        : newlyAddedPaths[0]
+    const targetIndex = currentPaths.indexOf(targetPath)
+
+    if (targetIndex !== -1) {
+      const behavior: ScrollBehavior =
+        sortedEntries.length <= 100 ? 'smooth' : 'auto'
+      virtualizer.scrollToIndex(targetIndex, { align: 'center', behavior })
+    }
+  }, [currentCollectionPath, sortedEntries, tabPath, virtualizer])
+}


### PR DESCRIPTION
- Implemented useScrollToNewEntry hook to automatically scroll to newly added entries in the collection view.
- Integrated the hook into the CollectionView component to enhance user experience when new notes are added.