### PR TITLE
refactor: migrate collection path management to a dedicated store

### DIFF
--- a/src/components/collection-view/collection-view.tsx
+++ b/src/components/collection-view/collection-view.tsx
@@ -5,6 +5,7 @@ import { useShallow } from 'zustand/shallow'
 import { useResizablePanel } from '@/hooks/use-resizable-panel'
 import { cn } from '@/lib/utils'
 import { useAISettingsStore } from '@/store/ai-settings-store'
+import { useCollectionStore } from '@/store/collection-store'
 import { useTabStore } from '@/store/tab-store'
 import { useUIStore } from '@/store/ui-store'
 import { useWorkspaceStore } from '@/store/workspace-store'
@@ -24,17 +25,17 @@ import { NoteEntry } from './ui/note-entry'
 import { SortSelector } from './ui/sort-selector'
 
 export function CollectionView() {
-  const {
-    currentCollectionPath,
-    entries,
-    workspacePath,
-    setCurrentCollectionPath,
-  } = useWorkspaceStore(
+  const { currentCollectionPath, setCurrentCollectionPath } =
+    useCollectionStore(
+      useShallow((state) => ({
+        currentCollectionPath: state.currentCollectionPath,
+        setCurrentCollectionPath: state.setCurrentCollectionPath,
+      }))
+    )
+  const { entries, workspacePath } = useWorkspaceStore(
     useShallow((state) => ({
-      currentCollectionPath: state.currentCollectionPath,
       entries: state.entries,
       workspacePath: state.workspacePath,
-      setCurrentCollectionPath: state.setCurrentCollectionPath,
     }))
   )
   const isCollectionViewOpen = currentCollectionPath !== null

--- a/src/components/editor/header/header.tsx
+++ b/src/components/editor/header/header.tsx
@@ -1,5 +1,6 @@
 import { useIsFullscreen } from '@/hooks/use-is-fullscreen'
 import { cn } from '@/lib/utils'
+import { useCollectionStore } from '@/store/collection-store'
 import { useEditorStore } from '@/store/editor-store'
 import { useUIStore } from '@/store/ui-store'
 import { useWorkspaceStore } from '@/store/workspace-store'
@@ -10,7 +11,7 @@ import { Tab } from './tab'
 
 export function Header() {
   const isFileExplorerOpen = useUIStore((s) => s.isFileExplorerOpen)
-  const isCollectionViewOpen = useWorkspaceStore(
+  const isCollectionViewOpen = useCollectionStore(
     (s) => s.currentCollectionPath !== null
   )
   const workspacePath = useWorkspaceStore((s) => s.workspacePath)

--- a/src/components/file-explorer/file-explorer.tsx
+++ b/src/components/file-explorer/file-explorer.tsx
@@ -6,6 +6,7 @@ import { useAutoCloseSidebars } from '@/hooks/use-auto-close-sidebars'
 import { useResizablePanel } from '@/hooks/use-resizable-panel'
 import { cn } from '@/lib/utils'
 import { useAISettingsStore } from '@/store/ai-settings-store'
+import { useCollectionStore } from '@/store/collection-store'
 import { useFileExplorerSelectionStore } from '@/store/file-explorer-selection-store'
 import { useTabStore } from '@/store/tab-store'
 import { useUIStore } from '@/store/ui-store'
@@ -55,11 +56,11 @@ export function FileExplorer() {
     toggleDirectory,
     setWorkspace,
     openFolderPicker,
-    setCurrentCollectionPath,
     pinnedDirectories,
     pinDirectory,
     unpinDirectory,
   } = useWorkspaceStore()
+  const { setCurrentCollectionPath } = useCollectionStore()
   const { tab, openNote, clearLinkedTab } = useTabStore(
     useShallow((s) => ({
       tab: s.tab,

--- a/src/components/file-explorer/ui/pinned-list.tsx
+++ b/src/components/file-explorer/ui/pinned-list.tsx
@@ -3,6 +3,7 @@ import { PinIcon, PinOffIcon } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
 import { useShallow } from 'zustand/shallow'
 
+import { useCollectionStore } from '@/store/collection-store'
 import { useWorkspaceStore } from '@/store/workspace-store'
 import {
   getFolderNameFromPath,
@@ -12,23 +13,22 @@ import { useEntryMap } from '../hooks/use-entry-map'
 import { getEntryButtonClassName } from '../utils/entry-classnames'
 
 export function PinnedList() {
-  const {
-    pinnedDirectories,
-    currentCollectionPath,
-    setCurrentCollectionPath,
-    workspacePath,
-    entries,
-    unpinDirectory,
-  } = useWorkspaceStore(
-    useShallow((state) => ({
-      pinnedDirectories: state.pinnedDirectories,
-      currentCollectionPath: state.currentCollectionPath,
-      setCurrentCollectionPath: state.setCurrentCollectionPath,
-      workspacePath: state.workspacePath,
-      entries: state.entries,
-      unpinDirectory: state.unpinDirectory,
-    }))
-  )
+  const { currentCollectionPath, setCurrentCollectionPath } =
+    useCollectionStore(
+      useShallow((state) => ({
+        currentCollectionPath: state.currentCollectionPath,
+        setCurrentCollectionPath: state.setCurrentCollectionPath,
+      }))
+    )
+  const { pinnedDirectories, workspacePath, entries, unpinDirectory } =
+    useWorkspaceStore(
+      useShallow((state) => ({
+        pinnedDirectories: state.pinnedDirectories,
+        workspacePath: state.workspacePath,
+        entries: state.entries,
+        unpinDirectory: state.unpinDirectory,
+      }))
+    )
 
   const entryMap = useEntryMap(entries)
 

--- a/src/components/file-explorer/ui/toggle-button.tsx
+++ b/src/components/file-explorer/ui/toggle-button.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeftToLineIcon, ArrowRightToLineIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useCollectionStore } from '@/store/collection-store'
 import { useEditorStore } from '@/store/editor-store'
-import { useWorkspaceStore } from '@/store/workspace-store'
 import { Button } from '@/ui/button'
 import { Kbd, KbdGroup } from '@/ui/kbd'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/tooltip'
@@ -14,7 +14,7 @@ type Props = {
 
 export function ToggleButton({ isOpen, onToggle }: Props) {
   const isFocusMode = useEditorStore((s) => s.isFocusMode)
-  const isCollectionViewOpen = useWorkspaceStore(
+  const isCollectionViewOpen = useCollectionStore(
     (s) => s.currentCollectionPath !== null
   )
   return (

--- a/src/components/window-menu/window-menu.tsx
+++ b/src/components/window-menu/window-menu.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useShallow } from 'zustand/shallow'
+import { useCollectionStore } from '@/store/collection-store'
 import { useFontScaleStore } from '@/store/font-scale-store'
 import { useTabStore } from '@/store/tab-store'
 import { useUIStore } from '@/store/ui-store'
@@ -7,14 +8,17 @@ import { useWorkspaceStore } from '@/store/workspace-store'
 import { installWindowMenu } from './menu'
 
 export function WindowMenu() {
-  const { createAndOpenNote, openFolderPicker, toggleCollectionView } =
-    useWorkspaceStore(
-      useShallow((s) => ({
-        createAndOpenNote: s.createAndOpenNote,
-        openFolderPicker: s.openFolderPicker,
-        toggleCollectionView: s.toggleCollectionView,
-      }))
-    )
+  const { createAndOpenNote, openFolderPicker } = useWorkspaceStore(
+    useShallow((s) => ({
+      createAndOpenNote: s.createAndOpenNote,
+      openFolderPicker: s.openFolderPicker,
+    }))
+  )
+  const { toggleCollectionView } = useCollectionStore(
+    useShallow((s) => ({
+      toggleCollectionView: s.toggleCollectionView,
+    }))
+  )
 
   const { toggleFileExplorer, openCommandMenu, toggleSettingsDialogOpen } =
     useUIStore(

--- a/src/hooks/use-auto-close-sidebars.ts
+++ b/src/hooks/use-auto-close-sidebars.ts
@@ -1,11 +1,11 @@
 import { useEffect } from 'react'
 import { useMediaQuery } from 'usehooks-ts'
+import { useCollectionStore } from '@/store/collection-store'
 import { useUIStore } from '@/store/ui-store'
-import { useWorkspaceStore } from '@/store/workspace-store'
 
 export function useAutoCloseSidebars() {
   const setFileExplorerOpen = useUIStore((state) => state.setFileExplorerOpen)
-  const setCurrentCollectionPath = useWorkspaceStore(
+  const setCurrentCollectionPath = useCollectionStore(
     (state) => state.setCurrentCollectionPath
   )
   const matches = useMediaQuery('(max-width: 640px)')

--- a/src/store/collection-store.tsx
+++ b/src/store/collection-store.tsx
@@ -1,0 +1,46 @@
+import { create } from 'zustand'
+
+type CollectionStore = {
+  currentCollectionPath: string | null
+  lastCollectionPath: string | null
+  setCurrentCollectionPath: (
+    path: string | null | ((prev: string | null) => string | null)
+  ) => void
+  resetCollectionPath: () => void
+  toggleCollectionView: () => void
+}
+
+export const useCollectionStore = create<CollectionStore>((set, get) => ({
+  currentCollectionPath: null,
+  lastCollectionPath: null,
+
+  setCurrentCollectionPath: (path) => {
+    set((state) => {
+      const nextPath =
+        typeof path === 'function' ? path(state.currentCollectionPath) : path
+      return {
+        currentCollectionPath: nextPath,
+        lastCollectionPath:
+          nextPath !== null ? nextPath : state.lastCollectionPath,
+      }
+    })
+  },
+
+  resetCollectionPath: () => {
+    set({
+      currentCollectionPath: null,
+      lastCollectionPath: null,
+    })
+  },
+
+  toggleCollectionView: () => {
+    const { currentCollectionPath, lastCollectionPath } = get()
+    if (currentCollectionPath !== null) {
+      // Close the view
+      set({ currentCollectionPath: null })
+    } else if (lastCollectionPath !== null) {
+      // Restore the last opened path
+      set({ currentCollectionPath: lastCollectionPath })
+    }
+  },
+}))


### PR DESCRIPTION
- Introduced a new `collection-store` to handle collection path state, including current and last collection paths.
- Updated components to utilize the new store for managing collection view state, improving separation of concerns.
- Removed collection path management from the workspace store to streamline its responsibilities.