### PR TITLE
feat: add optional embedding toggle for note indexing

### DIFF
--- a/apps/desktop/src-tauri/src/commands/vault_indexing.rs
+++ b/apps/desktop/src-tauri/src/commands/vault_indexing.rs
@@ -60,12 +60,17 @@ pub async fn index_note_command(
     app_handle: tauri::AppHandle,
     workspace_path: String,
     note_path: String,
+    include_embeddings: Option<bool>,
 ) -> Result<IndexSummary, String> {
     let db_path = crate::persistence::run_app_migrations(&app_handle)?;
     let workspace_path = PathBuf::from(workspace_path);
     let note_path = PathBuf::from(note_path);
-    let (embedding_provider, embedding_model) =
-        resolve_embedding_for_workspace(&db_path, &workspace_path)?;
+    let should_include_embeddings = include_embeddings.unwrap_or(true);
+    let (embedding_provider, embedding_model) = if should_include_embeddings {
+        resolve_embedding_for_workspace(&db_path, &workspace_path)?
+    } else {
+        (String::new(), String::new())
+    };
 
     run_blocking(move || {
         index_note(

--- a/apps/desktop/src/services/indexing-service.ts
+++ b/apps/desktop/src/services/indexing-service.ts
@@ -55,12 +55,16 @@ export class IndexingService {
 		return result
 	}
 
-	async indexNote(notePath: string): Promise<WorkspaceIndexSummary> {
+	async indexNote(
+		notePath: string,
+		options?: { includeEmbeddings?: boolean },
+	): Promise<WorkspaceIndexSummary> {
 		const result = await this.invoke<WorkspaceIndexSummary>(
 			"index_note_command",
 			{
 				workspacePath: this.workspacePath,
 				notePath,
+				includeEmbeddings: options?.includeEmbeddings ?? true,
 			},
 		)
 		return result

--- a/apps/desktop/src/store/indexing/indexing-slice.test.ts
+++ b/apps/desktop/src/store/indexing/indexing-slice.test.ts
@@ -120,8 +120,25 @@ describe("indexing-slice indexNote", () => {
 		expect(invoke).toHaveBeenCalledWith("index_note_command", {
 			workspacePath: "/ws",
 			notePath: "/ws/a.md",
+			includeEmbeddings: true,
 		})
 		expect(store.getState().indexingState["/ws"]).toBe(false)
+	})
+
+	it("can disable embeddings for note indexing", async () => {
+		const invoke = vi.fn().mockResolvedValue({}) as unknown as InvokeFunction
+		const { store } = createIndexingStore({ invoke })
+
+		const result = await store
+			.getState()
+			.indexNote("/ws", "/ws/a.md", { includeEmbeddings: false })
+
+		expect(result).toBe(true)
+		expect(invoke).toHaveBeenCalledWith("index_note_command", {
+			workspacePath: "/ws",
+			notePath: "/ws/a.md",
+			includeEmbeddings: false,
+		})
 	})
 
 	it("returns false and clears lock when note indexing fails", async () => {

--- a/apps/desktop/src/store/indexing/indexing-slice.ts
+++ b/apps/desktop/src/store/indexing/indexing-slice.ts
@@ -62,7 +62,11 @@ export type IndexingSlice = {
 		workspacePath: string,
 		forceReindex: boolean,
 	) => Promise<WorkspaceIndexSummary>
-	indexNote: (workspacePath: string, notePath: string) => Promise<boolean>
+	indexNote: (
+		workspacePath: string,
+		notePath: string,
+		options?: { includeEmbeddings?: boolean },
+	) => Promise<boolean>
 
 	loadIndexingMeta: (workspacePath: string) => Promise<void>
 	startIndexingMetaPolling: (workspacePath: string) => void
@@ -221,7 +225,11 @@ export const prepareIndexingSlice = ({
 			}
 		},
 
-		indexNote: async (workspacePath: string, notePath: string) => {
+		indexNote: async (
+			workspacePath: string,
+			notePath: string,
+			options?: { includeEmbeddings?: boolean },
+		) => {
 			const isRunning = get().indexingState[workspacePath]
 			if (isRunning) {
 				return false
@@ -236,7 +244,7 @@ export const prepareIndexingSlice = ({
 
 			try {
 				const service = createIndexingService(invoke, workspacePath)
-				await service.indexNote(notePath)
+				await service.indexNote(notePath, options)
 				return true
 			} catch (error) {
 				console.error("Failed to index note:", error)


### PR DESCRIPTION
## Summary
- add optional `include_embeddings` parameter to the Tauri `index_note_command`
- thread `includeEmbeddings` option through desktop indexing service and indexing slice
- update editor save-time indexing call to request note indexing without embeddings
- add indexing-slice tests for default and disabled embedding payloads

## Testing
- pnpm -C apps/desktop test -- src/store/indexing/indexing-slice.test.ts