### PR TITLE
feat: show app window after mount

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,8 +12,12 @@ use tauri_plugin_window_state::Builder as WindowStateBuilder;
 
 #[tauri::command]
 fn show_main_window(window: tauri::WebviewWindow) {
-    window.show().unwrap();
-    window.set_focus().unwrap();
+    if let Err(e) = window.show() {
+        eprintln!("Failed to show window: {e}");
+    }
+    if let Err(e) = window.set_focus() {
+        eprintln!("Failed to focus window: {e}");
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -11,8 +11,10 @@ export function Router() {
   const label = useCurrentWindowLabel()
 
   useEffect(() => {
-    invoke('show_main_window')
-  }, [])
+    if (label === 'main') {
+      invoke('show_main_window').catch(console.error)
+    }
+  }, [label])
 
   if (label === null) {
     return null


### PR DESCRIPTION
- Added a new Tauri command `show_main_window` to manage the visibility and focus of the main window.
- Integrated the command into the Router component using a useEffect hook to invoke it when the component mounts, ensuring the main window is displayed appropriately.