### PR TITLE
feat(editor): implement note indexing on save

### DIFF
--- a/src-tauri/src/indexing/tests.rs
+++ b/src-tauri/src/indexing/tests.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use rusqlite::Connection;
+use rusqlite::{params, Connection};
 
 use crate::indexing::files::collect_markdown_files;
-use crate::indexing::{get_indexing_meta, IndexSummary};
+use crate::indexing::{get_indexing_meta, index_note, IndexSummary};
 use crate::migrations;
 
 use super::sync::sync_documents;
@@ -44,6 +44,25 @@ fn collect_files(root: &Path) -> Vec<crate::indexing::files::MarkdownFile> {
     collect_markdown_files(root).expect("failed to collect markdown files")
 }
 
+fn load_source_link_targets(conn: &Connection, source_rel_path: &str) -> Vec<String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT l.target_path \
+             FROM link l \
+             JOIN doc d ON d.id = l.source_doc_id \
+             WHERE d.rel_path = ?1 \
+             ORDER BY l.target_path",
+        )
+        .expect("failed to prepare link target query");
+
+    let rows = stmt
+        .query_map(params![source_rel_path], |row| row.get::<_, String>(0))
+        .expect("failed to read link targets");
+
+    rows.map(|row| row.expect("failed to read link target row"))
+        .collect()
+}
+
 #[test]
 fn counts_indexed_docs_without_embeddings() {
     let root = temp_workspace();
@@ -59,4 +78,57 @@ fn counts_indexed_docs_without_embeddings() {
 
     let meta = get_indexing_meta(&root).expect("failed to load indexing meta");
     assert_eq!(meta.indexed_doc_count, 3);
+}
+
+#[test]
+fn index_note_updates_target_and_does_not_prune_other_docs() {
+    let root = temp_workspace();
+    write_file(&root, "a.md", "[[b]]\n");
+    write_file(&root, "b.md", "# B\n");
+    write_file(&root, "c.md", "# C\n");
+
+    let mut conn = setup_db(&root);
+    let files = collect_files(&root);
+    let mut summary = IndexSummary::default();
+    sync_documents(&mut conn, &root, files, None, &mut summary).expect("initial sync failed");
+
+    std::fs::remove_file(root.join("b.md")).expect("failed to remove b.md");
+    write_file(&root, "a.md", "[[c]]\n");
+
+    let note_summary =
+        index_note(&root, &root.join("a.md"), "", "").expect("index_note should succeed");
+    assert_eq!(note_summary.files_discovered, 1);
+    assert_eq!(note_summary.files_processed, 1);
+    assert_eq!(note_summary.docs_deleted, 0);
+
+    let meta = get_indexing_meta(&root).expect("failed to load indexing meta");
+    assert_eq!(meta.indexed_doc_count, 3);
+
+    let conn = setup_db(&root);
+    let targets = load_source_link_targets(&conn, "a.md");
+    assert_eq!(targets, vec!["c.md"]);
+}
+
+#[test]
+fn index_note_rejects_paths_outside_workspace() {
+    let root = temp_workspace();
+    write_file(&root, "a.md", "# A\n");
+
+    let outside_path =
+        std::env::temp_dir().join(format!("mdit-indexing-outside-{}.md", unique_id()));
+    std::fs::write(&outside_path, "# Outside\n").expect("failed to write outside file");
+
+    let error =
+        index_note(&root, &outside_path, "", "").expect_err("expected outside path to fail");
+    assert!(error.to_string().contains("outside workspace"));
+}
+
+#[test]
+fn index_note_rejects_non_markdown_paths() {
+    let root = temp_workspace();
+    write_file(&root, "note.txt", "plain text");
+
+    let error = index_note(&root, &root.join("note.txt"), "", "")
+        .expect_err("expected non-markdown file to fail");
+    assert!(error.to_string().contains("markdown"));
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,6 +52,7 @@ pub fn run() {
             preview::get_note_preview,
             migrations::apply_workspace_migrations,
             indexing::index_workspace_command,
+            indexing::index_note_command,
             indexing::get_indexing_meta_command,
             indexing::search_query_entries_command,
             indexing::get_backlinks_command,

--- a/src/components/editor/hooks/use-auto-rename-on-save.ts
+++ b/src/components/editor/hooks/use-auto-rename-on-save.ts
@@ -6,7 +6,7 @@ import { getFileNameWithoutExtension } from "@/utils/path-utils"
  * Hook to handle auto-renaming files based on first heading after save
  */
 export function useAutoRenameOnSave(path: string) {
-	const handleRenameAfterSave = useCallback(() => {
+	const handleRenameAfterSave = useCallback(async () => {
 		// Check if we should rename based on tab.name (which may be from first heading)
 		const { tab, linkedTab, renameEntry } = useStore.getState()
 
@@ -14,19 +14,21 @@ export function useAutoRenameOnSave(path: string) {
 			const isLinkedToCurrentTab = linkedTab && linkedTab.path === tab.path
 
 			if (!isLinkedToCurrentTab) {
-				return
+				return path
 			}
 
 			const currentFileName = getFileNameWithoutExtension(path)
 
 			// Only rename if tab.name differs from current filename and is not empty
 			if (linkedTab.name !== "" && linkedTab.name !== currentFileName) {
-				renameEntry(
+				return renameEntry(
 					{ path, name: linkedTab.name, isDirectory: false },
 					`${linkedTab.name}.md`,
 				)
 			}
 		}
+
+		return path
 	}, [path])
 
 	return { handleRenameAfterSave }

--- a/src/services/indexing-service.ts
+++ b/src/services/indexing-service.ts
@@ -36,4 +36,21 @@ export class IndexingService {
 		)
 		return result
 	}
+
+	async indexNote(
+		notePath: string,
+		embeddingProvider: string,
+		embeddingModel: string,
+	): Promise<WorkspaceIndexSummary> {
+		const result = await this.invoke<WorkspaceIndexSummary>(
+			"index_note_command",
+			{
+				workspacePath: this.workspacePath,
+				notePath,
+				embeddingProvider,
+				embeddingModel,
+			},
+		)
+		return result
+	}
 }

--- a/src/store/indexing/indexing-slice.test.ts
+++ b/src/store/indexing/indexing-slice.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest"
+import { createStore } from "zustand/vanilla"
+import {
+	IndexingService,
+	type InvokeFunction,
+} from "@/services/indexing-service"
+import { type IndexingSlice, prepareIndexingSlice } from "./indexing-slice"
+
+function createIndexingStore(invoke: InvokeFunction) {
+	const createSlice = prepareIndexingSlice({
+		invoke,
+		loadSettings: vi.fn().mockResolvedValue({}),
+		saveSettings: vi.fn().mockResolvedValue(undefined),
+		createIndexingService: (invokeFn, workspacePath) =>
+			new IndexingService(invokeFn, workspacePath),
+		timerUtils: {
+			setInterval: vi.fn().mockReturnValue(1),
+			clearInterval: vi.fn(),
+			Date,
+		},
+	})
+
+	return createStore<IndexingSlice>()((set, get, api) =>
+		createSlice(set, get, api),
+	)
+}
+
+describe("indexing-slice indexNote", () => {
+	it("skips new note indexing request when workspace indexing is already running", async () => {
+		let resolveInvoke: (() => void) | undefined
+		const invoke = vi.fn().mockImplementation(
+			() =>
+				new Promise<unknown>((resolve) => {
+					resolveInvoke = () => resolve({})
+				}),
+		) as unknown as InvokeFunction
+		const store = createIndexingStore(invoke)
+
+		const firstRequest = store
+			.getState()
+			.indexNote("/ws", "/ws/a.md", "ollama", "mxbai-embed-large")
+
+		const skipped = await store
+			.getState()
+			.indexNote("/ws", "/ws/b.md", "ollama", "mxbai-embed-large")
+
+		expect(skipped).toBe(false)
+		expect(invoke).toHaveBeenCalledTimes(1)
+
+		resolveInvoke?.()
+		await expect(firstRequest).resolves.toBe(true)
+	})
+
+	it("sends expected invoke payload for note indexing", async () => {
+		const invoke = vi.fn().mockResolvedValue({}) as unknown as InvokeFunction
+		const store = createIndexingStore(invoke)
+
+		const result = await store
+			.getState()
+			.indexNote("/ws", "/ws/a.md", "ollama", "mxbai-embed-large")
+
+		expect(result).toBe(true)
+		expect(invoke).toHaveBeenCalledWith("index_note_command", {
+			workspacePath: "/ws",
+			notePath: "/ws/a.md",
+			embeddingProvider: "ollama",
+			embeddingModel: "mxbai-embed-large",
+		})
+		expect(store.getState().indexingState["/ws"]).toBe(false)
+	})
+
+	it("returns false and clears lock when note indexing fails", async () => {
+		const invoke = vi
+			.fn()
+			.mockRejectedValue(
+				new Error("indexing failed"),
+			) as unknown as InvokeFunction
+		const store = createIndexingStore(invoke)
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+		const result = await store
+			.getState()
+			.indexNote("/ws", "/ws/a.md", "ollama", "mxbai-embed-large")
+
+		expect(result).toBe(false)
+		expect(store.getState().indexingState["/ws"]).toBe(false)
+
+		errorSpy.mockRestore()
+	})
+})


### PR DESCRIPTION
- Enhanced the handleSave function to trigger note indexing after saving, with an option to skip indexing if not needed.
- Added runBlurIndexing function to manage the indexing process, including loading configuration and validating models.
- Introduced indexNote method in the indexing slice to handle note indexing requests.
- Updated the editor component to utilize the new indexing functionality, ensuring notes are indexed appropriately upon saving.