### PR TITLE
fix(ai-menu): improve block selection logic

### DIFF
--- a/src/components/editor/ui/ai-menu.tsx
+++ b/src/components/editor/ui/ai-menu.tsx
@@ -125,10 +125,10 @@ export function AIMenu() {
         const end = editor.api.end(path)
         if (start && end) {
           editor.tf.select({ anchor: start, focus: end })
+          editor
+            .getApi(BlockSelectionPlugin)
+            .blockSelection.set(ancestor.id as string)
         }
-        editor
-          .getApi(BlockSelectionPlugin)
-          .blockSelection.set(ancestor.id as string)
       }
 
       const domNode = editor.api.toDOMNode(ancestor)


### PR DESCRIPTION
- Updated the block selection logic in the AIMenu component to ensure selection only occurs when the ancestor block is not empty. This change enhances the editor's behavior when selecting text within blocks.

resolves: #280 