### PR TITLE
fix: sync link index on note and directory deletion

### DIFF
--- a/apps/desktop/src-tauri/src/commands/vault_indexing.rs
+++ b/apps/desktop/src-tauri/src/commands/vault_indexing.rs
@@ -2,10 +2,10 @@ use std::path::{Path, PathBuf};
 
 use app_storage::vault::VaultEmbeddingConfig;
 use indexing_core::{
-    get_backlinks, get_graph_view_data, get_indexing_meta, get_related_notes, index_note,
-    index_workspace, rename_indexed_note, resolve_wiki_link, search_notes_for_query, BacklinkEntry,
-    GraphViewData, IndexSummary, IndexingMeta, RelatedNoteEntry, ResolveWikiLinkRequest,
-    ResolveWikiLinkResult, SemanticNoteEntry,
+    delete_indexed_note, get_backlinks, get_graph_view_data, get_indexing_meta, get_related_notes,
+    index_note, index_workspace, rename_indexed_note, resolve_wiki_link, search_notes_for_query,
+    BacklinkEntry, GraphViewData, IndexSummary, IndexingMeta, RelatedNoteEntry,
+    ResolveWikiLinkRequest, ResolveWikiLinkResult, SemanticNoteEntry,
 };
 use tauri::{AppHandle, Runtime};
 
@@ -101,6 +101,19 @@ pub async fn rename_indexed_note_command(
         rename_indexed_note(&workspace_path, &db_path, &old_note_path, &new_note_path)
     })
     .await
+}
+
+#[tauri::command]
+pub async fn delete_indexed_note_command(
+    app_handle: tauri::AppHandle,
+    workspace_path: String,
+    note_path: String,
+) -> Result<bool, String> {
+    let db_path = crate::persistence::run_app_migrations(&app_handle)?;
+    let workspace_path = PathBuf::from(workspace_path);
+    let note_path = PathBuf::from(note_path);
+
+    run_blocking(move || delete_indexed_note(&workspace_path, &db_path, &note_path)).await
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -53,6 +53,7 @@ pub fn run() {
             commands::vault_indexing::index_workspace_command,
             commands::vault_indexing::index_note_command,
             commands::vault_indexing::rename_indexed_note_command,
+            commands::vault_indexing::delete_indexed_note_command,
             commands::vault_indexing::get_indexing_meta_command,
             commands::vault_indexing::search_query_entries_command,
             commands::vault_indexing::resolve_wiki_link_command,

--- a/apps/desktop/src/store/workspace/actions/workspace-action-test-helpers.ts
+++ b/apps/desktop/src/store/workspace/actions/workspace-action-test-helpers.ts
@@ -63,6 +63,7 @@ export function createWorkspaceActionTestContext() {
 			}),
 			indexNote: vi.fn().mockResolvedValue(undefined),
 			renameIndexedNote: vi.fn().mockResolvedValue(false),
+			deleteIndexedNote: vi.fn().mockResolvedValue(false),
 		},
 	}
 

--- a/apps/desktop/src/store/workspace/helpers/deletion-indexing-helpers.test.ts
+++ b/apps/desktop/src/store/workspace/helpers/deletion-indexing-helpers.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest"
+import type { WorkspaceEntry } from "../workspace-state"
+import {
+	isPathDeletedByTargets,
+	resolveDeletedMarkdownPaths,
+} from "./deletion-indexing-helpers"
+
+describe("deletion-indexing-helpers", () => {
+	it("collects markdown deletions from direct paths and directory descendants", () => {
+		const entries: WorkspaceEntry[] = [
+			{
+				path: "/ws/folder",
+				name: "folder",
+				isDirectory: true,
+				children: [
+					{
+						path: "/ws/folder/target.md",
+						name: "target.md",
+						isDirectory: false,
+					},
+					{
+						path: "/ws/folder/nested",
+						name: "nested",
+						isDirectory: true,
+						children: [
+							{
+								path: "/ws/folder/nested/deep.md",
+								name: "deep.md",
+								isDirectory: false,
+							},
+						],
+					},
+					{
+						path: "/ws/folder/ignored.txt",
+						name: "ignored.txt",
+						isDirectory: false,
+					},
+					{
+						path: "/ws/folder/ignored.mdx",
+						name: "ignored.mdx",
+						isDirectory: false,
+					},
+				],
+			},
+		]
+
+		const result = resolveDeletedMarkdownPaths(
+			["/ws/folder", "/ws/standalone.md", "/ws/folder/target.md"],
+			entries,
+		)
+
+		expect(new Set(result)).toEqual(
+			new Set([
+				"/ws/folder/target.md",
+				"/ws/folder/nested/deep.md",
+				"/ws/standalone.md",
+			]),
+		)
+	})
+
+	it("resolves deleted directory path even when input uses backslashes", () => {
+		const entries: WorkspaceEntry[] = [
+			{
+				path: "/ws/folder",
+				name: "folder",
+				isDirectory: true,
+				children: [
+					{
+						path: "/ws/folder/target.md",
+						name: "target.md",
+						isDirectory: false,
+					},
+				],
+			},
+		]
+
+		const result = resolveDeletedMarkdownPaths(["/ws\\folder"], entries)
+
+		expect(result).toEqual(["/ws/folder/target.md"])
+	})
+
+	it("matches deleted targets by exact path or descendant path only", () => {
+		const deletedPathSet = new Set(["/ws/folder", "/ws/note.md"])
+
+		expect(isPathDeletedByTargets("/ws/folder", deletedPathSet)).toBe(true)
+		expect(isPathDeletedByTargets("/ws/folder/child.md", deletedPathSet)).toBe(
+			true,
+		)
+		expect(isPathDeletedByTargets("/ws/note.md", deletedPathSet)).toBe(true)
+		expect(
+			isPathDeletedByTargets("/ws/folder-two/child.md", deletedPathSet),
+		).toBe(false)
+		expect(isPathDeletedByTargets("/ws/note.md.bak", deletedPathSet)).toBe(
+			false,
+		)
+	})
+})

