### PR TITLE
fix: add close listener to system tray for graceful shutdown

### DIFF
--- a/src/components/system-tray/system-tray.tsx
+++ b/src/components/system-tray/system-tray.tsx
@@ -69,6 +69,7 @@ export function SystemTray() {
     const closeListener = appWindow.listen('tauri://close-requested', () => {
       trayPromise.then((tray) => {
         tray.close()
+        trayInstance = null
       })
     })
 


### PR DESCRIPTION
- Implemented a listener for the 'tauri://close-requested' event to ensure the system tray closes properly when the application window is requested to close.
- Updated cleanup logic to unregister the close listener and ensure the tray instance is only closed if it is the active instance.