### PR TITLE
fix: preserve exact-match detection with capped link suggestions

### DIFF
--- a/apps/desktop/src/components/editor/ui/link-url-input.tsx
+++ b/apps/desktop/src/components/editor/ui/link-url-input.tsx
@@ -240,32 +240,24 @@ export function LinkUrlInput({
 				relativePathLower.includes(candidate),
 			)
 
-			if (!exactMatchFound && exactQueryCandidates.has(relativePathLower)) {
-				exactMatchFound = true
-			}
-
 			if (
 				!exactMatchFound &&
-				relativeToTabLower &&
-				exactQueryCandidates.has(relativeToTabLower)
+				(exactQueryCandidates.has(relativePathLower) ||
+					(relativeToTabLower && exactQueryCandidates.has(relativeToTabLower)))
 			) {
 				exactMatchFound = true
 			}
 
 			if (suggestions.length < MAX_SUGGESTIONS) {
-				if (matchesRelativePath) {
-					suggestions.push(file)
-				} else if (
-					displayNameQuery &&
-					displayNameLower.includes(displayNameQuery)
-				) {
-					suggestions.push(file)
-				} else if (
+				const matchesDisplayName =
+					displayNameQuery && displayNameLower.includes(displayNameQuery)
+				const matchesRelativeToTab =
 					relativeToTabLower &&
 					pathQueryCandidates.some((candidate) =>
 						relativeToTabLower.includes(candidate),
 					)
-				) {
+
+				if (matchesRelativePath || matchesDisplayName || matchesRelativeToTab) {
 					suggestions.push(file)
 				}
 			}


### PR DESCRIPTION
## Summary
- keep scanning all searchable files for exact-match detection in link suggestions
- cap only the number of collected suggestions (`MAX_SUGGESTIONS`) without early loop break
- prevent false negatives that could show suggestions/empty state for exact queries

## Testing
- not run (logic-only change in existing component)