### PR TITLE
feat: display backlinks

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,7 @@ pub fn run() {
             indexing::index_workspace_command,
             indexing::get_indexing_meta_command,
             indexing::search_query_entries_command,
+            indexing::get_backlinks_command,
             image_processing::get_image_properties_command,
             image_processing::edit_image_command
         ])

--- a/src/components/editor/header/more-button.tsx
+++ b/src/components/editor/header/more-button.tsx
@@ -1,16 +1,35 @@
-import { InfoIcon } from 'lucide-react'
+import { invoke } from '@tauri-apps/api/core'
+import { ArrowRight, InfoIcon } from 'lucide-react'
+import { resolve } from 'pathe'
 import { useEditorRef } from 'platejs/react'
 import { useEffect, useState } from 'react'
 import { countGraphemes } from 'unicode-segmenter/grapheme'
+import { useShallow } from 'zustand/shallow'
+import { useStore } from '@/store'
 import { Button } from '@/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/ui/popover'
+import { Separator } from '@/ui/separator'
 
 const WORD_SPLIT_REGEX = /\s+/
+
+type BacklinkEntry = {
+  relPath: string
+  fileName: string
+}
 
 export function MoreButton() {
   const editor = useEditorRef()
   const [open, setOpen] = useState(false)
   const [stats, setStats] = useState({ characters: 0, words: 0, minutes: 0 })
+  const [backlinks, setBacklinks] = useState<BacklinkEntry[]>([])
+
+  const { tab, workspacePath, openTab } = useStore(
+    useShallow((s) => ({
+      tab: s.tab,
+      workspacePath: s.workspacePath,
+      openTab: s.openTab,
+    }))
+  )
 
   useEffect(() => {
     if (!editor || !open) {
@@ -28,6 +47,36 @@ export function MoreButton() {
 
     setStats({ characters, words, minutes })
   }, [editor, open])
+
+  useEffect(() => {
+    if (!open || !workspacePath || !tab?.path) {
+      return
+    }
+
+    let cancelled = false
+    invoke<BacklinkEntry[]>('get_backlinks_command', {
+      workspacePath,
+      filePath: tab.path,
+    })
+      .then((entries) => {
+        if (!cancelled) setBacklinks(entries)
+      })
+      .catch((error) => {
+        console.error('Failed to fetch backlinks:', error)
+        if (!cancelled) setBacklinks([])
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [open, workspacePath, tab?.path])
+
+  const handleBacklinkClick = (relPath: string) => {
+    if (!workspacePath) return
+    const absolutePath = resolve(workspacePath, relPath)
+    openTab(absolutePath)
+    setOpen(false)
+  }
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -51,6 +100,31 @@ export function MoreButton() {
             <span>{stats.minutes} min</span>
           </div>
         </div>
+
+        {backlinks.length > 0 && (
+          <>
+            <Separator className="my-3" />
+            <div className="space-y-1">
+              <div className="text-muted-foreground text-xs mb-1">
+                Backlinks
+              </div>
+              <div className="space-y-0.5">
+                {backlinks.map((entry) => (
+                  <button
+                    type="button"
+                    key={entry.relPath}
+                    onClick={() => handleBacklinkClick(entry.relPath)}
+                    className="inline-flex justify-between gap-1 w-full text-left py-1 text-xs rounded text-muted-foreground hover:text-accent-foreground transition-colors cursor-pointer truncate"
+                    title={entry.relPath}
+                  >
+                    {entry.fileName}
+                    <ArrowRight className="size-3" />
+                  </button>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
       </PopoverContent>
     </Popover>
   )


### PR DESCRIPTION
- Added functionality to fetch and display backlinks for the currently open document in the MoreButton component.
- Introduced a new Tauri command to retrieve backlinks from the database.
- Updated the UI to show a list of backlinks with clickable buttons for navigation.
- Enhanced state management to handle backlinks and integrate with the existing editor functionality.