### PR TITLE
fix(editor-ai): cmd+j on blockSelection

### DIFF
--- a/src/components/editor/ui/block-seleciton-after-editable.tsx
+++ b/src/components/editor/ui/block-seleciton-after-editable.tsx
@@ -1,3 +1,4 @@
+import { AIChatPlugin } from '@platejs/ai/react'
 import { MarkdownPlugin } from '@platejs/markdown'
 import {
   type BlockSelectionConfig,
@@ -210,6 +211,13 @@ export const BlockSelectionAfterEditable: EditableSiblingComponent = () => {
       if (isHotkey('mod+d')(e)) {
         e.preventDefault()
         editor.getTransforms(BlockSelectionPlugin).blockSelection.duplicate()
+        return
+      }
+      // Mod+J => open AI menu
+      if (isHotkey('mod+j')(e)) {
+        e.preventDefault()
+        e.stopPropagation()
+        editor.getApi(AIChatPlugin).aiChat.show()
         return
       }
       // Only continue if we have "some" selection


### PR DESCRIPTION
- Integrated a keyboard shortcut (Mod+J) to open the AI menu within the editor, enhancing user accessibility and interaction.
- Updated the event handling logic to prevent default actions and ensure proper functionality when the shortcut is used.