### PR TITLE
feat: save quick note

### DIFF
--- a/src/components/quick-note/quick-note.tsx
+++ b/src/components/quick-note/quick-note.tsx
@@ -8,6 +8,7 @@ import {
   usePlateEditor,
 } from 'platejs/react'
 import { useCallback, useEffect } from 'react'
+import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { useTabStore } from '@/store/tab-store'
 import { isMac } from '@/utils/platform'
@@ -46,6 +47,7 @@ export function QuickNote() {
       await openTab(path, false, false, { initialContent: content })
     } catch (error) {
       console.error('Failed to save file:', error)
+      toast.error('Failed to save file')
     }
   }, [editor, openTab])
 


### PR DESCRIPTION
- Added a save feature to the QuickNote component, allowing users to save notes as Markdown files.
- Integrated file dialog for selecting save location and filename.
- Implemented keyboard shortcut (Ctrl+S or Cmd+S) for saving notes.
- Enhanced component structure to include LicenseKeyButton and SettingsDialog.
- Updated editor focus behavior and improved layout styling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Markdown save (via dialog and Cmd/Ctrl+S), opens the saved note in a new tab, and handles window close; integrates editor/settings UI and layout tweaks.
> 
> - **QuickNote (`src/components/quick-note/quick-note.tsx`)**:
>   - **Save flow**: Serialize editor content to Markdown, show save dialog, write file via Tauri FS, and open saved path with `useTabStore.openTab`.
>   - **Shortcut**: Intercepts `Cmd/Ctrl+S` to trigger save.
>   - **Window lifecycle**: Listens to `tauri://close-requested` and destroys the window.
>   - **UI/UX**:
>     - Conditional UI: when `tab` exists, render full `Editor` with `LicenseKeyButton` and `SettingsDialog`.
>     - Adds draggable top bar (`data-tauri-drag-region`).
>     - Layout/behavior tweaks: padding/spacing adjustments, placeholder text, higher contrast text, and disables auto-capitalize/correct/complete.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d625b5140c803f0693fc99114af3066ce202744. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->