### PR TITLE
feat: add window pin toggle for quick note and edit windows

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
 		"core:window:allow-show",
 		"core:window:allow-destroy",
 		"core:window:allow-set-fullscreen",
+		"core:window:allow-set-always-on-top",
 		"process:default",
 		"opener:default",
 		"dialog:default",

--- a/apps/desktop/src/components/editor/header/header.tsx
+++ b/apps/desktop/src/components/editor/header/header.tsx
@@ -1,4 +1,6 @@
 import { useShallow } from "zustand/shallow"
+import { WindowPinButton } from "@/components/quick-note/window-pin-button"
+import { useCurrentWindowLabel } from "@/hooks/use-current-window-label"
 import { useIsFullscreen } from "@/hooks/use-is-fullscreen"
 import { cn } from "@/lib/utils"
 import { useStore } from "@/store"
@@ -23,6 +25,9 @@ export function Header() {
 	)
 	const isCollectionViewOpen = currentCollectionPath !== null
 	const isFullscreen = useIsFullscreen()
+	const windowLabel = useCurrentWindowLabel()
+	const showPin =
+		windowLabel?.startsWith("edit-") || windowLabel?.startsWith("quick-note-")
 
 	return (
 		<div
@@ -46,7 +51,8 @@ export function Header() {
 				<HistoryNavigation />
 			</div>
 			<Tab />
-			<div className="absolute right-0">
+			<div className="absolute right-0 flex items-center gap-0.5">
+				{showPin && <WindowPinButton />}
 				<MoreButton />
 			</div>
 		</div>

--- a/apps/desktop/src/components/quick-note/quick-note.tsx
+++ b/apps/desktop/src/components/quick-note/quick-note.tsx
@@ -13,6 +13,7 @@ import { useLocation } from "wouter"
 import { cn } from "@/lib/utils"
 import { isMac } from "@/utils/platform"
 import { EditorKit } from "../editor/plugins/editor-kit"
+import { WindowPinButton } from "./window-pin-button"
 
 export function QuickNote() {
 	const [, navigate] = useLocation()
@@ -66,6 +67,9 @@ export function QuickNote() {
 				className="fixed top-0 left-0 h-12 w-full z-50"
 				{...(isMac() && { "data-tauri-drag-region": "" })}
 			/>
+			<div className="fixed top-2 right-2 z-60">
+				<WindowPinButton />
+			</div>
 			<Plate editor={editor}>
 				<PlateContainer
 					className={cn(

--- a/apps/desktop/src/components/quick-note/window-pin-button.tsx
+++ b/apps/desktop/src/components/quick-note/window-pin-button.tsx
@@ -1,0 +1,68 @@
+import { getCurrentWindow } from "@tauri-apps/api/window"
+import { PinIcon, PinOffIcon } from "lucide-react"
+import { useCallback, useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+export function WindowPinButton({ className }: { className?: string }) {
+	const [isPinned, setIsPinned] = useState(false)
+	const [isPending, setIsPending] = useState(false)
+
+	useEffect(() => {
+		let isMounted = true
+		const appWindow = getCurrentWindow()
+
+		appWindow
+			.isAlwaysOnTop()
+			.then((alwaysOnTop) => {
+				if (isMounted) {
+					setIsPinned(alwaysOnTop)
+				}
+			})
+			.catch((error) => {
+				console.error("Failed to read window pin state:", error)
+			})
+
+		return () => {
+			isMounted = false
+		}
+	}, [])
+
+	const handleToggle = useCallback(async () => {
+		if (isPending) {
+			return
+		}
+
+		const nextPinned = !isPinned
+		const appWindow = getCurrentWindow()
+		setIsPending(true)
+
+		try {
+			await appWindow.setAlwaysOnTop(nextPinned)
+			setIsPinned(nextPinned)
+		} catch (error) {
+			console.error("Failed to toggle window pin state:", error)
+		} finally {
+			setIsPending(false)
+		}
+	}, [isPinned, isPending])
+
+	const label = isPinned ? "Unpin window" : "Pin window"
+
+	return (
+		<Button
+			type="button"
+			variant="ghost"
+			size="icon"
+			className={cn("text-foreground/70", className)}
+			aria-label={label}
+			title={label}
+			disabled={isPending}
+			onClick={() => {
+				void handleToggle()
+			}}
+		>
+			{isPinned ? <PinOffIcon /> : <PinIcon />}
+		</Button>
+	)
+}


### PR DESCRIPTION
## Summary
- add a reusable window pin button to toggle always-on-top state per window
- show pin toggle in editor header for edit and quick-note windows
- render pin toggle in quick-note view and add Tauri capability for always-on-top

## Testing
- not run (manual verification pending)