### PR TITLE
fix: handle fullscreen state on close request

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:app:allow-default-window-icon",
     "core:window:allow-hide",
     "core:window:allow-show",
+    "core:window:allow-set-fullscreen",
     "process:default",
     "opener:default",
     "dialog:default",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -24,8 +24,13 @@ export function App() {
   useEffect(() => {
     const appWindow = getCurrentWindow()
     appWindow.show()
-    const closeListener = appWindow.listen('tauri://close-requested', () => {
-      appWindow.hide()
+    const closeListener = appWindow.listen('tauri://close-requested', async () => {
+      const isFullscreen = await appWindow.isFullscreen()
+      if (isFullscreen) {
+        await appWindow.setFullscreen(false)
+        await new Promise((resolve) => setTimeout(resolve, 300))
+      }
+      await appWindow.hide()
     })
 
     return () => {


### PR DESCRIPTION
- Updated the close listener to check if the app window is in fullscreen mode before hiding it.
- Added logic to exit fullscreen if necessary, ensuring a smoother user experience when closing the application.