### PR TITLE
refactor: extract link exit helper

### DIFF
--- a/apps/desktop/src/components/editor/header/more-button.tsx
+++ b/apps/desktop/src/components/editor/header/more-button.tsx
@@ -1,3 +1,4 @@
+import { exitLinkForwardAtSelection } from "@mdit/editor/utils/link-exit"
 import { Button } from "@mdit/ui/components/button"
 import {
 	Popover,
@@ -9,7 +10,7 @@ import { LinkPlugin } from "@platejs/link/react"
 import { invoke } from "@tauri-apps/api/core"
 import { ArrowRight, InfoIcon, Link2 } from "lucide-react"
 import { resolve } from "pathe"
-import { KEYS, PathApi } from "platejs"
+import { KEYS } from "platejs"
 import { useEditorPlugin, useEditorRef } from "platejs/react"
 import { useEffect, useState } from "react"
 import { countGraphemes } from "unicode-segmenter/grapheme"
@@ -186,42 +187,11 @@ export function MoreButton() {
 		}
 
 		const moveSelectionOutsideInsertedLink = () => {
-			const selection = editor.selection
-			if (!selection) {
-				return
-			}
-
-			const linkType = editor.getType(KEYS.link)
-			const linkEntry = editor.api.above({
-				at: selection.anchor,
-				match: { type: linkType },
+			exitLinkForwardAtSelection(editor, {
+				allowFromInsideLink: true,
+				focusEditor: false,
+				markArrowRightExit: true,
 			})
-			if (!linkEntry) {
-				return
-			}
-
-			const [, path] = linkEntry
-			if (!editor.api.isEnd(selection.focus, path)) {
-				const end = editor.api.end(path)
-				if (end) {
-					editor.tf.select({ anchor: end, focus: end })
-				}
-			}
-
-			if (!editor.selection) {
-				return
-			}
-
-			// Same exit semantics as LinkExitPlugin arrowRight handler.
-			const nextStart = editor.api.start(path, { next: true })
-			if (nextStart) {
-				editor.tf.select({ anchor: nextStart, focus: nextStart })
-			} else {
-				const nextPath = PathApi.next(path)
-				editor.tf.insertNodes({ text: "" }, { at: nextPath })
-				editor.tf.select(nextPath)
-			}
-			editor.meta._linkExitedArrowRight = true
 		}
 
 		// Defer selection handling: other UI updates can overwrite selection immediately after insert.

--- a/packages/editor/src/plugins/link-kit.tsx
+++ b/packages/editor/src/plugins/link-kit.tsx
@@ -1,8 +1,8 @@
 import { LinkPlugin } from "@platejs/link/react"
-import { KEYS, PathApi } from "platejs"
 import { createPlatePlugin } from "platejs/react"
 import type { AnchorHTMLAttributes, ComponentType } from "react"
 import { LinkElement } from "../nodes/node-link"
+import { exitLinkForwardAtSelection } from "../utils/link-exit"
 
 type LinkLeafAttributes = Pick<
 	AnchorHTMLAttributes<HTMLAnchorElement>,
@@ -17,30 +17,11 @@ const LinkExitPlugin = createPlatePlugin({
 			handler: ({ editor, event }) => {
 				if (event.isComposing) return false
 
-				const selection = editor.selection
-				if (!selection || !editor.api.isCollapsed()) return false
-
-				const linkType = editor.getType(KEYS.link)
-				const linkEntry = editor.api.above({
-					at: selection.anchor,
-					match: { type: linkType },
+				return exitLinkForwardAtSelection(editor, {
+					allowFromInsideLink: false,
+					focusEditor: true,
+					markArrowRightExit: true,
 				})
-				if (!linkEntry) return false
-
-				const [, path] = linkEntry
-				if (!editor.api.isEnd(selection.focus, path)) return false
-
-				const nextStart = editor.api.start(path, { next: true })
-				if (nextStart) {
-					editor.tf.select({ anchor: nextStart, focus: nextStart })
-				} else {
-					const nextPath = PathApi.next(path)
-					editor.tf.insertNodes({ text: "" }, { at: nextPath })
-					editor.tf.select(nextPath)
-				}
-				editor.meta._linkExitedArrowRight = true
-				editor.tf.focus()
-				return true
 			},
 		},
 	},

--- a/packages/editor/src/utils/link-exit.ts
+++ b/packages/editor/src/utils/link-exit.ts
@@ -1,0 +1,65 @@
+import { KEYS, PathApi } from "platejs"
+import type { PlateEditor } from "platejs/react"
+
+type ExitLinkForwardOptions = {
+	allowFromInsideLink?: boolean
+	focusEditor?: boolean
+	markArrowRightExit?: boolean
+}
+
+export function exitLinkForwardAtSelection(
+	editor: PlateEditor,
+	options: ExitLinkForwardOptions = {},
+): boolean {
+	const {
+		allowFromInsideLink = false,
+		focusEditor = false,
+		markArrowRightExit = false,
+	} = options
+
+	const selection = editor.selection
+	if (!selection || !editor.api.isCollapsed()) {
+		return false
+	}
+
+	const linkType = editor.getType(KEYS.link)
+	const linkEntry = editor.api.above({
+		at: selection.anchor,
+		match: { type: linkType },
+	})
+	if (!linkEntry) {
+		return false
+	}
+
+	const [, path] = linkEntry
+	if (!editor.api.isEnd(selection.focus, path)) {
+		if (!allowFromInsideLink) {
+			return false
+		}
+
+		const end = editor.api.end(path)
+		if (!end) {
+			return false
+		}
+
+		editor.tf.select({ anchor: end, focus: end })
+	}
+
+	const nextStart = editor.api.start(path, { next: true })
+	if (nextStart) {
+		editor.tf.select({ anchor: nextStart, focus: nextStart })
+	} else {
+		const nextPath = PathApi.next(path)
+		editor.tf.insertNodes({ text: "" }, { at: nextPath })
+		editor.tf.select(nextPath)
+	}
+
+	if (markArrowRightExit) {
+		editor.meta._linkExitedArrowRight = true
+	}
+	if (focusEditor) {
+		editor.tf.focus()
+	}
+
+	return true
+}


### PR DESCRIPTION
## Summary
- extract shared link-exit behavior into `packages/editor/src/utils/link-exit.ts`
- reuse the helper in link arrow-right shortcut handling
- reuse the helper when moving selection after inserting related-note links from the more menu

## Testing
- not run (staged-only PR creation request)

## Notes
- includes only changes that were staged at commit time
- local unstaged edits were intentionally left out