### PR TITLE
fix(watch): make code more defensive

### DIFF
--- a/src/store/workspace-watch-store.tsx
+++ b/src/store/workspace-watch-store.tsx
@@ -54,9 +54,9 @@ export const useWorkspaceWatchStore = create<WorkspaceWatchStore>(
             return
           }
 
-          // Skip events that occurred within 1.5 second of an internal FS operation
+          // Skip events that occurred within 3 seconds of an internal FS operation
           const lastFsOpTime = useWorkspaceStore.getState().lastFsOperationTime
-          if (lastFsOpTime !== null && Date.now() - lastFsOpTime < 1500) {
+          if (lastFsOpTime !== null && Date.now() - lastFsOpTime < 3000) {
             return
           }
 
@@ -437,7 +437,7 @@ export const useWorkspaceWatchStore = create<WorkspaceWatchStore>(
         },
         {
           recursive: true,
-          delayMs: 1000,
+          delayMs: 2000,
         }
       )
 

--- a/src/store/workspace/utils/entry-utils.ts
+++ b/src/store/workspace/utils/entry-utils.ts
@@ -187,6 +187,13 @@ export function addEntryToState(
   parentPath: string,
   newEntry: WorkspaceEntry
 ): WorkspaceEntry[] {
+  // Check if entry with the same path already exists to avoid duplicates
+  const existingEntry = findEntryByPath(entries, newEntry.path)
+  if (existingEntry) {
+    // Entry already exists, return entries as-is
+    return entries
+  }
+
   const parent = findParentDirectory(entries, parentPath)
 
   if (!parent) {


### PR DESCRIPTION
- Increased the skip time for events after internal file system operations from 1.5 seconds to 3 seconds to improve responsiveness.
- Updated the delay for file system event handling from 1 second to 2 seconds for better performance.
- Added a check in `addEntryToState` to avoid adding duplicate entries based on the path, ensuring data integrity in the workspace state.

#282 