### PR TITLE
feat(ui): implement persistent state for file explorer visibility

### DIFF
--- a/src/store/ui-store.tsx
+++ b/src/store/ui-store.tsx
@@ -20,11 +20,32 @@ type UIStore = {
   closeImagePreview: () => void
 }
 
+const FILE_EXPLORER_STORAGE_KEY = 'isFileExplorerOpen'
+
+const getInitialFileExplorerOpen = () => {
+  if (typeof window === 'undefined') return true
+
+  const stored = localStorage.getItem(FILE_EXPLORER_STORAGE_KEY)
+  return stored === null ? true : stored === 'true'
+}
+
+const persistFileExplorerOpen = (isOpen: boolean) => {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(FILE_EXPLORER_STORAGE_KEY, String(isOpen))
+}
+
 export const useUIStore = create<UIStore>((set) => ({
-  isFileExplorerOpen: true,
-  setFileExplorerOpen: (isOpen) => set({ isFileExplorerOpen: isOpen }),
+  isFileExplorerOpen: getInitialFileExplorerOpen(),
+  setFileExplorerOpen: (isOpen) => {
+    persistFileExplorerOpen(isOpen)
+    set({ isFileExplorerOpen: isOpen })
+  },
   toggleFileExplorerOpen: () =>
-    set((state) => ({ isFileExplorerOpen: !state.isFileExplorerOpen })),
+    set((state) => {
+      const nextValue = !state.isFileExplorerOpen
+      persistFileExplorerOpen(nextValue)
+      return { isFileExplorerOpen: nextValue }
+    }),
   isSettingsDialogOpen: false,
   setSettingsDialogOpen: (isOpen) => set({ isSettingsDialogOpen: isOpen }),
   toggleSettingsDialogOpen: () =>


### PR DESCRIPTION
- Added functionality to persist the open/closed state of the file explorer using localStorage.
- Updated the initial state of `isFileExplorerOpen` to retrieve the stored value, defaulting to true if not set.
- Enhanced the `setFileExplorerOpen` and `toggleFileExplorerOpen` methods to save the state change in localStorage, improving user experience across sessions.