### PR TITLE
fix: sync tab path on edit-mode rename

### DIFF
--- a/apps/desktop/src/store/workspace/actions/workspace-fs-structure-actions.test.ts
+++ b/apps/desktop/src/store/workspace/actions/workspace-fs-structure-actions.test.ts
@@ -73,6 +73,31 @@ describe("workspace-fs-structure-actions", () => {
 		)
 	})
 
+	it("renameEntry updates tab path in edit mode without entryRenamed", async () => {
+		const { context, deps, ports, setState, getState } =
+			createWorkspaceActionTestContext()
+		const actions = createWorkspaceFsStructureActions(context)
+		getState().entryRenamed = vi.fn().mockResolvedValue(undefined)
+		setState({ isEditMode: true })
+
+		const renamedPath = await actions.renameEntry(
+			{
+				path: "/ws/old.md",
+				name: "old.md",
+				isDirectory: false,
+			},
+			"new.md",
+		)
+
+		expect(renamedPath).toBe("/ws/new.md")
+		expect(deps.fileSystemRepository.rename).toHaveBeenCalledWith(
+			"/ws/old.md",
+			"/ws/new.md",
+		)
+		expect(ports.tab.renameTab).toHaveBeenCalledWith("/ws/old.md", "/ws/new.md")
+		expect(getState().entryRenamed).not.toHaveBeenCalled()
+	})
+
 	it("deleteEntries uses moveManyToTrash for multiple items", async () => {
 		const { context, deps, getState } = createWorkspaceActionTestContext()
 		const actions = createWorkspaceFsStructureActions(context)

--- a/apps/desktop/src/store/workspace/actions/workspace-fs-structure-actions.ts
+++ b/apps/desktop/src/store/workspace/actions/workspace-fs-structure-actions.ts
@@ -173,6 +173,7 @@ export const createWorkspaceFsStructureActions = (
 		ctx.get().recordFsOperation()
 
 		if (ctx.get().isEditMode) {
+			await ctx.ports.tab.renameTab(entry.path, nextPath)
 			return nextPath
 		}
 


### PR DESCRIPTION
## Summary
- call `tab.renameTab` during `renameEntry` when edit mode is enabled
- add a regression test ensuring edit-mode rename updates the open tab path without invoking `entryRenamed`

## Testing
- pnpm -C apps/desktop test -- workspace-fs-structure-actions