### PR TITLE
feat: add create new note from link URL input when no matches

### DIFF
--- a/apps/desktop/src/components/editor/ui/link-toolbar-utils.ts
+++ b/apps/desktop/src/components/editor/ui/link-toolbar-utils.ts
@@ -136,6 +136,15 @@ export function normalizePathSeparators(path: string): string {
 	return collapsed.endsWith("/") ? collapsed.slice(0, -1) : collapsed
 }
 
+/** Prefixes relative markdown path with ./ when it doesn't start with . or / */
+export function formatMarkdownPath(relativePath: string): string {
+	return relativePath &&
+		!relativePath.startsWith(".") &&
+		!relativePath.startsWith("/")
+		? `./${relativePath}`
+		: relativePath
+}
+
 export function normalizeWikiTargetForDisplay(value: string): string {
 	const decoded = safelyDecodeUrl(value.trim())
 	if (!decoded) {

--- a/apps/desktop/src/components/editor/ui/link-url-input.tsx
+++ b/apps/desktop/src/components/editor/ui/link-url-input.tsx
@@ -32,6 +32,7 @@ import {
 	createPathQueryCandidates,
 	ensureUriEncoding,
 	flattenWorkspaceFiles,
+	formatMarkdownPath,
 	type LinkMode,
 	normalizeMarkdownPathForDisplay,
 	normalizePathSeparators,
@@ -80,6 +81,14 @@ export function LinkUrlInput({
 		})),
 	)
 	const currentTabPath = tab?.path ?? null
+	const currentRelativeDir = useMemo(() => {
+		if (currentTabPath && workspacePath) {
+			const dir = pathDirname(currentTabPath)
+			const relDir = relative(workspacePath, dir)
+			return normalizePathSeparators(relDir) || "root"
+		}
+		return "root"
+	}, [currentTabPath, workspacePath])
 
 	const suggestionsSource = useMemo(
 		() => flattenWorkspaceFiles(workspaceEntries, workspacePath),
@@ -401,12 +410,7 @@ export function LinkUrlInput({
 			const relativePath = relative(tabDirectory, file.absolutePath)
 
 			const normalizedRelativePath = normalizePathSeparators(relativePath)
-			const nextValue =
-				normalizedRelativePath &&
-				!normalizedRelativePath.startsWith(".") &&
-				!normalizedRelativePath.startsWith("/")
-					? `./${normalizedRelativePath}`
-					: normalizedRelativePath
+			const nextValue = formatMarkdownPath(normalizedRelativePath)
 
 			const displayValue = normalizeMarkdownPathForDisplay(nextValue)
 
@@ -514,12 +518,7 @@ export function LinkUrlInput({
 				const relativePath = normalizePathSeparators(
 					relative(tabDirectory, resolvedPath),
 				)
-				nextUrl =
-					relativePath &&
-					!relativePath.startsWith(".") &&
-					!relativePath.startsWith("/")
-						? `./${relativePath}`
-						: relativePath
+				nextUrl = formatMarkdownPath(relativePath)
 			}
 		}
 
@@ -561,12 +560,7 @@ export function LinkUrlInput({
 			const relativePath = normalizePathSeparators(
 				relative(targetDirectory, newFilePath),
 			)
-			finalUrl =
-				relativePath &&
-				!relativePath.startsWith(".") &&
-				!relativePath.startsWith("/")
-					? `./${relativePath}`
-					: relativePath
+			finalUrl = formatMarkdownPath(relativePath)
 			nextWikiTarget = null
 		} else {
 			const baseName =
@@ -800,14 +794,7 @@ export function LinkUrlInput({
 											Create new note "{trimmedValue}"
 										</span>
 										<span className="text-xs text-muted-foreground max-w-full truncate pl-5">
-											{currentTabPath && workspacePath
-												? normalizePathSeparators(
-														relative(
-															workspacePath,
-															pathDirname(currentTabPath),
-														),
-													) || "root"
-												: "root"}
+											{currentRelativeDir}
 										</span>
 									</div>
 								</div>


### PR DESCRIPTION
## Summary
매칭되는 노트가 없을 때 링크 URL 입력에서 새 노트를 바로 생성할 수 있도록 개선했습니다.

## Changes
- **Empty state 개선**: "No matching notes" 대신 "Create new note [이름]" 액션 추가
- **Enter 키 지원**: 빈 상태에서 Enter 시 새 노트 생성 후 링크 삽입
- **createNote/openTab 연동**: 스토어의 `createNote`, `openTab`으로 노트 생성 및 탭 열기
- **UI 일관성**: 제안 목록 아이템에 FileIcon 추가, 패딩 정리

## Testing
- 링크 삽입 플로우에서 존재하지 않는 노트명 입력 시 "Create new note" 표시
- 클릭 또는 Enter로 새 노트 생성 및 링크 삽입 확인

Made with [Cursor](https://cursor.com)