### PR TITLE
feat(local-api): secure endpoints with auth token

### DIFF
--- a/apps/desktop/src-tauri/src/commands/local_api.rs
+++ b/apps/desktop/src-tauri/src/commands/local_api.rs
@@ -1,8 +1,19 @@
 use tauri::AppHandle;
 
 #[tauri::command]
-pub fn start_local_api_server_command(app_handle: AppHandle) -> Result<(), String> {
+pub fn start_local_api_server_command(app_handle: AppHandle, token: String) -> Result<(), String> {
+    crate::local_api::set_local_api_auth_token(&app_handle, token)
+        .map_err(|error| format!("{error:#}"))?;
     crate::local_api::start_local_api_server(&app_handle).map_err(|error| format!("{error:#}"))
+}
+
+#[tauri::command]
+pub fn set_local_api_auth_token_command(
+    app_handle: AppHandle,
+    token: String,
+) -> Result<(), String> {
+    crate::local_api::set_local_api_auth_token(&app_handle, token)
+        .map_err(|error| format!("{error:#}"))
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub fn run() {
         .plugin(tauri_plugin_clipboard::init())
         .plugin(WindowStateBuilder::default().build())
         .manage(local_api::LocalApiRuntimeState::default())
+        .manage(local_api::LocalApiAuthState::default())
         .invoke_handler(tauri::generate_handler![
             app::window_lifecycle::show_main_window,
             commands::filesystem::copy,
@@ -62,6 +63,7 @@ pub fn run() {
             commands::vault_indexing::get_vault_embedding_config_command,
             commands::vault_indexing::set_vault_embedding_config_command,
             commands::local_api::start_local_api_server_command,
+            commands::local_api::set_local_api_auth_token_command,
             commands::local_api::stop_local_api_server_command,
             commands::image::get_image_properties,
             commands::image::edit_image,

--- a/apps/desktop/src-tauri/src/local_api/router.rs
+++ b/apps/desktop/src-tauri/src/local_api/router.rs
@@ -1,33 +1,37 @@
-use std::path::PathBuf;
+use std::{
+    future::Future,
+    path::PathBuf,
+    pin::Pin,
+    sync::{Arc, RwLock},
+    task::{Context, Poll},
+};
 
 use axum::{
-    extract::{Path, State},
-    http::StatusCode,
+    extract::{Path, Request, State},
+    http::{header, HeaderMap, StatusCode, Uri},
+    response::{IntoResponse, Response},
     routing::{get, post},
     Json, Router,
 };
 use local_api_core::{CreateNoteInput, LocalApiError, LocalApiErrorKind, SearchNotesInput};
 use serde::{Deserialize, Serialize};
+use tower::{Layer, Service};
 
 use super::mcp_sdk_server::build_mcp_service;
 
 #[derive(Debug, Clone)]
 pub struct LocalApiState {
     pub db_path: PathBuf,
+    pub auth_token: Arc<RwLock<String>>,
 }
 
 pub fn build_router(state: LocalApiState) -> Router {
-    let mcp_service = build_mcp_service(state.db_path.clone());
+    let protected_routes =
+        build_protected_routes(state.db_path.clone(), Arc::clone(&state.auth_token));
 
     Router::new()
         .route("/healthz", get(healthz_handler))
-        .route("/api/v1/vaults", get(list_vaults_handler))
-        .route("/api/v1/vaults/{vault_id}/notes", post(create_note_handler))
-        .route(
-            "/api/v1/vaults/{vault_id}/search",
-            post(search_notes_handler),
-        )
-        .nest_service("/mcp", mcp_service)
+        .merge(protected_routes)
         .with_state(state)
 }
 
@@ -85,6 +89,23 @@ struct ErrorBody {
 
 type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ErrorResponse>)>;
 
+fn build_protected_routes(
+    db_path: PathBuf,
+    auth_token: Arc<RwLock<String>>,
+) -> Router<LocalApiState> {
+    let mcp_service = build_mcp_service(db_path);
+
+    Router::new()
+        .route("/api/v1/vaults", get(list_vaults_handler))
+        .route("/api/v1/vaults/{vault_id}/notes", post(create_note_handler))
+        .route(
+            "/api/v1/vaults/{vault_id}/search",
+            post(search_notes_handler),
+        )
+        .nest_service("/mcp", mcp_service)
+        .route_layer(AuthLayer::new(auth_token))
+}
+
 async fn healthz_handler() -> Json<HealthResponse> {
     Json(HealthResponse { status: "ok" })
 }
@@ -137,6 +158,151 @@ async fn search_notes_handler(
     }
 }
 
+#[derive(Clone)]
+struct AuthLayer {
+    auth_token: Arc<RwLock<String>>,
+}
+
+impl AuthLayer {
+    fn new(auth_token: Arc<RwLock<String>>) -> Self {
+        Self { auth_token }
+    }
+}
+
+impl<S> Layer<S> for AuthLayer {
+    type Service = AuthService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AuthService {
+            inner,
+            auth_token: Arc::clone(&self.auth_token),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct AuthService<S> {
+    inner: S,
+    auth_token: Arc<RwLock<String>>,
+}
+
+impl<S> Service<Request> for AuthService<S>
+where
+    S: Service<Request, Response = Response> + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let configured_token = match self.auth_token.read() {
+            Ok(token) => token.clone(),
+            Err(error) => {
+                let response = internal_auth_error_to_http(format!(
+                    "Failed to lock local API auth token: {error}"
+                ))
+                .into_response();
+                return Box::pin(async move { Ok(response) });
+            }
+        };
+
+        if request_has_valid_token(&request, &configured_token) {
+            let future = self.inner.call(request);
+            return Box::pin(async move { future.await });
+        }
+
+        let response = unauthorized_error_to_http().into_response();
+        Box::pin(async move { Ok(response) })
+    }
+}
+
+fn request_has_valid_token(request: &Request, configured_token: &str) -> bool {
+    if configured_token.is_empty() {
+        return false;
+    }
+
+    let provided_token = extract_bearer_token(request.headers()).or_else(|| {
+        if request.uri().path().starts_with("/mcp") {
+            extract_token_from_query(request.uri())
+        } else {
+            None
+        }
+    });
+
+    matches!(provided_token, Some(token) if token == configured_token)
+}
+
+fn extract_bearer_token(headers: &HeaderMap) -> Option<String> {
+    let auth_header = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
+    let (scheme, token) = auth_header.split_once(' ')?;
+    if !scheme.eq_ignore_ascii_case("bearer") {
+        return None;
+    }
+
+    let normalized = token.trim();
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized.to_string())
+    }
+}
+
+fn extract_token_from_query(uri: &Uri) -> Option<String> {
+    let query = uri.query()?;
+
+    for part in query.split('&') {
+        let mut segments = part.splitn(2, '=');
+        let key = segments.next().unwrap_or_default();
+        if key != "token" {
+            continue;
+        }
+
+        let raw_value = segments.next().unwrap_or_default();
+        if raw_value.is_empty() {
+            return None;
+        }
+
+        let decoded = urlencoding::decode(raw_value).ok()?;
+        let normalized = decoded.trim();
+        if normalized.is_empty() {
+            return None;
+        }
+
+        return Some(normalized.to_string());
+    }
+
+    None
+}
+
+fn unauthorized_error_to_http() -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(ErrorResponse {
+            error: ErrorBody {
+                code: "UNAUTHORIZED".to_string(),
+                message: "Missing or invalid local API token.".to_string(),
+            },
+        }),
+    )
+}
+
+fn internal_auth_error_to_http(message: String) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse {
+            error: ErrorBody {
+                code: "AUTH_STATE_ERROR".to_string(),
+                message,
+            },
+        }),
+    )
+}
+
 fn local_api_error_to_http(error: LocalApiError) -> (StatusCode, Json<ErrorResponse>) {
     local_api_error_to_http_with_invalid_input_status(error, StatusCode::UNPROCESSABLE_ENTITY)
 }
