### PR TITLE
feat: persist workspace embedding config in vault

### DIFF
--- a/src-tauri/migrations/0001_vault_embedding_config.sql
+++ b/src-tauri/migrations/0001_vault_embedding_config.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `vault` ADD COLUMN `embedding_provider` text;
+--> statement-breakpoint
+ALTER TABLE `vault` ADD COLUMN `embedding_model` text;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,6 +64,8 @@ pub fn run() {
             vault::list_vault_workspaces_command,
             vault::touch_vault_workspace_command,
             vault::remove_vault_workspace_command,
+            vault::get_vault_embedding_config_command,
+            vault::set_vault_embedding_config_command,
             image_processing::get_image_properties_command,
             image_processing::edit_image_command
         ])

--- a/src-tauri/src/vault.rs
+++ b/src-tauri/src/vault.rs
@@ -6,9 +6,17 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
+use serde::Serialize;
 use tauri::{AppHandle, Runtime};
 
 use crate::migrations;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultEmbeddingConfig {
+    pub embedding_provider: String,
+    pub embedding_model: String,
+}
 
 fn open_vault_connection(db_path: &Path) -> Result<Connection> {
     let conn = Connection::open(db_path)
@@ -80,6 +88,79 @@ pub(crate) fn ensure_workspace_exists(conn: &Connection, workspace_root: &Path) 
         |row| row.get::<_, i64>(0),
     )
     .context("Failed to load vault id")
