### PR TITLE
feat: add customizable desktop hotkeys

### DIFF
--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -29,6 +29,7 @@ export function App() {
 		isLoading,
 		initializeWorkspace,
 		initializeAISettings,
+		initializeHotkeys,
 		checkLicense,
 		watchWorkspace,
 		unwatchWorkspace,
@@ -43,6 +44,7 @@ export function App() {
 			isLoading: s.isLoading,
 			initializeWorkspace: s.initializeWorkspace,
 			initializeAISettings: s.initializeAISettings,
+			initializeHotkeys: s.initializeHotkeys,
 			checkLicense: s.checkLicense,
 			watchWorkspace: s.watchWorkspace,
 			unwatchWorkspace: s.unwatchWorkspace,
@@ -98,6 +100,10 @@ export function App() {
 	useEffect(() => {
 		void initializeAISettings()
 	}, [initializeAISettings])
+
+	useEffect(() => {
+		void initializeHotkeys()
+	}, [initializeHotkeys])
 
 	useEffect(() => {
 		const checkAndValidateLicense = async () => {

--- a/apps/desktop/src/components/collection-view/ui/collection-resizer.tsx
+++ b/apps/desktop/src/components/collection-view/ui/collection-resizer.tsx
@@ -1,4 +1,3 @@
-import { Kbd, KbdGroup } from "@mdit/ui/components/kbd"
 import {
 	Popover,
 	PopoverAnchor,
@@ -7,7 +6,8 @@ import {
 import { tooltipContentVariants } from "@mdit/ui/components/tooltip"
 import { cn } from "@mdit/ui/lib/utils"
 import { memo, useCallback, useState } from "react"
-import { getModifierKey } from "@/utils/keyboard-shortcut"
+import { HotkeyKbd } from "@/components/hotkeys/hotkey-kbd"
+import { useStore } from "@/store"
 
 type CollectionResizerProps = {
 	isOpen: boolean
@@ -20,6 +20,9 @@ export const CollectionResizer = memo(function CollectionResizer({
 	isResizing,
 	onPointerDown,
 }: CollectionResizerProps) {
+	const toggleCollectionHotkey = useStore(
+		(s) => s.hotkeys["toggle-collection-view"],
+	)
 	const [isPopoverOpen, setIsPopoverOpen] = useState(false)
 	const [anchorPoint, setAnchorPoint] = useState<{
 		x: number
@@ -106,14 +109,10 @@ export const CollectionResizer = memo(function CollectionResizer({
 				>
 					<div className="flex items-center gap-1">
 						Close
-						<KbdGroup>
-							<Kbd className="bg-background/20 text-background dark:bg-background/10">
-								{getModifierKey()}
-							</Kbd>
-							<Kbd className="bg-background/20 text-background dark:bg-background/10">
-								D
-							</Kbd>
-						</KbdGroup>
+						<HotkeyKbd
+							binding={toggleCollectionHotkey}
+							kbdClassName="bg-background/20 text-background dark:bg-background/10"
+						/>
 					</div>
 				</PopoverContent>
 			)}

--- a/apps/desktop/src/components/collection-view/ui/new-note-button.tsx
+++ b/apps/desktop/src/components/collection-view/ui/new-note-button.tsx
@@ -1,20 +1,25 @@
 import { Button } from "@mdit/ui/components/button"
-import { Kbd, KbdGroup } from "@mdit/ui/components/kbd"
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "@mdit/ui/components/tooltip"
 import { SquarePenIcon } from "lucide-react"
+import { useShallow } from "zustand/shallow"
+import { HotkeyKbd } from "@/components/hotkeys/hotkey-kbd"
 import { useStore } from "@/store"
-import { getModifierKey } from "@/utils/keyboard-shortcut"
 
 export function NewNoteButton({
 	directoryPath,
 }: {
 	directoryPath: string | null
 }) {
-	const createNote = useStore((s) => s.createNote)
+	const { createNote, createNoteHotkey } = useStore(
+		useShallow((s) => ({
+			createNote: s.createNote,
+			createNoteHotkey: s.hotkeys["create-note"],
+		})),
+	)
 
 	return (
 		<Tooltip>
@@ -33,10 +38,7 @@ export function NewNoteButton({
 			<TooltipContent className="pr-1">
 				<div className="flex items-center gap-1">
 					New Note
-					<KbdGroup>
-						<Kbd>{getModifierKey()}</Kbd>
-						<Kbd>N</Kbd>
-					</KbdGroup>
+					<HotkeyKbd binding={createNoteHotkey} />
 				</div>
 			</TooltipContent>
 		</Tooltip>

--- a/apps/desktop/src/components/editor/header/history-navigation.tsx
+++ b/apps/desktop/src/components/editor/header/history-navigation.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@mdit/ui/components/button"
-import { Kbd, KbdGroup } from "@mdit/ui/components/kbd"
 import {
 	Tooltip,
 	TooltipContent,
@@ -8,16 +7,25 @@ import {
 import type { LucideIcon } from "lucide-react"
 import { ChevronLeft, ChevronRight } from "lucide-react"
 import { useShallow } from "zustand/shallow"
+import { HotkeyKbd } from "@/components/hotkeys/hotkey-kbd"
 import { useStore } from "@/store"
-import { getModifierKey } from "@/utils/keyboard-shortcut"
 
 export function HistoryNavigation() {
-	const { canGoBack, canGoForward, goBack, goForward } = useStore(
+	const {
+		canGoBack,
+		canGoForward,
+		goBack,
+		goForward,
+		goBackHotkey,
+		goForwardHotkey,
+	} = useStore(
 		useShallow((s) => ({
 			canGoBack: s.historyIndex > 0,
 			canGoForward: s.historyIndex < s.history.length - 1,
 			goBack: s.goBack,
 			goForward: s.goForward,
+			goBackHotkey: s.hotkeys["go-back"],
+			goForwardHotkey: s.hotkeys["go-forward"],
 		})),
 	)
 
@@ -27,7 +35,7 @@ export function HistoryNavigation() {
 				icon={ChevronLeft}
 				ariaLabel="Go back"
 				tooltipLabel="Back"
-				shortcutKeys={[getModifierKey(), "["]}
+				binding={goBackHotkey}
 				disabled={!canGoBack}
 				onClick={goBack}
 			/>
@@ -35,7 +43,7 @@ export function HistoryNavigation() {
 				icon={ChevronRight}
 				ariaLabel="Go forward"
 				tooltipLabel="Forward"
-				shortcutKeys={[getModifierKey(), "]"]}
+				binding={goForwardHotkey}
 				disabled={!canGoForward}
 				onClick={goForward}
 			/>
@@ -47,7 +55,7 @@ interface HistoryButtonProps {
 	icon: LucideIcon
 	ariaLabel: string
 	tooltipLabel: string
-	shortcutKeys: [string, string]
+	binding: string
 	disabled: boolean
 	onClick: () => void
 }
@@ -56,7 +64,7 @@ function HistoryButton({
 	icon: Icon,
 	ariaLabel,
 	tooltipLabel,
-	shortcutKeys,
+	binding,
 	disabled,
 	onClick,
 }: HistoryButtonProps) {
@@ -77,10 +85,7 @@ function HistoryButton({
 			<TooltipContent className="pr-1">
 				<div className="flex items-center gap-1">
 					{tooltipLabel}
-					<KbdGroup>
-						<Kbd>{shortcutKeys[0]}</Kbd>
-						<Kbd>{shortcutKeys[1]}</Kbd>
-					</KbdGroup>
+					<HotkeyKbd binding={binding} />
 				</div>
 			</TooltipContent>
 		</Tooltip>

--- a/apps/desktop/src/components/file-explorer/ui/graph-view-open-button.tsx
+++ b/apps/desktop/src/components/file-explorer/ui/graph-view-open-button.tsx
@@ -1,10 +1,16 @@
 import { Button } from "@mdit/ui/components/button"
 import { GitBranchIcon } from "lucide-react"
+import { useShallow } from "zustand/shallow"
+import { HotkeyKbd } from "@/components/hotkeys/hotkey-kbd"
 import { useStore } from "@/store"
-import { getModifierKey } from "@/utils/keyboard-shortcut"
 
 export function GraphViewOpenButton({ disabled }: { disabled: boolean }) {
-	const openGraphViewDialog = useStore((s) => s.openGraphViewDialog)
+	const { openGraphViewDialog, graphViewHotkey } = useStore(
+		useShallow((s) => ({
+			openGraphViewDialog: s.openGraphViewDialog,
+			graphViewHotkey: s.hotkeys["toggle-graph-view"],
+		})),
+	)
 
 	return (
 		<Button
@@ -16,10 +22,10 @@ export function GraphViewOpenButton({ disabled }: { disabled: boolean }) {
 			disabled={disabled}
 		>
 			<GitBranchIcon className="size-4" /> Graph View
-			<span className="ml-auto text-sm text-muted-foreground transition-opacity group-hover:opacity-100 opacity-0">
-				{getModifierKey()}
-				<span className="ml-1">G</span>
-			</span>
+			<HotkeyKbd
+				binding={graphViewHotkey}
+				className="ml-auto text-sm text-muted-foreground transition-opacity group-hover:opacity-100 opacity-0"
+			/>
 		</Button>
 	)
 }

--- a/apps/desktop/src/components/file-explorer/ui/search-button.tsx
+++ b/apps/desktop/src/components/file-explorer/ui/search-button.tsx
@@ -1,16 +1,17 @@
 import { Button } from "@mdit/ui/components/button"
-import { Kbd, KbdGroup } from "@mdit/ui/components/kbd"
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "@mdit/ui/components/tooltip"
 import { SearchIcon } from "lucide-react"
+import { HotkeyKbd } from "@/components/hotkeys/hotkey-kbd"
 import { useStore } from "@/store"
-import { getModifierKey } from "@/utils/keyboard-shortcut"
 
 export function SearchButton() {
 	const openCommandMenu = useStore((s) => s.openCommandMenu)
+	const commandMenuHotkey = useStore((s) => s.hotkeys["open-command-menu"])
+
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
@@ -26,10 +27,7 @@ export function SearchButton() {
 			<TooltipContent className="pr-1">
 				<div className="flex items-center gap-1">
 					Search
-					<KbdGroup>
-						<Kbd>{getModifierKey()}</Kbd>
-						<Kbd>K</Kbd>
-					</KbdGroup>
+					<HotkeyKbd binding={commandMenuHotkey} />
 				</div>
 			</TooltipContent>
 		</Tooltip>

--- a/apps/desktop/src/components/file-explorer/ui/settings-menu.tsx
+++ b/apps/desktop/src/components/file-explorer/ui/settings-menu.tsx
@@ -1,10 +1,16 @@
 import { Button } from "@mdit/ui/components/button"
 import { SettingsIcon } from "lucide-react"
+import { useShallow } from "zustand/shallow"
+import { HotkeyKbd } from "@/components/hotkeys/hotkey-kbd"
 import { useStore } from "@/store"
-import { getModifierKey } from "@/utils/keyboard-shortcut"
 
 export function SettingsMenu() {
-	const setSettingsDialogOpen = useStore((s) => s.setSettingsDialogOpen)
+	const { setSettingsDialogOpen, settingsHotkey } = useStore(
+		useShallow((s) => ({
+			setSettingsDialogOpen: s.setSettingsDialogOpen,
+			settingsHotkey: s.hotkeys["toggle-settings"],
+		})),
+	)
 
 	return (
 		<Button
@@ -15,10 +21,10 @@ export function SettingsMenu() {
 			onClick={() => setSettingsDialogOpen(true)}
 		>
 			<SettingsIcon className="size-4" /> Settings
-			<span className="ml-auto text-sm text-muted-foreground transition-opacity group-hover:opacity-100 opacity-0">
-				{getModifierKey()}
-				<span className="ml-1">{"/"}</span>
-			</span>
+			<HotkeyKbd
+				binding={settingsHotkey}
+				className="ml-auto text-sm text-muted-foreground transition-opacity group-hover:opacity-100 opacity-0"
+			/>
 		</Button>
 	)
 }

--- a/apps/desktop/src/components/file-explorer/ui/toggle-button.tsx
+++ b/apps/desktop/src/components/file-explorer/ui/toggle-button.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@mdit/ui/components/button"
-import { Kbd, KbdGroup } from "@mdit/ui/components/kbd"
 import {
 	Tooltip,
 	TooltipContent,
@@ -8,8 +7,8 @@ import {
 import { cn } from "@mdit/ui/lib/utils"
 import { ArrowLeftToLineIcon, ArrowRightToLineIcon } from "lucide-react"
 import { useShallow } from "zustand/shallow"
+import { HotkeyKbd } from "@/components/hotkeys/hotkey-kbd"
 import { useStore } from "@/store"
-import { getModifierKey } from "@/utils/keyboard-shortcut"
 
 type Props = {
 	isOpen: boolean
@@ -17,10 +16,11 @@ type Props = {
 }
 
 export function ToggleButton({ isOpen, onToggle }: Props) {
-	const { isFocusMode, currentCollectionPath } = useStore(
+	const { isFocusMode, currentCollectionPath, toggleExplorerHotkey } = useStore(
 		useShallow((s) => ({
 			isFocusMode: s.isFocusMode,
 			currentCollectionPath: s.currentCollectionPath,
+			toggleExplorerHotkey: s.hotkeys["toggle-file-explorer"],
 		})),
 	)
 	const isCollectionViewOpen = currentCollectionPath !== null
@@ -44,10 +44,7 @@ export function ToggleButton({ isOpen, onToggle }: Props) {
 			<TooltipContent className="pr-1">
 				<div className="flex items-center gap-1">
 					Toggle
-					<KbdGroup>
-						<Kbd>{getModifierKey()}</Kbd>
-						<Kbd>S</Kbd>
-					</KbdGroup>
+					<HotkeyKbd binding={toggleExplorerHotkey} />
 				</div>
 			</TooltipContent>
 		</Tooltip>

--- a/apps/desktop/src/components/file-explorer/ui/workspace-dropdown.tsx
+++ b/apps/desktop/src/components/file-explorer/ui/workspace-dropdown.tsx
@@ -6,14 +6,14 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@mdit/ui/components/dropdown-menu"
-import { Kbd, KbdGroup } from "@mdit/ui/components/kbd"
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "@mdit/ui/components/tooltip"
 import { ChevronDown, InboxIcon, MinusIcon } from "lucide-react"
-import { getModifierKey } from "@/utils/keyboard-shortcut"
+import { HotkeyKbd } from "@/components/hotkeys/hotkey-kbd"
+import { useStore } from "@/store"
 import { getFolderNameFromPath } from "@/utils/path-utils"
 
 const REMOVE_WORKSPACE_SELECTOR = '[data-remove-workspace="true"]'
@@ -44,6 +44,7 @@ export function WorkspaceDropdown({
 	onWorkspaceRemove,
 	onOpenFolderPicker,
 }: WorkspaceDropdownProps) {
+	const openFolderHotkey = useStore((s) => s.hotkeys["open-folder"])
 	const currentWorkspaceName = workspacePath
 		? getFolderNameFromPath(workspacePath)
 		: "No folder"
@@ -134,10 +135,7 @@ export function WorkspaceDropdown({
 					<span className="text-sm text-accent-foreground/90 mr-auto">
 						Open Folder...
 					</span>
-					<KbdGroup>
-						<Kbd>{getModifierKey()}</Kbd>
-						<Kbd>O</Kbd>
-					</KbdGroup>
+					<HotkeyKbd binding={openFolderHotkey} />
 				</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>

--- a/apps/desktop/src/components/hotkeys/hotkey-kbd.tsx
+++ b/apps/desktop/src/components/hotkeys/hotkey-kbd.tsx
@@ -1,0 +1,29 @@
+import { Kbd, KbdGroup } from "@mdit/ui/components/kbd"
+import { hotkeyToDisplayTokens } from "@/lib/hotkeys"
+
+type HotkeyKbdProps = {
+	binding: string
+	className?: string
+	kbdClassName?: string
+}
+
+export function HotkeyKbd({
+	binding,
+	className,
+	kbdClassName,
+}: HotkeyKbdProps) {
+	const tokens = hotkeyToDisplayTokens(binding)
+	if (tokens.length === 0) {
+		return null
+	}
+
+	return (
+		<KbdGroup className={className}>
+			{tokens.map((token) => (
+				<Kbd key={`${binding}-${token}`} className={kbdClassName}>
+					{token}
+				</Kbd>
+			))}
+		</KbdGroup>
+	)
+}

--- a/apps/desktop/src/components/settings/settings.tsx
+++ b/apps/desktop/src/components/settings/settings.tsx
@@ -4,6 +4,7 @@ import { useShallow } from "zustand/shallow"
 import { useStore } from "@/store"
 import { AITab } from "./ui/ai-tab"
 import { ApiMcpTab } from "./ui/api-mcp-tab"
+import { HotkeysTab } from "./ui/hotkeys-tab"
 import { IndexingTab } from "./ui/indexing-tab"
 import { LicenseTab } from "./ui/license-tab"
 import { SettingsNavigation, type SettingsTab } from "./ui/navigation"
@@ -59,6 +60,7 @@ export function SettingsDialog() {
 
 				<div className="flex-1 flex flex-col">
 					{activeTab === "preferences" && <PreferencesTab />}
+					{activeTab === "hotkeys" && <HotkeysTab />}
 					{activeTab === "ai" && <AITab />}
 					{activeTab === "api-mcp" && <ApiMcpTab />}
 					{activeTab === "sync" && <SyncTab />}

--- a/apps/desktop/src/components/settings/ui/hotkeys-tab.tsx
+++ b/apps/desktop/src/components/settings/ui/hotkeys-tab.tsx
@@ -1,0 +1,232 @@
+import { Button } from "@mdit/ui/components/button"
+import {
+	Field,
+	FieldContent,
+	FieldDescription,
+	FieldGroup,
+	FieldLabel,
+	FieldLegend,
+	FieldSet,
+} from "@mdit/ui/components/field"
+import {
+	IconCircleFilled,
+	IconRefresh,
+	IconSquareFilled,
+} from "@tabler/icons-react"
+import { useHotkeyRecorder } from "@tanstack/react-hotkeys"
+import { useCallback, useMemo, useState } from "react"
+import { useShallow } from "zustand/shallow"
+import { HotkeyKbd } from "@/components/hotkeys/hotkey-kbd"
+import {
+	APP_HOTKEY_CATEGORY_LABELS,
+	APP_HOTKEY_DEFINITIONS,
+	type AppHotkeyActionId,
+	type AppHotkeyCategory,
+} from "@/lib/hotkeys"
+import { useStore } from "@/store"
+
+const HOTKEY_LABEL_BY_ID: Record<AppHotkeyActionId, string> =
+	APP_HOTKEY_DEFINITIONS.reduce(
+		(acc, definition) => {
+			acc[definition.id] = definition.label
+			return acc
+		},
+		{} as Record<AppHotkeyActionId, string>,
+	)
+
+const CATEGORY_ORDER: AppHotkeyCategory[] = ["file", "view", "history", "app"]
+
+export function HotkeysTab() {
+	const { hotkeys, setHotkeyBinding, resetHotkeyBindings } = useStore(
+		useShallow((state) => ({
+			hotkeys: state.hotkeys,
+			setHotkeyBinding: state.setHotkeyBinding,
+			resetHotkeyBindings: state.resetHotkeyBindings,
+		})),
+	)
+
+	const [recordingActionId, setRecordingActionId] =
+		useState<AppHotkeyActionId | null>(null)
+	const [errors, setErrors] = useState<
+		Partial<Record<AppHotkeyActionId, string>>
+	>({})
+
+	const groupedDefinitions = useMemo(
+		() =>
+			CATEGORY_ORDER.map((category) => ({
+				category,
+				definitions: APP_HOTKEY_DEFINITIONS.filter(
+					(definition) => definition.category === category,
+				),
+			})).filter((group) => group.definitions.length > 0),
+		[],
+	)
+
+	const saveBinding = useCallback(
+		async (actionId: AppHotkeyActionId, binding: string) => {
+			const result = await setHotkeyBinding(actionId, binding)
+			if (result.success) {
+				setErrors((prev) => {
+					const next = { ...prev }
+					delete next[actionId]
+					return next
+				})
+				return
+			}
+
+			const conflictLabel = result.conflictWith
+				? HOTKEY_LABEL_BY_ID[result.conflictWith]
+				: null
+			setErrors((prev) => ({
+				...prev,
+				[actionId]: conflictLabel
+					? `Already assigned to ${conflictLabel}`
+					: (result.error ?? "Failed to update shortcut"),
+			}))
+		},
+		[setHotkeyBinding],
+	)
+
+	const recorder = useHotkeyRecorder({
+		onRecord: (binding) => {
+			if (!recordingActionId) {
+				return
+			}
+			const targetActionId = recordingActionId
+			setRecordingActionId(null)
+			void saveBinding(targetActionId, binding)
+		},
+		onCancel: () => {
+			setRecordingActionId(null)
+		},
+	})
+
+	const startRecording = (actionId: AppHotkeyActionId) => {
+		if (recorder.isRecording) {
+			recorder.cancelRecording()
+		}
+		setRecordingActionId(actionId)
+		recorder.startRecording()
+	}
+
+	const cancelRecording = () => {
+		recorder.cancelRecording()
+		setRecordingActionId(null)
+	}
+
+	const restoreDefaultBinding = async (
+		actionId: AppHotkeyActionId,
+		defaultBinding: string,
+	) => {
+		if (recordingActionId === actionId) {
+			cancelRecording()
+		}
+		await saveBinding(actionId, defaultBinding)
+	}
+
+	const resetAllBindings = async () => {
+		cancelRecording()
+		setErrors({})
+		await resetHotkeyBindings()
+	}
+
+	return (
+		<div className="flex-1 overflow-y-auto p-12">
+			<FieldSet>
+				<div className="flex items-start justify-between gap-3">
+					<div>
+						<FieldLegend>Hotkeys</FieldLegend>
+						<FieldDescription>
+							Customize keyboard shortcuts used throughout the app
+						</FieldDescription>
+					</div>
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => void resetAllBindings()}
+					>
+						Reset to defaults
+					</Button>
+				</div>
+
+				{groupedDefinitions.map((group) => (
+					<div key={group.category} className="mt-8 first:mt-0">
+						<h3 className="text-sm font-medium text-muted-foreground">
+							{APP_HOTKEY_CATEGORY_LABELS[group.category]}
+						</h3>
+						<FieldGroup className="mt-3">
+							{group.definitions.map((definition) => {
+								const isRecording =
+									recorder.isRecording && recordingActionId === definition.id
+								const binding = hotkeys[definition.id]
+								const hasBinding = binding.length > 0
+								const isDefaultBinding = binding === definition.defaultBinding
+
+								return (
+									<Field
+										key={definition.id}
+										orientation="horizontal"
+										className="items-start"
+									>
+										<FieldContent>
+											<FieldLabel>{definition.label}</FieldLabel>
+											{errors[definition.id] && (
+												<FieldDescription className="text-destructive">
+													{errors[definition.id]}
+												</FieldDescription>
+											)}
+										</FieldContent>
+										<div className="flex flex-wrap items-center justify-end gap-2">
+											{!isDefaultBinding && (
+												<Button
+													variant="ghost"
+													size="icon"
+													onClick={() =>
+														void restoreDefaultBinding(
+															definition.id,
+															definition.defaultBinding,
+														)
+													}
+													title="Restore default shortcut"
+												>
+													<IconRefresh className="size-4" />
+												</Button>
+											)}
+											{hasBinding ? (
+												<HotkeyKbd binding={binding} />
+											) : (
+												<span className="text-sm text-muted-foreground">
+													Unassigned
+												</span>
+											)}
+											<Button
+												variant="secondary"
+												size="icon"
+												onClick={() => {
+													if (isRecording) {
+														cancelRecording()
+														return
+													}
+													startRecording(definition.id)
+												}}
+												title={
+													isRecording ? "Cancel recording" : "Record shortcut"
+												}
+											>
+												{isRecording ? (
+													<IconSquareFilled className="size-3 text-red-500/90" />
+												) : (
+													<IconCircleFilled className="size-3 text-red-500/90" />
+												)}
+											</Button>
+										</div>
+									</Field>
+								)
+							})}
+						</FieldGroup>
+					</div>
+				))}
+			</FieldSet>
+		</div>
+	)
+}

--- a/apps/desktop/src/components/settings/ui/navigation.tsx
+++ b/apps/desktop/src/components/settings/ui/navigation.tsx
@@ -8,6 +8,7 @@ export type SettingsTab =
 	| "api-mcp"
 	| "sync"
 	| "indexing"
+	| "hotkeys"
 	| "license"
 
 interface SettingsNavigationProps {
@@ -31,6 +32,7 @@ export function SettingsNavigation({
 					{ id: "indexing", label: "Indexing" } as const,
 				]
 			: []),
+		{ id: "hotkeys", label: "Hotkeys" },
 		{ id: "license", label: "License" },
 	]
 

--- a/apps/desktop/src/components/window-menu/menu/file-menu.ts
+++ b/apps/desktop/src/components/window-menu/menu/file-menu.ts
@@ -1,11 +1,14 @@
 import { MenuItem, PredefinedMenuItem, Submenu } from "@tauri-apps/api/menu"
+import { type AppHotkeyMap, hotkeyToMenuAccelerator } from "@/lib/hotkeys"
 
 export async function createFileMenu({
 	createNote,
 	openWorkspace,
+	hotkeys,
 }: {
 	createNote: () => void | Promise<void>
 	openWorkspace: () => void | Promise<void>
+	hotkeys: AppHotkeyMap
 }) {
 	return await Submenu.new({
 		text: "File",
@@ -13,13 +16,13 @@ export async function createFileMenu({
 			await MenuItem.new({
 				id: "new-note",
 				text: "New Note",
-				accelerator: "CmdOrCtrl+N",
+				accelerator: hotkeyToMenuAccelerator(hotkeys["create-note"]),
 				action: () => createNote(),
 			}),
 			await MenuItem.new({
 				id: "open-folder",
 				text: "Open Folder...",
-				accelerator: "CmdOrCtrl+O",
+				accelerator: hotkeyToMenuAccelerator(hotkeys["open-folder"]),
 				action: () => openWorkspace(),
 			}),
 			await PredefinedMenuItem.new({

--- a/apps/desktop/src/components/window-menu/menu/history-menu.ts
+++ b/apps/desktop/src/components/window-menu/menu/history-menu.ts
@@ -1,11 +1,14 @@
 import { MenuItem, Submenu } from "@tauri-apps/api/menu"
+import { type AppHotkeyMap, hotkeyToMenuAccelerator } from "@/lib/hotkeys"
 
 export async function createHistoryMenu({
 	goBack,
 	goForward,
+	hotkeys,
 }: {
 	goBack: () => Promise<boolean>
 	goForward: () => Promise<boolean>
+	hotkeys: AppHotkeyMap
 }) {
 	return await Submenu.new({
 		text: "History",
@@ -13,13 +16,13 @@ export async function createHistoryMenu({
 			await MenuItem.new({
 				id: "go-back",
 				text: "Back",
-				accelerator: "CmdOrCtrl+[",
+				accelerator: hotkeyToMenuAccelerator(hotkeys["go-back"]),
 				action: () => goBack(),
 			}),
 			await MenuItem.new({
 				id: "go-forward",
 				text: "Forward",
-				accelerator: "CmdOrCtrl+]",
+				accelerator: hotkeyToMenuAccelerator(hotkeys["go-forward"]),
 				action: () => goForward(),
 			}),
 		],

--- a/apps/desktop/src/components/window-menu/menu/index.ts
+++ b/apps/desktop/src/components/window-menu/menu/index.ts
@@ -1,4 +1,5 @@
 import { Menu } from "@tauri-apps/api/menu"
+import type { AppHotkeyMap } from "@/lib/hotkeys"
 import { createEditMenu } from "./edit-menu"
 import { createFileMenu } from "./file-menu"
 import { createHelpMenu } from "./help-menu"
@@ -20,6 +21,7 @@ export async function installWindowMenu({
 	goBack,
 	goForward,
 	toggleSettings,
+	hotkeys,
 }: {
 	createNote: () => void | Promise<void>
 	openWorkspace: () => void | Promise<void>
@@ -33,13 +35,15 @@ export async function installWindowMenu({
 	goBack: () => Promise<boolean>
 	goForward: () => Promise<boolean>
 	toggleSettings: () => void
+	hotkeys: AppHotkeyMap
 }) {
 	const menu = await Menu.new({
 		items: [
-			await createMditMenu({ toggleSettings }),
+			await createMditMenu({ toggleSettings, hotkeys }),
 			await createFileMenu({
 				createNote,
 				openWorkspace,
+				hotkeys,
 			}),
 			await createEditMenu(),
 			await createViewMenu({
@@ -50,10 +54,12 @@ export async function installWindowMenu({
 				resetZoom,
 				openCommandMenu,
 				openGraphView,
+				hotkeys,
 			}),
 			await createHistoryMenu({
 				goBack,
 				goForward,
+				hotkeys,
 			}),
 			await createWindowMenu(),
 			await createHelpMenu(),

--- a/apps/desktop/src/components/window-menu/menu/mdit-menu.ts
+++ b/apps/desktop/src/components/window-menu/menu/mdit-menu.ts
@@ -1,9 +1,12 @@
 import { MenuItem, PredefinedMenuItem, Submenu } from "@tauri-apps/api/menu"
+import { type AppHotkeyMap, hotkeyToMenuAccelerator } from "@/lib/hotkeys"
 
 export async function createMditMenu({
 	toggleSettings,
+	hotkeys,
 }: {
 	toggleSettings: () => void
+	hotkeys: AppHotkeyMap
 }) {
 	return await Submenu.new({
 		text: "Mdit",
@@ -19,7 +22,7 @@ export async function createMditMenu({
 			await MenuItem.new({
 				id: "settings",
 				text: "Settings…",
-				accelerator: "CmdOrCtrl+/",
+				accelerator: hotkeyToMenuAccelerator(hotkeys["toggle-settings"]),
 				action: () => toggleSettings(),
 			}),
 			await PredefinedMenuItem.new({

--- a/apps/desktop/src/components/window-menu/menu/view-menu.ts
+++ b/apps/desktop/src/components/window-menu/menu/view-menu.ts
@@ -1,4 +1,5 @@
 import { MenuItem, PredefinedMenuItem, Submenu } from "@tauri-apps/api/menu"
+import { type AppHotkeyMap, hotkeyToMenuAccelerator } from "@/lib/hotkeys"
 
 export async function createViewMenu({
 	toggleFileExplorer,
@@ -8,6 +9,7 @@ export async function createViewMenu({
 	resetZoom,
 	openCommandMenu,
 	openGraphView,
+	hotkeys,
 }: {
 	toggleFileExplorer: () => void
 	toggleCollectionView: () => void
@@ -16,6 +18,7 @@ export async function createViewMenu({
 	resetZoom: () => void
 	openCommandMenu: () => void
 	openGraphView: () => void
+	hotkeys: AppHotkeyMap
 }) {
 	return await Submenu.new({
 		text: "View",
@@ -23,13 +26,13 @@ export async function createViewMenu({
 			await MenuItem.new({
 				id: "command-menu",
 				text: "Command Menu…",
-				accelerator: "CmdOrCtrl+K",
+				accelerator: hotkeyToMenuAccelerator(hotkeys["open-command-menu"]),
 				action: () => openCommandMenu(),
 			}),
 			await MenuItem.new({
 				id: "graph-view",
 				text: "Graph View…",
-				accelerator: "CmdOrCtrl+G",
+				accelerator: hotkeyToMenuAccelerator(hotkeys["toggle-graph-view"]),
 				action: () => openGraphView(),
 			}),
 			await PredefinedMenuItem.new({
@@ -39,13 +42,13 @@ export async function createViewMenu({
 			await MenuItem.new({
 				id: "toggle-explorer",
 				text: "Toggle File Explorer",
-				accelerator: "CmdOrCtrl+S",
+				accelerator: hotkeyToMenuAccelerator(hotkeys["toggle-file-explorer"]),
 				action: () => toggleFileExplorer(),
 			}),
 			await MenuItem.new({
 				id: "toggle-collection-view",
 				text: "Toggle Collection View",
-				accelerator: "CmdOrCtrl+D",
+				accelerator: hotkeyToMenuAccelerator(hotkeys["toggle-collection-view"]),
 				action: () => toggleCollectionView(),
 			}),
 			await PredefinedMenuItem.new({
@@ -55,19 +58,19 @@ export async function createViewMenu({
 			await MenuItem.new({
 				id: "zoom-in",
 				text: "Zoom In",
-				accelerator: "CmdOrCtrl+=",
+				accelerator: hotkeyToMenuAccelerator(hotkeys["zoom-in"]),
 				action: () => zoomIn(),
 			}),
 			await MenuItem.new({
 				id: "zoom-out",
 				text: "Zoom Out",
-				accelerator: "CmdOrCtrl+-",
+				accelerator: hotkeyToMenuAccelerator(hotkeys["zoom-out"]),
 				action: () => zoomOut(),
 			}),
 			await MenuItem.new({
 				id: "reset-zoom",
 				text: "Reset Zoom",
-				accelerator: "CmdOrCtrl+0",
+				accelerator: hotkeyToMenuAccelerator(hotkeys["reset-zoom"]),
 				action: () => resetZoom(),
 			}),
 		],

--- a/apps/desktop/src/components/window-menu/window-menu.tsx
+++ b/apps/desktop/src/components/window-menu/window-menu.tsx
@@ -31,6 +31,7 @@ export function WindowMenu() {
 		zoomIn,
 		zoomOut,
 		resetZoom,
+		hotkeys,
 	} = useStore(
 		useShallow((s) => ({
 			toggleFileExplorer: s.toggleFileExplorerOpen,
@@ -41,6 +42,7 @@ export function WindowMenu() {
 			zoomIn: s.increaseFontScale,
 			zoomOut: s.decreaseFontScale,
 			resetZoom: s.resetFontScale,
+			hotkeys: s.hotkeys,
 		})),
 	)
 
@@ -63,6 +65,7 @@ export function WindowMenu() {
 			goBack,
 			goForward,
 			toggleSettings: toggleSettingsDialogOpen,
+			hotkeys,
 		})
 	}, [
 		createAndOpenNote,
@@ -79,6 +82,7 @@ export function WindowMenu() {
 		goBack,
 		goForward,
 		toggleSettingsDialogOpen,
+		hotkeys,
 	])
 
 	return null

--- a/apps/desktop/src/lib/hotkeys.ts
+++ b/apps/desktop/src/lib/hotkeys.ts
@@ -1,0 +1,261 @@
+import { getModifierKey } from "@/utils/keyboard-shortcut"
+
+export type AppHotkeyActionId =
+	| "create-note"
+	| "open-folder"
+	| "open-command-menu"
+	| "toggle-graph-view"
+	| "toggle-file-explorer"
+	| "toggle-collection-view"
+	| "zoom-in"
+	| "zoom-out"
+	| "reset-zoom"
+	| "go-back"
+	| "go-forward"
+	| "toggle-settings"
+
+export type AppHotkeyCategory = "file" | "view" | "history" | "app"
+
+export type AppHotkeyDefinition = {
+	id: AppHotkeyActionId
+	label: string
+	category: AppHotkeyCategory
+	defaultBinding: string
+}
+
+export type AppHotkeyMap = Record<AppHotkeyActionId, string>
+
+export const APP_HOTKEY_DEFINITIONS: readonly AppHotkeyDefinition[] = [
+	{
+		id: "create-note",
+		label: "New Note",
+		category: "file",
+		defaultBinding: "Mod+N",
+	},
+	{
+		id: "open-folder",
+		label: "Open Folder",
+		category: "file",
+		defaultBinding: "Mod+O",
+	},
+	{
+		id: "open-command-menu",
+		label: "Command Menu",
+		category: "view",
+		defaultBinding: "Mod+K",
+	},
+	{
+		id: "toggle-graph-view",
+		label: "Graph View",
+		category: "view",
+		defaultBinding: "Mod+G",
+	},
+	{
+		id: "toggle-file-explorer",
+		label: "Toggle File Explorer",
+		category: "view",
+		defaultBinding: "Mod+S",
+	},
+	{
+		id: "toggle-collection-view",
+		label: "Toggle Collection View",
+		category: "view",
+		defaultBinding: "Mod+D",
+	},
+	{
+		id: "zoom-in",
+		label: "Zoom In",
+		category: "view",
+		defaultBinding: "Mod+=",
+	},
+	{
+		id: "zoom-out",
+		label: "Zoom Out",
+		category: "view",
+		defaultBinding: "Mod+-",
+	},
+	{
+		id: "reset-zoom",
+		label: "Reset Zoom",
+		category: "view",
+		defaultBinding: "Mod+0",
+	},
+	{
+		id: "go-back",
+		label: "Go Back",
+		category: "history",
+		defaultBinding: "Mod+[",
+	},
+	{
+		id: "go-forward",
+		label: "Go Forward",
+		category: "history",
+		defaultBinding: "Mod+]",
+	},
+	{
+		id: "toggle-settings",
+		label: "Toggle Settings",
+		category: "app",
+		defaultBinding: "Mod+,",
+	},
+] as const
+
+const APP_HOTKEY_ACTION_ID_SET = new Set<AppHotkeyActionId>(
+	APP_HOTKEY_DEFINITIONS.map((definition) => definition.id),
+)
+
+const MODIFIER_ALIASES: Record<string, "Mod" | "Ctrl" | "Alt" | "Shift"> = {
+	mod: "Mod",
+	cmd: "Mod",
+	command: "Mod",
+	meta: "Mod",
+	cmdorctrl: "Mod",
+	control: "Ctrl",
+	ctrl: "Ctrl",
+	alt: "Alt",
+	option: "Alt",
+	shift: "Shift",
+}
+
+const MODIFIER_ORDER = ["Mod", "Ctrl", "Alt", "Shift"] as const
+
+export const DEFAULT_APP_HOTKEYS: AppHotkeyMap =
+	APP_HOTKEY_DEFINITIONS.reduce<AppHotkeyMap>((acc, definition) => {
+		acc[definition.id] = definition.defaultBinding
+		return acc
+	}, {} as AppHotkeyMap)
+
+export const APP_HOTKEY_CATEGORY_LABELS: Record<AppHotkeyCategory, string> = {
+	file: "File",
+	view: "View",
+	history: "History",
+	app: "App",
+}
+
+export function createDefaultAppHotkeys(): AppHotkeyMap {
+	return { ...DEFAULT_APP_HOTKEYS }
+}
+
+export function isAppHotkeyActionId(
+	value: unknown,
+): value is AppHotkeyActionId {
+	return (
+		typeof value === "string" &&
+		APP_HOTKEY_ACTION_ID_SET.has(value as AppHotkeyActionId)
+	)
+}
+
+export function normalizeHotkeyBinding(binding: string): string {
+	const trimmed = binding.trim()
+	if (!trimmed) {
+		return ""
+	}
+
+	const parts = trimmed
+		.split("+")
+		.map((part) => part.trim())
+		.filter((part) => part.length > 0)
+
+	if (parts.length === 0) {
+		return ""
+	}
+
+	const normalizedParts = parts.map((part) => normalizeHotkeyPart(part))
+	const key = normalizedParts[normalizedParts.length - 1]
+	const modifierSet = new Set<string>()
+
+	for (const part of normalizedParts.slice(0, -1)) {
+		if (isModifier(part)) {
+			modifierSet.add(part)
+		}
+	}
+
+	const orderedModifiers = MODIFIER_ORDER.filter((modifier) =>
+		modifierSet.has(modifier),
+	)
+
+	return [...orderedModifiers, key].join("+")
+}
+
+export function mergeWithDefaultHotkeys(
+	bindings: Partial<Record<AppHotkeyActionId, unknown>> | null | undefined,
+): AppHotkeyMap {
+	const merged = createDefaultAppHotkeys()
+	if (!bindings) {
+		return merged
+	}
+
+	for (const definition of APP_HOTKEY_DEFINITIONS) {
+		const value = bindings[definition.id]
+		if (typeof value !== "string") {
+			continue
+		}
+		merged[definition.id] = normalizeHotkeyBinding(value)
+	}
+
+	return merged
+}
+
+export function findHotkeyConflict(
+	bindings: AppHotkeyMap,
+	actionId: AppHotkeyActionId,
+	candidateBinding: string,
+): AppHotkeyActionId | null {
+	if (!candidateBinding) {
+		return null
+	}
+
+	for (const definition of APP_HOTKEY_DEFINITIONS) {
+		if (definition.id === actionId) {
+			continue
+		}
+		if (bindings[definition.id] === candidateBinding) {
+			return definition.id
+		}
+	}
+
+	return null
+}
+
+export function hotkeyToDisplayTokens(binding: string): string[] {
+	const normalizedBinding = normalizeHotkeyBinding(binding)
+	if (!normalizedBinding) {
+		return []
+	}
+
+	return normalizedBinding.split("+").map((token) => {
+		if (token === "Mod") {
+			return getModifierKey()
+		}
+		return token
+	})
+}
+
+export function hotkeyToMenuAccelerator(binding: string): string | undefined {
+	const normalizedBinding = normalizeHotkeyBinding(binding)
+	if (!normalizedBinding) {
+		return undefined
+	}
+
+	return normalizedBinding
+		.split("+")
+		.map((token) => (token === "Mod" ? "CmdOrCtrl" : token))
+		.join("+")
+}
+
+function normalizeHotkeyPart(part: string): string {
+	const alias = MODIFIER_ALIASES[part.toLowerCase()]
+	if (alias) {
+		return alias
+	}
+
+	if (part.length === 1 && /[a-z]/i.test(part)) {
+		return part.toUpperCase()
+	}
+
+	return part
+}
+
+function isModifier(part: string): part is (typeof MODIFIER_ORDER)[number] {
+	return MODIFIER_ORDER.includes(part as (typeof MODIFIER_ORDER)[number])
+}

--- a/apps/desktop/src/store/hotkeys/hotkeys-slice.test.ts
+++ b/apps/desktop/src/store/hotkeys/hotkeys-slice.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { createStore } from "zustand/vanilla"
+import { createDefaultAppHotkeys } from "@/lib/hotkeys"
+import {
+	type HotkeyStorage,
+	type HotkeysSlice,
+	prepareHotkeysSlice,
+} from "./hotkeys-slice"
+
+const createHotkeysStore = (storage: HotkeyStorage) => {
+	const createSlice = prepareHotkeysSlice({ storage })
+	return createStore<HotkeysSlice>()((set, get, api) =>
+		createSlice(set, get, api),
+	)
+}
+
+describe("hotkeys-slice", () => {
+	let persistedBindings = createDefaultAppHotkeys()
+	let storage: HotkeyStorage
+
+	beforeEach(() => {
+		persistedBindings = createDefaultAppHotkeys()
+		storage = {
+			load: vi.fn(async () => persistedBindings),
+			save: vi.fn(async (bindings) => {
+				persistedBindings = { ...bindings }
+			}),
+			reset: vi.fn(async () => {
+				persistedBindings = createDefaultAppHotkeys()
+			}),
+		}
+	})
+
+	it("loads hotkeys from injected storage", async () => {
+		persistedBindings = {
+			...persistedBindings,
+			"open-command-menu": "Mod+P",
+		}
+		const store = createHotkeysStore(storage)
+
+		await store.getState().initializeHotkeys()
+
+		expect(store.getState().isHotkeysLoaded).toBe(true)
+		expect(store.getState().hotkeys["open-command-menu"]).toBe("Mod+P")
+		expect(storage.load).toHaveBeenCalledTimes(1)
+	})
+
+	it("falls back to default hotkeys when storage returns null", async () => {
+		storage.load = vi.fn(async () => null)
+		const store = createHotkeysStore(storage)
+
+		await store.getState().initializeHotkeys()
+
+		expect(store.getState().isHotkeysLoaded).toBe(true)
+		expect(store.getState().hotkeys).toEqual(createDefaultAppHotkeys())
+	})
+
+	it("updates hotkey binding and persists it", async () => {
+		const store = createHotkeysStore(storage)
+
+		const result = await store
+			.getState()
+			.setHotkeyBinding("open-command-menu", "mod+p")
+
+		expect(result).toEqual({ success: true })
+		expect(store.getState().hotkeys["open-command-menu"]).toBe("Mod+P")
+		expect(storage.save).toHaveBeenCalledTimes(1)
+	})
+
+	it("rejects conflicting hotkeys", async () => {
+		const store = createHotkeysStore(storage)
+
+		const result = await store
+			.getState()
+			.setHotkeyBinding("create-note", "Mod+O")
+
+		expect(result.success).toBe(false)
+		expect(result.conflictWith).toBe("open-folder")
+		expect(storage.save).not.toHaveBeenCalled()
+	})
+
+	it("allows unassigned hotkeys", async () => {
+		const store = createHotkeysStore(storage)
+
+		const result = await store.getState().setHotkeyBinding("open-folder", "")
+
+		expect(result).toEqual({ success: true })
+		expect(store.getState().hotkeys["open-folder"]).toBe("")
+		expect(storage.save).toHaveBeenCalledTimes(1)
+	})
+
+	it("resets hotkeys through storage", async () => {
+		const store = createHotkeysStore(storage)
+
+		await store.getState().setHotkeyBinding("open-command-menu", "Mod+P")
+		await store.getState().resetHotkeyBindings()
+
+		expect(storage.reset).toHaveBeenCalledTimes(1)
+		expect(store.getState().hotkeys).toEqual(createDefaultAppHotkeys())
+	})
+
+	it("returns error when storage save fails", async () => {
+		const consoleErrorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined)
+		storage.save = vi.fn(async () => {
+			throw new Error("disk error")
+		})
+		const store = createHotkeysStore(storage)
+
+		const result = await store
+			.getState()
+			.setHotkeyBinding("open-command-menu", "Mod+P")
+
+		expect(result.success).toBe(false)
+		expect(result.error).toBe("disk error")
+		expect(store.getState().hotkeys["open-command-menu"]).toBe("Mod+K")
+		consoleErrorSpy.mockRestore()
+	})
+})

--- a/apps/desktop/src/store/hotkeys/hotkeys-slice.ts
+++ b/apps/desktop/src/store/hotkeys/hotkeys-slice.ts
@@ -1,0 +1,221 @@
+import { validateHotkey } from "@tanstack/react-hotkeys"
+import { BaseDirectory } from "@tauri-apps/api/path"
+import {
+	exists,
+	mkdir,
+	readTextFile,
+	writeTextFile,
+} from "@tauri-apps/plugin-fs"
+import type { StateCreator } from "zustand"
+import {
+	type AppHotkeyActionId,
+	type AppHotkeyMap,
+	createDefaultAppHotkeys,
+	findHotkeyConflict,
+	isAppHotkeyActionId,
+	mergeWithDefaultHotkeys,
+	normalizeHotkeyBinding,
+} from "@/lib/hotkeys"
+
+export type HotkeyStorage = {
+	load: () => Promise<AppHotkeyMap | null>
+	save: (bindings: AppHotkeyMap) => Promise<void>
+	reset: () => Promise<void>
+}
+
+export type SetHotkeyBindingResult = {
+	success: boolean
+	conflictWith?: AppHotkeyActionId
+	error?: string
+}
+
+export type HotkeysSlice = {
+	hotkeys: AppHotkeyMap
+	isHotkeysLoaded: boolean
+	initializeHotkeys: () => Promise<void>
+	setHotkeyBinding: (
+		actionId: AppHotkeyActionId,
+		combo: string,
+	) => Promise<SetHotkeyBindingResult>
+	resetHotkeyBindings: () => Promise<void>
+}
+
+type HotkeysSliceDependencies = {
+	storage: HotkeyStorage
+}
+
+const HOTKEY_SETTINGS_DIR = "settings"
+const HOTKEY_SETTINGS_FILE = "settings/hotkeys.json"
+const HOTKEY_SETTINGS_VERSION = 1
+
+const createAppDataHotkeyStorage = (): HotkeyStorage => ({
+	load: async () => {
+		try {
+			const hasFile = await exists(HOTKEY_SETTINGS_FILE, {
+				baseDir: BaseDirectory.AppData,
+			})
+			if (!hasFile) {
+				return null
+			}
+
+			const raw = await readTextFile(HOTKEY_SETTINGS_FILE, {
+				baseDir: BaseDirectory.AppData,
+			})
+			const parsed = JSON.parse(raw) as unknown
+			if (typeof parsed !== "object" || parsed === null) {
+				return null
+			}
+
+			const maybeRecord = parsed as { bindings?: unknown }
+			if (
+				typeof maybeRecord.bindings !== "object" ||
+				maybeRecord.bindings === null
+			) {
+				return null
+			}
+
+			const rawBindings = maybeRecord.bindings as Record<string, unknown>
+			const normalizedBindings: Partial<Record<AppHotkeyActionId, unknown>> = {}
+
+			for (const [key, value] of Object.entries(rawBindings)) {
+				if (isAppHotkeyActionId(key)) {
+					normalizedBindings[key] = value
+				}
+			}
+
+			return mergeWithDefaultHotkeys(normalizedBindings)
+		} catch (error) {
+			console.error("Failed to load hotkeys from AppData:", error)
+			return null
+		}
+	},
+	save: async (bindings) => {
+		await mkdir(HOTKEY_SETTINGS_DIR, {
+			recursive: true,
+			baseDir: BaseDirectory.AppData,
+		})
+
+		await writeTextFile(
+			HOTKEY_SETTINGS_FILE,
+			JSON.stringify(
+				{
+					version: HOTKEY_SETTINGS_VERSION,
+					bindings,
+				},
+				null,
+				2,
+			),
+			{ baseDir: BaseDirectory.AppData },
+		)
+	},
+	reset: async () => {
+		const defaults = createDefaultAppHotkeys()
+		await mkdir(HOTKEY_SETTINGS_DIR, {
+			recursive: true,
+			baseDir: BaseDirectory.AppData,
+		})
+
+		await writeTextFile(
+			HOTKEY_SETTINGS_FILE,
+			JSON.stringify(
+				{
+					version: HOTKEY_SETTINGS_VERSION,
+					bindings: defaults,
+				},
+				null,
+				2,
+			),
+			{ baseDir: BaseDirectory.AppData },
+		)
+	},
+})
+
+export const prepareHotkeysSlice =
+	({
+		storage,
+	}: HotkeysSliceDependencies): StateCreator<
+		HotkeysSlice,
+		[],
+		[],
+		HotkeysSlice
+	> =>
+	(set, get) => ({
+		hotkeys: createDefaultAppHotkeys(),
+		isHotkeysLoaded: false,
+
+		initializeHotkeys: async () => {
+			try {
+				const loadedHotkeys = await storage.load()
+				set({
+					hotkeys: loadedHotkeys ?? createDefaultAppHotkeys(),
+					isHotkeysLoaded: true,
+				})
+			} catch (error) {
+				console.error("Failed to initialize hotkeys:", error)
+				set({
+					hotkeys: createDefaultAppHotkeys(),
+					isHotkeysLoaded: true,
+				})
+			}
+		},
+
+		setHotkeyBinding: async (actionId, combo) => {
+			const normalizedBinding = normalizeHotkeyBinding(combo)
+			if (normalizedBinding) {
+				const validationResult = validateHotkey(normalizedBinding)
+				if (!validationResult.valid) {
+					return {
+						success: false,
+						error: validationResult.errors[0] ?? "Invalid hotkey format",
+					}
+				}
+			}
+
+			const currentHotkeys = get().hotkeys
+			const conflictWith = findHotkeyConflict(
+				currentHotkeys,
+				actionId,
+				normalizedBinding,
+			)
+			if (conflictWith) {
+				return {
+					success: false,
+					conflictWith,
+					error: "Shortcut already assigned",
+				}
+			}
+
+			const nextHotkeys: AppHotkeyMap = {
+				...currentHotkeys,
+				[actionId]: normalizedBinding,
+			}
+
+			try {
+				await storage.save(nextHotkeys)
+				set({ hotkeys: nextHotkeys })
+				return { success: true }
+			} catch (error) {
+				console.error("Failed to save hotkey binding:", error)
+				return {
+					success: false,
+					error:
+						error instanceof Error
+							? error.message
+							: "Failed to save hotkey binding",
+				}
+			}
+		},
+
+		resetHotkeyBindings: async () => {
+			try {
+				await storage.reset()
+				set({ hotkeys: createDefaultAppHotkeys() })
+			} catch (error) {
+				console.error("Failed to reset hotkeys:", error)
+			}
+		},
+	})
+
+export const createHotkeysSlice = prepareHotkeysSlice({
+	storage: createAppDataHotkeyStorage(),
+})

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -12,6 +12,7 @@ import {
 	createGitSyncSlice,
 	type GitSyncSlice,
 } from "./git-sync/git-sync-slice"
+import { createHotkeysSlice, type HotkeysSlice } from "./hotkeys/hotkeys-slice"
 import {
 	createImageEditSlice,
 	type ImageEditSlice,
@@ -36,6 +37,7 @@ export type StoreState = WorkspaceSlice &
 	GitSyncSlice &
 	ImageEditSlice &
 	IndexingSlice &
+	HotkeysSlice &
 	LicenseSlice &
 	UISlice
 
@@ -48,6 +50,7 @@ export const useStore = create<StoreState>()((...a) => ({
 	...createGitSyncSlice(...a),
 	...createImageEditSlice(...a),
 	...createIndexingSlice(...a),
+	...createHotkeysSlice(...a),
 	...createLicenseSlice(...a),
 	...createUISlice(...a),
 }))


### PR DESCRIPTION
## Summary
- add centralized app hotkey definitions, normalization helpers, and persistence in a dedicated hotkeys store slice
- add a new Settings > Hotkeys tab with recording, conflict handling, reset-to-default, and per-shortcut restore
- wire configured hotkeys into global handlers, shortcut displays, and Tauri window menu accelerators

## Testing
- pnpm -C apps/desktop test -- hotkeys-slice
- pnpm -C apps/desktop ts:check