@@ -165,8 +331,10 @@ fn local_api_error_to_http_with_invalid_input_status(
 
 #[cfg(test)]
 pub fn build_mcp_only_router(state: LocalApiState) -> Router {
+    let auth_token = Arc::clone(&state.auth_token);
     let mcp_service = build_mcp_service(state.db_path.clone());
     Router::new()
         .nest_service("/mcp", mcp_service)
+        .route_layer(AuthLayer::new(auth_token))
         .with_state(state)
 }

--- a/apps/desktop/src/components/settings/ui/api-mcp-tab.tsx
+++ b/apps/desktop/src/components/settings/ui/api-mcp-tab.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@mdit/ui/components/button"
 import {
 	Field,
 	FieldContent,
@@ -7,8 +8,17 @@ import {
 	FieldLegend,
 	FieldSet,
 } from "@mdit/ui/components/field"
+import { Input } from "@mdit/ui/components/input"
 import { Switch } from "@mdit/ui/components/switch"
+import { Check, Copy } from "lucide-react"
+import { useEffect, useState } from "react"
+import { toast } from "sonner"
 import { useShallow } from "zustand/shallow"
+import {
+	ensureLocalApiAuthToken,
+	rotateLocalApiAuthToken,
+} from "@/services/local-api-auth-service"
+import { setLocalApiAuthToken } from "@/services/local-api-service"
 import { useStore } from "@/store"
 
 const REST_APIS = [
@@ -53,17 +63,18 @@ const CLIENT_GUIDES = [
 	{
 		name: "Claude Code",
 		description: "Add an MCP server using the Claude Code CLI.",
-		snippet: "claude mcp add --transport http mdit http://127.0.0.1:39123/mcp",
+		snippet:
+			'claude mcp add --transport http mdit "http://127.0.0.1:39123/mcp?token=<TOKEN>"',
 	},
 	{
 		name: "Codex",
 		description: "Register the MCP server with Codex CLI (or use config.toml).",
 		snippet: `# CLI
-codex mcp add mdit --url http://127.0.0.1:39123/mcp
+codex mcp add mdit --url "http://127.0.0.1:39123/mcp?token=<TOKEN>"
 
 # ~/.codex/config.toml
 [mcp_servers.mdit]
-url = "http://127.0.0.1:39123/mcp"`,
+url = "http://127.0.0.1:39123/mcp?token=<TOKEN>"`,
 	},
 	{
 		name: "Cursor",
@@ -71,7 +82,7 @@ url = "http://127.0.0.1:39123/mcp"`,
 		snippet: `{
   "mcpServers": {
     "mdit": {
-      "url": "http://127.0.0.1:39123/mcp"
+      "url": "http://127.0.0.1:39123/mcp?token=<TOKEN>"
     }
   }
 }`,
@@ -79,15 +90,87 @@ url = "http://127.0.0.1:39123/mcp"`,
 ] as const
 
 export function ApiMcpTab() {
-	const { licenseStatus, localApiEnabled, setLocalApiEnabled, localApiError } =
-		useStore(
-			useShallow((state) => ({
-				licenseStatus: state.status,
-				localApiEnabled: state.localApiEnabled,
-				setLocalApiEnabled: state.setLocalApiEnabled,
-				localApiError: state.localApiError,
-			})),
-		)
+	const {
+		licenseStatus,
+		localApiEnabled,
+		setLocalApiEnabled,
+		localApiError,
+		setLocalApiError,
+	} = useStore(
+		useShallow((state) => ({
+			licenseStatus: state.status,
+			localApiEnabled: state.localApiEnabled,
+			setLocalApiEnabled: state.setLocalApiEnabled,
+			localApiError: state.localApiError,
+			setLocalApiError: state.setLocalApiError,
+		})),
+	)
+	const [token, setToken] = useState("")
+	const [tokenCopied, setTokenCopied] = useState(false)
+
+	useEffect(() => {
+		let isActive = true
+
+		const loadToken = async () => {
+			try {
+				const ensuredToken = await ensureLocalApiAuthToken()
+				if (!isActive) {
+					return
+				}
+				setToken(ensuredToken)
+				await setLocalApiAuthToken(ensuredToken)
+			} catch (error) {
+				const message =
+					error instanceof Error ? error.message : String(error ?? "Unknown")
+				toast.error("Failed to load local API auth token")
+				console.error("Failed to initialize local API auth token:", error)
+				if (isActive) {
+					setLocalApiError(`Failed to load local API auth token: ${message}`)
+				}
+			}
+		}
+
+		void loadToken()
+
+		return () => {
+			isActive = false
+		}
+	}, [setLocalApiError])
+
+	const handleCopyToken = async () => {
+		if (!token) return
+		try {
+			await navigator.clipboard.writeText(token)
+			setTokenCopied(true)
+			setTimeout(() => setTokenCopied(false), 2000)
+		} catch (error) {
+			console.error("Clipboard write failed:", error)
+			toast.error("Failed to copy")
+		}
+	}
+
+	const copyToClipboard = async (value: string, successMessage: string) => {
+		try {
+			await navigator.clipboard.writeText(value)
+			toast.success(successMessage)
+		} catch (error) {
+			console.error("Clipboard write failed:", error)
+			toast.error("Failed to copy")
+		}
+	}
+
+	const handleRotateToken = async () => {
+		try {
+			const rotatedToken = await rotateLocalApiAuthToken()
+			await setLocalApiAuthToken(rotatedToken)
+			setToken(rotatedToken)
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : String(error ?? "Unknown")
+			toast.error("Failed to rotate local API token")
+			setLocalApiError(`Failed to rotate local API auth token: ${message}`)
+		}
+	}
 
 	return (
 		<div className="flex-1 overflow-y-auto px-12 pt-12 pb-24">
@@ -124,9 +207,59 @@ export function ApiMcpTab() {
 			</FieldSet>
 
 			<FieldSet className="mt-8 border-b pb-8">
+				<FieldLegend>Authentication Token</FieldLegend>
+				<FieldDescription>
+					All local API endpoints require this token except{" "}
+					<code>/healthz</code>.
+				</FieldDescription>
+				<FieldGroup className="gap-4">
+					<Field orientation="vertical">
+						<FieldContent>
+							<FieldLabel>Token</FieldLabel>
+						</FieldContent>
+						<div className="flex items-center gap-2 mt-2">
+							<div className="relative flex-1">
+								<Input
+									readOnly
+									type="text"
+									value={token}
+									placeholder="Loading token..."
+									className="font-mono text-xs pr-10"
+								/>
+								<div className="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5">
+									<Button
+										variant="ghost"
+										size="icon"
+										className="h-7 w-7 text-muted-foreground hover:text-foreground"
+										onClick={handleCopyToken}
+										disabled={!token}
+										title="Copy Token"
+									>
+										{tokenCopied ? (
+											<Check className="size-4" />
+										) : (
+											<Copy className="size-4" />
+										)}
+									</Button>
+								</div>
+							</div>
+							<Button
+								variant="secondary"
+								className="shrink-0"
+								onClick={handleRotateToken}
+							>
+								Regenerate
+							</Button>
+						</div>
+					</Field>
+				</FieldGroup>
+			</FieldSet>
+
+			<FieldSet className="mt-8 border-b pb-8">
 				<FieldLegend>Available REST APIs</FieldLegend>
 				<FieldDescription>
-					These are the currently implemented local REST APIs.
+					Requests must include an{" "}
+					<code>Authorization: Bearer &lt;token&gt;</code> header.
 				</FieldDescription>
 				<FieldGroup className="gap-2">
 					{REST_APIS.map((api) => (
@@ -145,7 +278,8 @@ export function ApiMcpTab() {
 			<FieldSet className="mt-8 border-b pb-8">
 				<FieldLegend>Available MCP Tools</FieldLegend>
 				<FieldDescription>
-					Exposed through MCP endpoint <code>/mcp</code>.
+					Exposed through MCP endpoint <code>/mcp</code> using{" "}
+					<code>?token=&lt;token&gt;</code> in the URL.
 				</FieldDescription>
 				<FieldGroup className="gap-2">
 					{MCP_TOOLS.map((tool) => (
@@ -164,8 +298,7 @@ export function ApiMcpTab() {
 			<FieldSet className="mt-8">
 				<FieldLegend>Connect from Claude Code / Codex / Cursor</FieldLegend>
 				<FieldDescription>
-					Field names may vary by client version; keep the endpoint URL
-					unchanged.
+					Field names may vary by client version.
 				</FieldDescription>
 				<FieldGroup className="gap-4">
 					{CLIENT_GUIDES.map((client) => (
@@ -174,9 +307,30 @@ export function ApiMcpTab() {
 								<FieldLabel>{client.name}</FieldLabel>
 								<FieldDescription>{client.description}</FieldDescription>
 							</FieldContent>
-							<pre className="rounded-md border bg-muted px-3 py-2 text-xs whitespace-pre-wrap">
-								{client.snippet}
-							</pre>
+							<div className="relative group/snippet">
+								<pre className="rounded-md border bg-muted px-3 py-2 text-xs whitespace-pre-wrap pr-10">
+									{token
+										? client.snippet.replace(/<TOKEN>/g, token)
+										: client.snippet}
+								</pre>
+								<Button
+									variant="ghost"
+									size="icon"
+									className="absolute right-2 top-2 h-6 w-6 text-muted-foreground hover:text-foreground opacity-0 group-hover\/snippet:opacity-100 transition-opacity"
+									onClick={() =>
+										copyToClipboard(
+											token
+												? client.snippet.replace(/<TOKEN>/g, token)
+												: client.snippet,
+											"Snippet copied",
+										)
+									}
+									disabled={!token}
+									title="Copy Snippet"
+								>
+									<Copy className="size-3" />
+								</Button>
+							</div>
 						</Field>
 					))}
 				</FieldGroup>

--- a/apps/desktop/src/services/local-api-auth-service.ts
+++ b/apps/desktop/src/services/local-api-auth-service.ts
@@ -1,0 +1,96 @@
+import {
+	getPassword as getPasswordFromKeyring,
+	setPassword as setPasswordInKeyring,
+} from "tauri-plugin-keyring-api"
+
+const LOCAL_API_TOKEN_SERVICE = "app.mdit"
+const LOCAL_API_TOKEN_USER = "local_api"
+const LOCAL_API_TOKEN_BYTE_LENGTH = 32
+const LOCAL_API_TOKEN_MIN_LENGTH = 32
+const LOCAL_API_STORE_VERSION = 1 as const
+
+type LocalApiAuthStore = {
+	version: typeof LOCAL_API_STORE_VERSION
+	token: string
+}
+
+function generateLocalApiToken(): string {
+	const cryptoApi = globalThis.crypto
+	if (!cryptoApi) {
+		throw new Error("Secure crypto API is unavailable")
+	}
+
+	const bytes = new Uint8Array(LOCAL_API_TOKEN_BYTE_LENGTH)
+	cryptoApi.getRandomValues(bytes)
+	return Array.from(bytes, (value) => value.toString(16).padStart(2, "0")).join(
+		"",
+	)
+}
+
+function isValidLocalApiToken(value: string | null): value is string {
+	return Boolean(value && value.trim().length >= LOCAL_API_TOKEN_MIN_LENGTH)
+}
+
+function isLocalApiAuthStore(value: unknown): value is LocalApiAuthStore {
+	if (typeof value !== "object" || value === null) return false
+	const o = value as Record<string, unknown>
+	return (
+		o.version === LOCAL_API_STORE_VERSION &&
+		typeof o.token === "string" &&
+		isValidLocalApiToken(o.token)
+	)
+}
+
+function decodeLocalApiAuthStore(raw: string | null): LocalApiAuthStore | null {
+	if (!raw?.trim()) return null
+	try {
+		const parsed = JSON.parse(raw) as unknown
+		return isLocalApiAuthStore(parsed) ? parsed : null
+	} catch {
+		return null
+	}
+}
+
+function encodeLocalApiAuthStore(store: LocalApiAuthStore): string {
+	return JSON.stringify(store)
+}
+
+export async function getLocalApiAuthToken(): Promise<string | null> {
+	const raw = await getPasswordFromKeyring(
+		LOCAL_API_TOKEN_SERVICE,
+		LOCAL_API_TOKEN_USER,
+	)
+	const store = decodeLocalApiAuthStore(raw)
+	return store?.token ?? null
+}
+
+export async function ensureLocalApiAuthToken(): Promise<string> {
+	const existingToken = await getLocalApiAuthToken()
+	if (isValidLocalApiToken(existingToken)) {
+		return existingToken
+	}
+
+	const generatedToken = generateLocalApiToken()
+	await setPasswordInKeyring(
+		LOCAL_API_TOKEN_SERVICE,
+		LOCAL_API_TOKEN_USER,
+		encodeLocalApiAuthStore({
+			version: LOCAL_API_STORE_VERSION,
+			token: generatedToken,
+		}),
+	)
+	return generatedToken
+}
+
+export async function rotateLocalApiAuthToken(): Promise<string> {
+	const generatedToken = generateLocalApiToken()
+	await setPasswordInKeyring(
+		LOCAL_API_TOKEN_SERVICE,
+		LOCAL_API_TOKEN_USER,
+		encodeLocalApiAuthStore({
+			version: LOCAL_API_STORE_VERSION,
+			token: generatedToken,
+		}),
+	)
+	return generatedToken
+}

--- a/apps/desktop/src/services/local-api-service.ts
+++ b/apps/desktop/src/services/local-api-service.ts
@@ -1,9 +1,15 @@
 import { invoke } from "@tauri-apps/api/core"
+import { ensureLocalApiAuthToken } from "./local-api-auth-service"
 
 export async function startLocalApiServer(): Promise<void> {
-	await invoke("start_local_api_server_command")
+	const token = await ensureLocalApiAuthToken()
+	await invoke("start_local_api_server_command", { token })
 }
 
 export async function stopLocalApiServer(): Promise<void> {
 	await invoke("stop_local_api_server_command")
+}
+
+export async function setLocalApiAuthToken(token: string): Promise<void> {
+	await invoke("set_local_api_auth_token_command", { token })
 }


### PR DESCRIPTION
## Summary
- require local API auth token before starting local server
- add token management via keyring and settings UI (copy/regenerate)
- protect local REST and MCP routes with token auth
- restrict query-string token auth to MCP path only
- align settings copy with actual auth behavior

## Testing
- pnpm -C apps/desktop ts:check
- cargo test -p mdit --manifest-path Cargo.toml local_api -- --nocapture