--- a/apps/desktop/src/store/workspace/helpers/deletion-indexing-helpers.ts
+++ b/apps/desktop/src/store/workspace/helpers/deletion-indexing-helpers.ts
@@ -1,0 +1,57 @@
+import type { WorkspaceEntry } from "../workspace-state"
+import { findEntryByPath } from "./entry-helpers"
+import { isMarkdownNotePath, normalizeSlashes } from "./fs-structure-helpers"
+
+const collectMarkdownDescendants = (
+	entry: WorkspaceEntry,
+	accumulator: Set<string>,
+) => {
+	if (!entry.isDirectory) {
+		const normalizedPath = normalizeSlashes(entry.path)
+		if (isMarkdownNotePath(normalizedPath)) {
+			accumulator.add(normalizedPath)
+		}
+		return
+	}
+
+	for (const child of entry.children ?? []) {
+		collectMarkdownDescendants(child, accumulator)
+	}
+}
+
+export const resolveDeletedMarkdownPaths = (
+	paths: string[],
+	entries: WorkspaceEntry[],
+) => {
+	const markdownPaths = new Set<string>()
+
+	for (const path of paths) {
+		const normalizedPath = normalizeSlashes(path)
+		if (isMarkdownNotePath(normalizedPath)) {
+			markdownPaths.add(normalizedPath)
+		}
+
+		const entry =
+			findEntryByPath(entries, path) ?? findEntryByPath(entries, normalizedPath)
+		if (entry?.isDirectory) {
+			collectMarkdownDescendants(entry, markdownPaths)
+		}
+	}
+
+	return [...markdownPaths]
+}
+
+export const isPathDeletedByTargets = (
+	normalizedPath: string,
+	deletedPathSet: Set<string>,
+) => {
+	for (const deletedPath of deletedPathSet) {
+		if (
+			normalizedPath === deletedPath ||
+			normalizedPath.startsWith(`${deletedPath}/`)
+		) {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/desktop/src/store/workspace/workspace-dependencies.ts
+++ b/apps/desktop/src/store/workspace/workspace-dependencies.ts
@@ -100,6 +100,10 @@ export type LinkIndexingDependencies = {
 		oldNotePath: string,
 		newNotePath: string,
 	) => Promise<boolean>
+	deleteIndexedNote: (
+		workspacePath: string,
+		notePath: string,
+	) => Promise<boolean>
 }
 
 export type WorkspaceDependencies = {

--- a/apps/desktop/src/store/workspace/workspace-slice.ts
+++ b/apps/desktop/src/store/workspace/workspace-slice.ts
@@ -229,5 +229,10 @@ export const createWorkspaceSlice = prepareWorkspaceSlice({
 				oldNotePath,
 				newNotePath,
 			}),
+		deleteIndexedNote: (workspacePath: string, notePath: string) =>
+			invoke<boolean>("delete_indexed_note_command", {
+				workspacePath,
+				notePath,
+			}),
 	},
 })


### PR DESCRIPTION
## Summary
- add `delete_indexed_note` command plumbing from desktop store through Tauri into indexing-core
- sync link index after delete operations by removing deleted note docs and reindexing backlink sources
- handle directory deletions by expanding nested markdown notes and skipping reindex for deleted descendants
- extract deletion index sync path logic into `deletion-indexing-helpers`
- add JS and Rust tests for note deletion, backlink cleanup, and directory delete behavior

## Testing
- pnpm -C apps/desktop test -- src/store/workspace/actions/workspace-fs-structure-actions.test.ts
- cargo test -p indexing-core --manifest-path Cargo.toml note_scenarios