### PR TITLE
fix: handle fullscreen state on close request

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "core:window:allow-hide",
     "core:window:allow-show",
     "core:window:allow-destroy",
+    "core:window:allow-set-fullscreen",
     "process:default",
     "opener:default",
     "dialog:default",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -38,7 +38,13 @@ export function App() {
 
   useEffect(() => {
     const appWindow = getCurrentWindow()
-    const closeListener = appWindow.listen('tauri://close-requested', () => {
+    const closeListener = appWindow.listen('tauri://close-requested', async () => {
+      const isFullscreen = await appWindow.isFullscreen()
+      console.log('isFullscreen', isFullscreen)
+      if (isFullscreen) {
+        await appWindow.setFullscreen(false)
+        await new Promise((resolve) => setTimeout(resolve, 700))
+      }
       appWindow.hide()
     })
 


### PR DESCRIPTION
- Updated the close listener to check if the app window is in fullscreen mode before hiding it.
- Added logic to exit fullscreen if necessary, ensuring a smoother user experience when closing the application.