### PR TITLE
fix(frontmatter): set focus after creation from slash command

### DIFF
--- a/src/components/editor/ui/node-slash.tsx
+++ b/src/components/editor/ui/node-slash.tsx
@@ -25,6 +25,7 @@ import { KEYS, type TComboboxInputElement } from 'platejs'
 import type { PlateEditor, PlateElementProps } from 'platejs/react'
 import { PlateElement } from 'platejs/react'
 import YAML from 'yaml'
+import { useEditorStore } from '@/store/editor-store'
 import { useMDXSettingsStore } from '@/store/mdx-settings-store'
 import { useTabStore } from '@/store/tab-store'
 import { FRONTMATTER_KEY } from '../plugins/frontmatter-kit'
@@ -239,6 +240,7 @@ const groups: Group[] = [
           if (editor.api.some({ match: { type: FRONTMATTER_KEY } })) return
 
           const defaults = await collectFrontmatterDefaults()
+          useEditorStore.getState().setShouldFrontmatterFocus(true)
           editor.tf.replaceNodes(
             {
               type: FRONTMATTER_KEY,

--- a/src/store/editor-store.tsx
+++ b/src/store/editor-store.tsx
@@ -10,6 +10,8 @@ type EditorStore = {
   typingBurstCount: number
   handleTypingProgress: () => void
   resetFocusMode: () => void
+  shouldFrontmatterFocus: boolean
+  setShouldFrontmatterFocus: (shouldFrontmatterFocus: boolean) => void
 }
 
 export const useEditorStore = create<EditorStore>((set, get) => ({
@@ -37,6 +39,12 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
     set({
       typingBurstCount: 0,
       isFocusMode: false,
+    })
+  },
+  shouldFrontmatterFocus: false,
+  setShouldFrontmatterFocus: (shouldFrontmatterFocus: boolean) => {
+    set({
+      shouldFrontmatterFocus,
     })
   },
 }))


### PR DESCRIPTION
- Added state management for frontmatter focus using Zustand store.
- Enhanced focus behavior in FrontmatterTable to automatically focus the first row when required.
- Updated node-slash component to trigger frontmatter focus when necessary, improving user experience during editing.