### PR TITLE
fix(editor): handle backspace at start of input in inline combobox

### DIFF
--- a/src/components/editor/ui/inline-combobox.tsx
+++ b/src/components/editor/ui/inline-combobox.tsx
@@ -220,12 +220,13 @@ const InlineComboboxInput = ({
       const isBackspaceAtStart =
         event.key === 'Backspace' && contextRef.current?.selectionStart === 0
 
-      inputProps.onKeyDown?.(event)
-
       if (isBackspaceAtStart) {
         event.preventDefault()
         event.stopPropagation()
+        return
       }
+
+      inputProps.onKeyDown?.(event)
     },
     [contextRef, inputProps]
   )


### PR DESCRIPTION
- Added a new keydown handler to prevent default behavior when backspace is pressed at the start of the input, improving user experience in the inline combobox component.