### PR TITLE
feat: unify local API and license secret storage

### DIFF
--- a/apps/desktop/src/services/local-api-auth-service.ts
+++ b/apps/desktop/src/services/local-api-auth-service.ts
@@ -1,18 +1,7 @@
-import {
-	getPassword as getPasswordFromKeyring,
-	setPassword as setPasswordInKeyring,
-} from "tauri-plugin-keyring-api"
+import { getAppSecret, setAppSecret } from "@mdit/ai-auth"
 
-const LOCAL_API_TOKEN_SERVICE = "app.mdit"
-const LOCAL_API_TOKEN_USER = "local_api"
 const LOCAL_API_TOKEN_BYTE_LENGTH = 32
 const LOCAL_API_TOKEN_MIN_LENGTH = 32
-const LOCAL_API_STORE_VERSION = 1 as const
-
-type LocalApiAuthStore = {
-	version: typeof LOCAL_API_STORE_VERSION
-	token: string
-}
 
 function generateLocalApiToken(): string {
 	const cryptoApi = globalThis.crypto
@@ -31,37 +20,12 @@ function isValidLocalApiToken(value: string | null): value is string {
 	return Boolean(value && value.trim().length >= LOCAL_API_TOKEN_MIN_LENGTH)
 }
 
-function isLocalApiAuthStore(value: unknown): value is LocalApiAuthStore {
-	if (typeof value !== "object" || value === null) return false
-	const o = value as Record<string, unknown>
-	return (
-		o.version === LOCAL_API_STORE_VERSION &&
-		typeof o.token === "string" &&
-		isValidLocalApiToken(o.token)
-	)
-}
-
-function decodeLocalApiAuthStore(raw: string | null): LocalApiAuthStore | null {
-	if (!raw?.trim()) return null
-	try {
-		const parsed = JSON.parse(raw) as unknown
-		return isLocalApiAuthStore(parsed) ? parsed : null
-	} catch {
+export async function getLocalApiAuthToken(): Promise<string | null> {
+	const token = await getAppSecret("local_api_token")
+	if (!isValidLocalApiToken(token)) {
 		return null
 	}
-}
-
-function encodeLocalApiAuthStore(store: LocalApiAuthStore): string {
-	return JSON.stringify(store)
-}
-
-export async function getLocalApiAuthToken(): Promise<string | null> {
-	const raw = await getPasswordFromKeyring(
-		LOCAL_API_TOKEN_SERVICE,
-		LOCAL_API_TOKEN_USER,
-	)
-	const store = decodeLocalApiAuthStore(raw)
-	return store?.token ?? null
+	return token
 }
 
 export async function ensureLocalApiAuthToken(): Promise<string> {
@@ -71,26 +35,12 @@ export async function ensureLocalApiAuthToken(): Promise<string> {
 	}
 
 	const generatedToken = generateLocalApiToken()
-	await setPasswordInKeyring(
-		LOCAL_API_TOKEN_SERVICE,
-		LOCAL_API_TOKEN_USER,
-		encodeLocalApiAuthStore({
-			version: LOCAL_API_STORE_VERSION,
-			token: generatedToken,
-		}),
-	)
+	await setAppSecret("local_api_token", generatedToken)
 	return generatedToken
 }
 
 export async function rotateLocalApiAuthToken(): Promise<string> {
 	const generatedToken = generateLocalApiToken()
-	await setPasswordInKeyring(
-		LOCAL_API_TOKEN_SERVICE,
-		LOCAL_API_TOKEN_USER,
-		encodeLocalApiAuthStore({
-			version: LOCAL_API_STORE_VERSION,
-			token: generatedToken,
-		}),
-	)
+	await setAppSecret("local_api_token", generatedToken)
 	return generatedToken
 }

--- a/packages/ai-auth/src/index.ts
+++ b/packages/ai-auth/src/index.ts
@@ -7,6 +7,8 @@ export {
 } from "./codex-oauth"
 export type {
 	ApiKeyCredential,
+	AppSecretKey,
+	AppSecrets,
 	CodexOAuthCredential,
 	CredentialStore,
 	KeyringApi,
@@ -16,11 +18,14 @@ export type {
 export {
 	AI_CREDENTIALS_SERVICE,
 	AI_CREDENTIALS_USER,
+	deleteAppSecret,
 	deleteCredential,
+	getAppSecret,
 	getCredential,
 	listCredentialProviders,
 	loadCredentialStore,
 	setApiKeyCredential,
+	setAppSecret,
 	setCodexCredential,
 } from "./credential-store"
 export type {


### PR DESCRIPTION
## Summary
- move local API token and license key storage to the shared `@mdit/ai-auth` credential store APIs
- add app-secret primitives in `packages/ai-auth` and export them from the package entry point
- migrate legacy license key reads into the unified store when missing, with a test that verifies migration behavior

## Test plan
- [ ] pnpm -C apps/desktop test -- src/store/license/license-slice.test.ts
- [ ] pnpm -C apps/desktop ts:check
- [ ] Manually verify local API auth token generation/rotation in desktop app

Made with [Cursor](https://cursor.com)