### PR TITLE
fix: simplify routing and URL handling

### DIFF
--- a/src-tauri/src/file_opener.rs
+++ b/src-tauri/src/file_opener.rs
@@ -33,9 +33,9 @@ fn open_edit_window(app_handle: &tauri::AppHandle) {
 
     // Build the URL with hash route
     let url = if file_path.is_empty() {
-        "index.html#/edit".to_string()
+        "/edit".to_string()
     } else {
-        format!("index.html#/edit?path={}", urlencoding::encode(&file_path))
+        format!("/edit?path={}", urlencoding::encode(&file_path))
     };
 
     // Create the editor-only window on demand for file association opens (Finder, "Open with", etc.).

--- a/src/components/system-tray/system-tray.tsx
+++ b/src/components/system-tray/system-tray.tsx
@@ -13,7 +13,7 @@ const createQuickNoteWindow = () => {
 	const windowLabel = `quick-note-${crypto.randomUUID()}`
 
 	new WebviewWindow(windowLabel, {
-		url: "/index.html#/quick-note",
+		url: "/quick-note",
 		title: "Mdit",
 		width: 800,
 		height: 600,

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -7,7 +7,6 @@ import {
 	useSearch,
 	Router as WouterRouter,
 } from "wouter"
-import { useHashLocation } from "wouter/use-hash-location"
 import { App } from "@/app"
 import { EditNote } from "./components/quick-note/edit-note"
 import { QuickNote } from "./components/quick-note/quick-note"
@@ -56,7 +55,7 @@ function AppRouter() {
 
 export function Router() {
 	return (
-		<WouterRouter hook={useHashLocation}>
+		<WouterRouter>
 			<AppRouter />
 		</WouterRouter>
 	)


### PR DESCRIPTION
- Removed the use of hash location in the router component for cleaner URL management.
- Updated URLs in the system tray and file opener to remove the hash fragment, ensuring direct access to routes.