### PR TITLE
feat(preview): add frontmatter stripping functionality

### DIFF
--- a/src-tauri/src/preview.rs
+++ b/src-tauri/src/preview.rs
@@ -148,7 +148,8 @@ fn strip_frontmatter(raw: &str) -> String {
     }
 
     if let Some(rest_index) = frontmatter_rest_index(trimmed) {
-        return trimmed[rest_index..].to_string();
+        let leading_ws_len = raw.len() - trimmed.len();
+        return raw[leading_ws_len + rest_index..].to_string();
     }
 
     raw.to_string()


### PR DESCRIPTION
- Introduced `strip_frontmatter` and related helper functions to remove YAML frontmatter from the start of the preview text.
- Updated `format_preview_text` to utilize the new frontmatter stripping logic, enhancing the formatting process.
- Added tests to ensure correct handling of frontmatter in various scenarios, improving reliability of the preview text output.