### PR TITLE
fix(link-toolbar): hide link-input on escape key

### DIFF
--- a/src/components/editor/ui/link-toolbar.tsx
+++ b/src/components/editor/ui/link-toolbar.tsx
@@ -426,8 +426,6 @@ function LinkUrlInput() {
 
       if (key === 'Escape') {
         event.preventDefault()
-        event.stopPropagation()
-        event.nativeEvent.stopImmediatePropagation()
         api.floatingLink.hide()
         editor.tf.focus()
         return


### PR DESCRIPTION
- Added handling for the Escape key to hide the floating link toolbar and refocus the editor input, improving user experience.
- Updated dependencies in the useCallback hook to include necessary references for proper functionality.