+}
+
+pub(crate) fn get_embedding_config(
+    db_path: &Path,
+    workspace_root: &Path,
+) -> Result<Option<VaultEmbeddingConfig>> {
+    let workspace_key = normalized_workspace_key(workspace_root)?;
+    let conn = open_vault_connection(db_path)?;
+
+    let row: Option<(Option<String>, Option<String>)> = conn
+        .query_row(
+            "SELECT embedding_provider, embedding_model FROM vault WHERE workspace_root = ?1",
+            params![workspace_key],
+            |db_row| Ok((db_row.get(0)?, db_row.get(1)?)),
+        )
+        .optional()
+        .context("Failed to load vault embedding config")?;
+
+    let Some((provider, model)) = row else {
+        return Ok(None);
+    };
+
+    let normalized_model = model.unwrap_or_default().trim().to_string();
+    if normalized_model.is_empty() {
+        return Ok(None);
+    }
+
+    let normalized_provider = provider.unwrap_or_default().trim().to_string();
+    let embedding_provider = if normalized_provider.is_empty() {
+        "ollama".to_string()
+    } else {
+        normalized_provider
+    };
+
+    Ok(Some(VaultEmbeddingConfig {
+        embedding_provider,
+        embedding_model: normalized_model,
+    }))
+}
+
+pub(crate) fn set_embedding_config(
+    db_path: &Path,
+    workspace_root: &Path,
+    embedding_provider: &str,
+    embedding_model: &str,
+) -> Result<()> {
+    let conn = open_vault_connection(db_path)?;
+    let vault_id = ensure_workspace_exists(&conn, workspace_root)?;
+    let normalized_model = embedding_model.trim();
+
+    if normalized_model.is_empty() {
+        conn.execute(
+            "UPDATE vault SET embedding_provider = NULL, embedding_model = NULL WHERE id = ?1",
+            params![vault_id],
+        )
+        .context("Failed to clear vault embedding config")?;
+        return Ok(());
+    }
+
+    let normalized_provider = embedding_provider.trim();
+    let provider_to_store = if normalized_provider.is_empty() {
+        "ollama"
+    } else {
+        normalized_provider
+    };
+
+    conn.execute(
+        "UPDATE vault SET embedding_provider = ?1, embedding_model = ?2 WHERE id = ?3",
+        params![provider_to_store, normalized_model, vault_id],
+    )
+    .context("Failed to save vault embedding config")?;
+
+    Ok(())
 }
 
 pub(crate) fn touch_workspace(db_path: &Path, workspace_root: &Path) -> Result<()> {
@@ -165,9 +246,38 @@ pub fn remove_vault_workspace_command<R: Runtime>(
     remove_workspace(&db_path, &workspace_path).map_err(|error| error.to_string())
 }
 
+#[tauri::command]
+pub fn get_vault_embedding_config_command<R: Runtime>(
+    app_handle: AppHandle<R>,
+    workspace_path: String,
+) -> Result<Option<VaultEmbeddingConfig>, String> {
+    let db_path = migrations::run_app_migrations(&app_handle).map_err(|error| error.to_string())?;
+    get_embedding_config(&db_path, Path::new(&workspace_path)).map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub fn set_vault_embedding_config_command<R: Runtime>(
+    app_handle: AppHandle<R>,
+    workspace_path: String,
+    embedding_provider: String,
+    embedding_model: String,
+) -> Result<(), String> {
+    let db_path = migrations::run_app_migrations(&app_handle).map_err(|error| error.to_string())?;
+    set_embedding_config(
+        &db_path,
+        Path::new(&workspace_path),
+        &embedding_provider,
+        &embedding_model,
+    )
+    .map_err(|error| error.to_string())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ensure_workspace_exists, list_workspaces, remove_workspace, touch_workspace};
+    use super::{
+        ensure_workspace_exists, get_embedding_config, list_workspaces, remove_workspace,
+        set_embedding_config, touch_workspace,
+    };
     use crate::migrations;
     use rusqlite::{params, Connection, OptionalExtension};
     use std::{
@@ -316,6 +426,97 @@ mod tests {
 
         assert!(removed_missing.is_none());
         assert!(removed_workspace.is_none());
+    }
+
+    #[test]
+    fn given_saved_embedding_config_when_loading_then_it_roundtrips() {
+        let harness = VaultHarness::new("mdit-vault-embedding-roundtrip");
+        let workspace = harness.create_workspace("ws");
+
+        set_embedding_config(&harness.db_path, &workspace, "ollama", "mxbai-embed-large")
+            .expect("set config should succeed");
+
+        let config = get_embedding_config(&harness.db_path, &workspace)
+            .expect("get config should succeed")
+            .expect("config should exist");
+
+        assert_eq!(config.embedding_provider, "ollama");
+        assert_eq!(config.embedding_model, "mxbai-embed-large");
+    }
+
+    #[test]
+    fn given_empty_model_when_saving_embedding_config_then_it_clears_columns() {
+        let harness = VaultHarness::new("mdit-vault-embedding-clear");
+        let workspace = harness.create_workspace("ws");
+
+        set_embedding_config(&harness.db_path, &workspace, "ollama", "model-a")
+            .expect("set config should succeed");
+        set_embedding_config(&harness.db_path, &workspace, "openai", "")
+            .expect("clear config should succeed");
+
+        let config = get_embedding_config(&harness.db_path, &workspace)
+            .expect("get config should succeed");
+        assert!(config.is_none());
+
+        let conn = harness.open_connection();
+        let key = VaultHarness::workspace_key(&workspace);
+        let row: (Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT embedding_provider, embedding_model FROM vault WHERE workspace_root = ?1",
+                params![key],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("failed to read cleared columns");
+        assert!(row.0.is_none());
+        assert!(row.1.is_none());
+    }
+
+    #[test]
+    fn given_missing_workspace_row_when_setting_embedding_then_row_is_created() {
+        let harness = VaultHarness::new("mdit-vault-embedding-create-row");
+        let workspace = harness.create_workspace("ws");
+
+        set_embedding_config(&harness.db_path, &workspace, "", "model-a")
+            .expect("set config should create vault row");
+
+        let key = VaultHarness::workspace_key(&workspace);
+        let conn = harness.open_connection();
+        let row: (i64, Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT COUNT(*), MAX(embedding_provider), MAX(embedding_model) \
+                 FROM vault WHERE workspace_root = ?1",
+                params![key],
+                |db_row| Ok((db_row.get(0)?, db_row.get(1)?, db_row.get(2)?)),
+            )
+            .expect("failed to inspect created row");
+
+        assert_eq!(row.0, 1);
+        assert_eq!(row.1.as_deref(), Some("ollama"));
+        assert_eq!(row.2.as_deref(), Some("model-a"));
+    }
+
+    #[test]
+    fn given_two_workspaces_when_saving_embedding_configs_then_values_are_isolated() {
+        let harness = VaultHarness::new("mdit-vault-embedding-isolated");
+        let workspace_a = harness.create_workspace("a");
+        let workspace_b = harness.create_workspace("b");
+
+        set_embedding_config(&harness.db_path, &workspace_a, "ollama", "model-a")
+            .expect("set config for workspace a should succeed");
+        set_embedding_config(&harness.db_path, &workspace_b, "openai", "text-embedding-3-small")
+            .expect("set config for workspace b should succeed");
+
+        let config_a = get_embedding_config(&harness.db_path, &workspace_a)
+            .expect("get config for workspace a should succeed")
+            .expect("config for workspace a should exist");
+        let config_b = get_embedding_config(&harness.db_path, &workspace_b)
+            .expect("get config for workspace b should succeed")
+            .expect("config for workspace b should exist");
+
+        assert_eq!(config_a.embedding_provider, "ollama");
+        assert_eq!(config_a.embedding_model, "model-a");
+        assert_eq!(config_b.embedding_provider, "openai");
+        assert_eq!(config_b.embedding_model, "text-embedding-3-small");
     }
 
     fn unique_id() -> u128 {

--- a/src/lib/settings-utils.ts
+++ b/src/lib/settings-utils.ts
@@ -15,10 +15,6 @@ export type WorkspaceSettings = {
 		commitMessage: string
 		autoSync: boolean
 	}
-	indexing?: {
-		embeddingProvider: string
-		embeddingModel: string
-	}
 	pinnedDirectories?: string[]
 	lastOpenedNotePath?: string
 	expandedDirectories?: string[]
@@ -40,7 +36,6 @@ export const loadSettings = async (
 
 		const content = await readTextFile(configPath)
 		const config: WorkspaceSettings = JSON.parse(content)
-
 		return config
 	} catch (error) {
 		console.error("Failed to load settings from file:", error)

--- a/src/services/indexing-service.ts
+++ b/src/services/indexing-service.ts
@@ -20,6 +20,30 @@ export class IndexingService {
 		return meta
 	}
 
+	async getIndexingConfig(): Promise<{
+		embeddingProvider: string
+		embeddingModel: string
+	} | null> {
+		const config = await this.invoke<{
+			embeddingProvider: string
+			embeddingModel: string
+		} | null>("get_vault_embedding_config_command", {
+			workspacePath: this.workspacePath,
+		})
+		return config
+	}
+
+	async setIndexingConfig(
+		embeddingProvider: string,
+		embeddingModel: string,
+	): Promise<void> {
+		await this.invoke<void>("set_vault_embedding_config_command", {
+			workspacePath: this.workspacePath,
+			embeddingProvider,
+			embeddingModel,
+		})
+	}
+
 	async indexWorkspace(
 		embeddingProvider: string,
 		embeddingModel: string,


### PR DESCRIPTION
## Summary
- add vault migration for embedding provider/model columns
- add tauri commands to get/set workspace embedding config in appdata vault
- switch indexing slice to read/write config via vault commands instead of workspace settings file
- update indexing slice tests for the new invoke commands

## Testing
- pnpm test src/store/indexing/indexing-slice.test.ts
- cargo test vault::tests::given_ --manifest-path src-tauri/Cargo.toml
- pnpm ts:check