### PR TITLE
fix: open wiki link editor from floating toolbar

### DIFF
--- a/apps/desktop/src/components/editor/ui/link-toolbar.tsx
+++ b/apps/desktop/src/components/editor/ui/link-toolbar.tsx
@@ -36,7 +36,6 @@ import { LinkUrlInput } from "./link-url-input"
 const popoverVariants = cva(
 	"z-50 w-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md outline-hidden animate-in fade-in-0 zoom-in-95 motion-reduce:animate-none",
 )
-const LINK_INSERT_FOCUS_REQUEST_TTL_MS = 1000
 
 export function LinkFloatingToolbar({
 	state,
@@ -93,7 +92,6 @@ export function LinkFloatingToolbar({
 	const inputProps = useFormInputProps({
 		preventDefaultOnEnterKeydown: true,
 	})
-	const isInsertOpen = isOpen && mode === "insert"
 	const isEditOpen = isOpen && mode === "edit"
 	const isLinkLeafSelected = useMemo(() => {
 		if (!selection || !editor.api.isCollapsed()) {
@@ -142,27 +140,6 @@ export function LinkFloatingToolbar({
 		if (!end) return
 		editor.tf.select({ anchor: end, focus: end })
 	}, [editor, mode, selection])
-
-	useEffect(() => {
-		if (!isInsertOpen) {
-			return
-		}
-
-		const requestedAt = editor.meta._linkInsertFocusRequestedAt
-		if (typeof requestedAt !== "number") {
-			return
-		}
-
-		editor.meta._linkInsertFocusRequestedAt = undefined
-
-		if (Date.now() - requestedAt > LINK_INSERT_FOCUS_REQUEST_TTL_MS) {
-			return
-		}
-
-		requestAnimationFrame(() => {
-			insertInputRef.current?.focus()
-		})
-	}, [editor, isInsertOpen])
 
 	useEffect(() => {
 		if (!isEditOpen || !isLinkLeafSelected) {


### PR DESCRIPTION
## Summary
- replace link toolbar button insert flow with direct `upsertLink` path for selected text
- mark newly inserted links as wiki links and open floating link UI in edit mode
- remove legacy insert-focus meta handoff from desktop link toolbar

## Testing
- pnpm -C apps/desktop ts:check