### PR TITLE
ux(database): focus name input on new row

### DIFF
--- a/src/components/editor/ui/database-property.tsx
+++ b/src/components/editor/ui/database-property.tsx
@@ -64,9 +64,11 @@ export function InlineEditableField({
 }: InlineEditableFieldProps) {
   const [isEditing, setIsEditing] = useState(false)
   const inputRef = useRef<HTMLInputElement | null>(null)
+  const hasAutoEdited = useRef(false)
 
   useEffect(() => {
-    if (autoEdit && !isEditing) {
+    if (autoEdit && !isEditing && !hasAutoEdited.current) {
+      hasAutoEdited.current = true
       // Add a small delay to ensure scrolling completes before focusing
       const timer = setTimeout(() => {
         setIsEditing(true)

--- a/src/components/editor/ui/node-database.tsx
+++ b/src/components/editor/ui/node-database.tsx
@@ -874,7 +874,7 @@ export function DatabaseElement(props: PlateElementProps<TDatabaseElement>) {
     newlyCreatedPath,
     virtualizer,
     onScrollComplete: () => {
-      setNewlyCreatedPath(null)
+      // setNewlyCreatedPath(null)
     },
   })
 


### PR DESCRIPTION
- Added `autoEdit` prop to `InlineEditableField` to enable automatic editing when the component mounts.
- Integrated `newlyCreatedPath` prop in `DatabaseRow` to trigger automatic editing for newly created entries.
- Improved user experience by allowing immediate focus on newly created database entries for seamless editing.