### PR TITLE
refactor(indexing): move embedding config resolution to tauri commands

### DIFF
--- a/apps/desktop/src/components/editor/editor.tsx
+++ b/apps/desktop/src/components/editor/editor.tsx
@@ -79,18 +79,11 @@ function EditorContent({
 }) {
 	const isSaved = useRef(true)
 	const isInitializing = useRef(true)
-	const {
-		setTabSaved,
-		saveNoteContent,
-		workspacePath,
-		getIndexingConfig,
-		indexNote,
-	} = useStore(
+	const { setTabSaved, saveNoteContent, workspacePath, indexNote } = useStore(
 		useShallow((s) => ({
 			setTabSaved: s.setTabSaved,
 			saveNoteContent: s.saveNoteContent,
 			workspacePath: s.workspacePath,
-			getIndexingConfig: s.getIndexingConfig,
 			indexNote: s.indexNote,
 		})),
 	)
@@ -109,38 +102,9 @@ function EditorContent({
 				return
 			}
 
-			const state = useStore.getState()
-			let config: Awaited<ReturnType<typeof getIndexingConfig>> =
-				state.configs[workspacePath] ?? null
-
-			if (!config) {
-				try {
-					config = await getIndexingConfig(workspacePath)
-				} catch (error) {
-					console.error(
-						"Failed to load indexing config for blur indexing:",
-						error,
-					)
-					return
-				}
-			}
-
-			const provider = config?.embeddingProvider ?? ""
-			const model = config?.embeddingModel ?? ""
-			if (model && !provider) {
-				return
-			}
-
-			if (model && provider === "ollama") {
-				const isModelAvailable = state.ollamaModels.includes(model)
-				if (!isModelAvailable) {
-					return
-				}
-			}
-
-			await indexNote(workspacePath, notePath, provider, model)
+			await indexNote(workspacePath, notePath)
 		},
-		[workspacePath, getIndexingConfig, indexNote],
+		[workspacePath, indexNote],
 	)
 
 	const handleSave = useCallback(

--- a/apps/desktop/src/components/settings/ui/indexing-tab.tsx
+++ b/apps/desktop/src/components/settings/ui/indexing-tab.tsx
@@ -110,7 +110,12 @@ export function IndexingTab() {
 
 	// Start/stop polling based on indexing state
 	useEffect(() => {
-		if (!workspacePath || !isIndexing) {
+		if (!workspacePath) {
+			stopIndexingMetaPolling(true)
+			return
+		}
+
+		if (!isIndexing) {
 			stopIndexingMetaPolling()
 			return
 		}
@@ -171,17 +176,8 @@ export function IndexingTab() {
 			return
 		}
 
-		if (isEmbeddingModelConfigured && !isEmbeddingModelAvailable) {
-			return
-		}
-
 		try {
-			await indexWorkspace(
-				workspacePath,
-				embeddingProvider,
-				embeddingModel,
-				forceReindex,
-			)
+			await indexWorkspace(workspacePath, forceReindex)
 			await loadIndexingMeta(workspacePath)
 		} catch (error) {
 			console.error("Failed to index workspace:", error)

--- a/apps/desktop/src/hooks/use-auto-indexing.ts
+++ b/apps/desktop/src/hooks/use-auto-indexing.ts
@@ -8,17 +8,13 @@ export function useAutoIndexing(workspacePath: string | null) {
 	const {
 		getIndexingConfig,
 		indexWorkspace,
-		config,
 		isMigrationsComplete,
-		ollamaModels,
 		fetchOllamaModels,
 	} = useStore(
 		useShallow((state) => ({
 			getIndexingConfig: state.getIndexingConfig,
 			indexWorkspace: state.indexWorkspace,
-			config: workspacePath ? state.configs[workspacePath] : null,
 			isMigrationsComplete: state.isMigrationsComplete,
-			ollamaModels: state.ollamaModels,
 			fetchOllamaModels: state.fetchOllamaModels,
 		})),
 	)
@@ -58,24 +54,7 @@ export function useAutoIndexing(workspacePath: string | null) {
 			}
 
 			try {
-				const provider = config?.embeddingProvider ?? ""
-				const model = config?.embeddingModel ?? ""
-				if (model && !provider) {
-					// Misconfigured state; do not attempt indexing.
-					return
-				}
-				if (model && provider && provider === "ollama") {
-					const isAvailable = ollamaModels.includes(model)
-					if (!isAvailable) {
-						return
-					}
-				}
-				await indexWorkspace(
-					workspacePath,
-					provider,
-					model,
-					false, // forceReindex: false for incremental updates
-				)
+				await indexWorkspace(workspacePath, false)
 			} catch (error) {
 				// Silent failure - just log to console
 				console.error("Auto-indexing failed:", error)
@@ -98,11 +77,5 @@ export function useAutoIndexing(workspacePath: string | null) {
 				intervalRef.current = null
 			}
 		}
-	}, [
-		workspacePath,
-		config,
-		indexWorkspace,
-		isMigrationsComplete,
-		ollamaModels,
-	])
+	}, [workspacePath, indexWorkspace, isMigrationsComplete])
 }

--- a/apps/desktop/src/hooks/use-semantic-note-search.ts
+++ b/apps/desktop/src/hooks/use-semantic-note-search.ts
@@ -50,8 +50,6 @@ export function useSemanticNoteSearch(
 		invoke<QuerySearchEntry[]>("search_query_entries_command", {
 			workspacePath,
 			query: trimmedQuery,
-			embeddingProvider,
-			embeddingModel,
 		})
 			.then((entries) => {
 				if (requestIdRef.current !== requestId) {
@@ -82,7 +80,7 @@ export function useSemanticNoteSearch(
 				console.error("Failed to perform semantic search:", error)
 				setResults([])
 			})
-	}, [workspacePath, trimmedQuery, embeddingProvider, embeddingModel])
+	}, [workspacePath, trimmedQuery])
 
 	return {
 		results,

--- a/apps/desktop/src/services/indexing-service.ts
+++ b/apps/desktop/src/services/indexing-service.ts
@@ -44,35 +44,23 @@ export class IndexingService {
 		})
 	}
 
-	async indexWorkspace(
-		embeddingProvider: string,
-		embeddingModel: string,
-		forceReindex: boolean,
-	): Promise<WorkspaceIndexSummary> {
+	async indexWorkspace(forceReindex: boolean): Promise<WorkspaceIndexSummary> {
 		const result = await this.invoke<WorkspaceIndexSummary>(
 			"index_workspace_command",
 			{
 				workspacePath: this.workspacePath,
-				embeddingProvider,
-				embeddingModel,
 				forceReindex,
 			},
 		)
 		return result
 	}
 
-	async indexNote(
-		notePath: string,
-		embeddingProvider: string,
-		embeddingModel: string,
-	): Promise<WorkspaceIndexSummary> {
+	async indexNote(notePath: string): Promise<WorkspaceIndexSummary> {
 		const result = await this.invoke<WorkspaceIndexSummary>(
 			"index_note_command",
 			{
 				workspacePath: this.workspacePath,
 				notePath,
-				embeddingProvider,
-				embeddingModel,
 			},
 		)
 		return result


### PR DESCRIPTION
## Summary
- move embedding provider/model resolution from frontend payloads into Tauri indexing/search commands
- simplify indexing service/slice/editor/hooks APIs by removing embedding args from index/search command calls
- adjust indexing polling stop behavior and update tests for new invoke payload shapes

## Testing
- pnpm -C apps/desktop test -- src/store/indexing/indexing-slice.test.ts
- pnpm -C apps/desktop ts:check