### PR TITLE
fix: rename in edit-note

### DIFF
--- a/src/components/quick-note/edit-note.tsx
+++ b/src/components/quick-note/edit-note.tsx
@@ -2,6 +2,7 @@ import { getCurrentWindow } from '@tauri-apps/api/window'
 import { useEffect } from 'react'
 import { useEditorOnlyMode } from '@/components/quick-note/hooks/use-editor-only-mode'
 import { useFontScale } from '@/hooks/use-font-scale'
+import { useStore } from '@/store'
 import { Editor } from '../editor/editor'
 import { LicenseKeyButton } from '../license/license-key-button'
 import { SettingsDialog } from '../settings/settings'
@@ -9,8 +10,10 @@ import { SettingsDialog } from '../settings/settings'
 export function EditNote() {
   const { hasCheckedOpenedFiles } = useEditorOnlyMode()
   useFontScale()
+  const setIsEditMode = useStore((s) => s.setIsEditMode)
 
   useEffect(() => {
+    setIsEditMode(true)
     const appWindow = getCurrentWindow()
     const closeListener = appWindow.listen('tauri://close-requested', () => {
       appWindow.destroy()
@@ -19,7 +22,7 @@ export function EditNote() {
     return () => {
       closeListener.then((unlisten) => unlisten())
     }
-  }, [])
+  }, [setIsEditMode])
 
   if (!hasCheckedOpenedFiles) {
     return <div className="h-screen bg-muted" />

--- a/src/components/quick-note/quick-note.tsx
+++ b/src/components/quick-note/quick-note.tsx
@@ -19,10 +19,11 @@ import { LicenseKeyButton } from '../license/license-key-button'
 import { SettingsDialog } from '../settings/settings'
 
 export function QuickNote() {
-  const { tab, openTab } = useStore(
+  const { tab, openTab, setIsEditMode } = useStore(
     useShallow((state) => ({
       tab: state.tab,
       openTab: state.openTab,
+      setIsEditMode: state.setIsEditMode,
     }))
   )
   const editor = usePlateEditor({ plugins: EditorKit })
@@ -50,11 +51,12 @@ export function QuickNote() {
     try {
       await writeTextFile(path, content)
       await openTab(path, false, false, { initialContent: content })
+      setIsEditMode(true)
     } catch (error) {
       console.error('Failed to save file:', error)
       toast.error('Failed to save file')
     }
-  }, [editor, openTab])
+  }, [editor, openTab, setIsEditMode])
 
   useEffect(() => {
     const appWindow = getCurrentWindow()

--- a/src/store/workspace/workspace-fs-slice.ts
+++ b/src/store/workspace/workspace-fs-slice.ts
@@ -489,14 +489,11 @@ export const prepareWorkspaceFsSlice =
         await get().renameTab(entry.path, nextPath)
         get().updateHistoryPath(entry.path, nextPath)
 
-        const {
-          workspacePath,
-          pinnedDirectories,
-          expandedDirectories,
-          entries,
-        } = get()
+        if (get().isEditMode) {
+          return nextPath
+        }
 
-        if (!workspacePath) throw new Error('Workspace path is not set')
+        const { pinnedDirectories, expandedDirectories, entries } = get()
 
         const updatedPins = entry.isDirectory
           ? renamePinnedDirectories(pinnedDirectories, entry.path, nextPath)

--- a/src/store/workspace/workspace-slice.ts
+++ b/src/store/workspace/workspace-slice.ts
@@ -45,6 +45,7 @@ type WorkspaceSliceDependencies = {
 
 const buildWorkspaceState = (overrides?: Partial<WorkspaceSlice>) => ({
   isLoading: false,
+  isEditMode: false,
   workspacePath: null,
   recentWorkspacePaths: [],
   entries: [],
@@ -66,6 +67,8 @@ export type WorkspaceEntry = {
 
 export type WorkspaceSlice = {
   isLoading: boolean
+  isEditMode: boolean
+  setIsEditMode: (isEditMode: boolean) => void
   workspacePath: string | null
   recentWorkspacePaths: string[]
   isTreeLoading: boolean
@@ -229,6 +232,10 @@ export const prepareWorkspaceSlice =
 
     return {
       ...buildWorkspaceState({ isLoading: true }),
+
+      setIsEditMode: (isEditMode: boolean) => {
+        set({ isEditMode })
+      },
 
       setExpandedDirectories: async (action) => {
         const { workspacePath, expandedDirectories } = get()


### PR DESCRIPTION
- Integrated isEditMode state management into QuickNote and EditNote components, allowing for better control of the editing state.
- Updated the store to include setIsEditMode function, enabling components to toggle edit mode as needed.
- Adjusted useEffect hooks to set edit mode appropriately when editing notes or saving files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces centralized `isEditMode` state and adjusts rename behavior to avoid workspace tree updates while editing.
> 
> - Adds `isEditMode` and `setIsEditMode` to the workspace store
> - `QuickNote` and `EditNote` set `isEditMode` on open/save
> - Updates `renameEntry` to early-return after FS/tab/history updates when `isEditMode` is true (skips pins/expanded/tree updates)
> - Minor effect dependency updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bde1f88c1e9d2ea23778475544ac79b6111c0a85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->