### PR TITLE
ux: enhance createNote functionality

### DIFF
--- a/src/components/collection-view/collection-view.tsx
+++ b/src/components/collection-view/collection-view.tsx
@@ -199,7 +199,7 @@ export function CollectionView() {
             sortDirection={sortDirection}
             onDirectionChange={setSortDirection}
           />
-          <NewNoteButton />
+          <NewNoteButton directoryPath={currentCollectionPath} />
         </div>
       </div>
       <div

--- a/src/components/collection-view/ui/new-note-button.tsx
+++ b/src/components/collection-view/ui/new-note-button.tsx
@@ -5,8 +5,12 @@ import { Kbd, KbdGroup } from '@/ui/kbd'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/tooltip'
 import { getModifierKey } from '@/utils/keyboard-shortcut'
 
-export function NewNoteButton() {
-  const createAndOpenNote = useStore((s) => s.createAndOpenNote)
+export function NewNoteButton({
+  directoryPath,
+}: {
+  directoryPath: string | null
+}) {
+  const createNote = useStore((s) => s.createNote)
 
   return (
     <Tooltip>
@@ -15,7 +19,9 @@ export function NewNoteButton() {
           variant="ghost"
           size="icon"
           className="text-foreground/70 hover:bg-background/40"
-          onClick={createAndOpenNote}
+          onClick={() =>
+            directoryPath && createNote(directoryPath, { openTab: true })
+          }
         >
           <SquarePenIcon />
         </Button>

--- a/src/components/file-explorer/file-explorer.tsx
+++ b/src/components/file-explorer/file-explorer.tsx
@@ -21,7 +21,6 @@ import { GitSyncStatus } from './ui/git-sync-status'
 import { PinnedList } from './ui/pinned-list'
 import { RootNewFolderInput } from './ui/root-new-folder-input'
 import { SettingsMenu } from './ui/settings-menu'
-// import { TagList } from './ui/tag-list'
 import { TopMenu } from './ui/top-menu'
 import { TreeNode } from './ui/tree-node'
 import { WorkspaceDropdown } from './ui/workspace-dropdown'
@@ -274,7 +273,6 @@ export function FileExplorer() {
       beginNewFolder,
       handleDeleteEntries,
       createNote: createNoteAndScroll,
-      openTab,
       workspacePath,
       selectedEntryPaths,
       setSelectedEntryPaths,

--- a/src/components/file-explorer/hooks/use-context-menus.ts
+++ b/src/components/file-explorer/hooks/use-context-menus.ts
@@ -44,9 +44,12 @@ type UseFileExplorerMenusProps = {
   handleDeleteEntries: (paths: string[]) => Promise<void>
   createNote: (
     directoryPath: string,
-    options?: { initialName?: string; initialContent?: string }
+    options?: {
+      initialName?: string
+      initialContent?: string
+      openTab?: boolean
+    }
   ) => Promise<string>
-  openTab: (path: string) => void
   workspacePath: string | null
   selectedEntryPaths: Set<string>
   setSelectedEntryPaths: (paths: Set<string>) => void
@@ -66,7 +69,6 @@ export const useFileExplorerMenus = ({
   beginNewFolder,
   handleDeleteEntries,
   createNote,
-  openTab,
   workspacePath,
   selectedEntryPaths,
   setSelectedEntryPaths,
@@ -263,8 +265,7 @@ export const useFileExplorerMenus = ({
             id: `new-note-${normalizedDirectoryPath}`,
             text: 'New Note',
             action: async () => {
-              const filePath = await createNote(directoryPath)
-              openTab(filePath)
+              await createNote(directoryPath, { openTab: true })
             },
           }),
         ]
@@ -289,12 +290,9 @@ export const useFileExplorerMenus = ({
                         const templateContent = await readTextFile(
                           template.path
                         )
-                        const filePath = await createNote(directoryPath, {
+                        await createNote(directoryPath, {
+                          openTab: true,
                           initialName: template.name,
-                          initialContent: templateContent,
-                        })
-                        const { openTab } = useStore.getState()
-                        await openTab(filePath, false, false, {
                           initialContent: templateContent,
                         })
                       } catch {
@@ -428,7 +426,6 @@ export const useFileExplorerMenus = ({
       beginNewFolder,
       createNote,
       handleDeleteEntries,
-      openTab,
       workspacePath,
       pinnedDirectories,
       pinDirectory,

--- a/src/store/workspace/workspace-fs-slice.ts
+++ b/src/store/workspace/workspace-fs-slice.ts
@@ -125,7 +125,11 @@ export type WorkspaceFsSlice = {
   ) => Promise<string | null>
   createNote: (
     directoryPath: string,
-    options?: { initialName?: string; initialContent?: string }
+    options?: {
+      initialName?: string
+      initialContent?: string
+      openTab?: boolean
+    }
   ) => Promise<string>
   createAndOpenNote: () => Promise<void>
   deleteEntries: (paths: string[]) => Promise<void>
@@ -263,10 +267,7 @@ export const prepareWorkspaceFsSlice =
         }
       },
 
-      createNote: async (
-        directoryPath: string,
-        options?: { initialName?: string; initialContent?: string }
-      ) => {
+      createNote: async (directoryPath, options) => {
         const { workspacePath } = get()
 
         if (!workspacePath) {
@@ -304,8 +305,11 @@ export const prepareWorkspaceFsSlice =
             : addEntryToState(entries, directoryPath, newFileEntry)
         )
 
-        get().setSelectedEntryPaths(new Set([filePath]))
-        get().setSelectionAnchorPath(filePath)
+        if (options?.openTab) {
+          await get().openTab(filePath)
+          get().setSelectedEntryPaths(new Set([filePath]))
+          get().setSelectionAnchorPath(filePath)
+        }
 
         return filePath
       },


### PR DESCRIPTION
- Updated NewNoteButton to accept a directoryPath prop, allowing note creation in a specified directory.
- Modified createNote function to include an openTab option, enabling the new note to open in a tab upon creation.
- Adjusted related components and hooks to support the new functionality, improving user experience in the note-taking workflow.