### PR TITLE
fix: show untitled note at the top in file-explorer

### DIFF
--- a/src/components/file-explorer/file-explorer.tsx
+++ b/src/components/file-explorer/file-explorer.tsx
@@ -228,46 +228,13 @@ export function FileExplorer() {
     [expandedDirectories, setExpandedDirectories]
   )
 
-  const scrollEntryIntoView = useCallback(
-    (entryPath: string | null) => {
-      if (!entryPath || typeof document === 'undefined' || !isOpen) {
-        return
-      }
-
-      let attempts = 0
-      const scrollIfReady = () => {
-        if (!isOpen) {
-          return
-        }
-
-        const targetNode = document.getElementById(entryPath)
-
-        if (targetNode) {
-          targetNode.scrollIntoView({ block: 'nearest', inline: 'nearest' })
-          return
-        }
-
-        if (attempts < 4) {
-          attempts += 1
-          requestAnimationFrame(scrollIfReady)
-        }
-      }
-
-      requestAnimationFrame(scrollIfReady)
-    },
-    [isOpen]
-  )
-
   const createNoteAndScroll = useCallback(
     async (directoryPath: string) => {
-      ensureDirectoryExpanded(directoryPath)
       const newEntryPath = await createNote(directoryPath)
-      if (newEntryPath) {
-        scrollEntryIntoView(newEntryPath)
-      }
+      ensureDirectoryExpanded(directoryPath)
       return newEntryPath
     },
-    [createNote, ensureDirectoryExpanded, scrollEntryIntoView]
+    [createNote, ensureDirectoryExpanded]
   )
 
   const { handleEntryContextMenu, handleRootContextMenu } =

--- a/src/store/workspace/utils/entry-utils.ts
+++ b/src/store/workspace/utils/entry-utils.ts
@@ -78,6 +78,14 @@ export async function buildWorkspaceEntries(
   }
 }
 
+function isUntitledNote(name: string): boolean {
+  if (!name.endsWith('.md')) {
+    return false
+  }
+  const nameWithoutExtension = name.slice(0, -3) // Remove '.md'
+  return nameWithoutExtension.startsWith('Untitled')
+}
+
 export function sortWorkspaceEntries(
   entries: WorkspaceEntry[]
 ): WorkspaceEntry[] {
@@ -91,6 +99,16 @@ export function sortWorkspaceEntries(
     .sort((a, b) => {
       if (a.isDirectory !== b.isDirectory) {
         return a.isDirectory ? -1 : 1
+      }
+
+      // For files, prioritize "Untitled" notes
+      if (!a.isDirectory && !b.isDirectory) {
+        const aIsUntitled = isUntitledNote(a.name)
+        const bIsUntitled = isUntitledNote(b.name)
+
+        if (aIsUntitled !== bIsUntitled) {
+          return aIsUntitled ? -1 : 1
+        }
       }
 
       return a.name.localeCompare(b.name)


### PR DESCRIPTION
- Removed the scrollEntryIntoView function from FileExplorer to simplify the component logic.
- Updated createNoteAndScroll to ensure directory expansion without scrolling.
- Introduced isUntitledNote utility function to prioritize "Untitled" notes in the sortWorkspaceEntries function, improving file organization.