### PR TITLE
fix: exit link after url submit

### DIFF
--- a/apps/desktop/src/components/editor/ui/link-url-input.tsx
+++ b/apps/desktop/src/components/editor/ui/link-url-input.tsx
@@ -1,3 +1,4 @@
+import { exitLinkForwardAtSelection } from "@mdit/editor/utils/link-exit"
 import { buttonVariants } from "@mdit/ui/components/button"
 import { cn } from "@mdit/ui/lib/utils"
 import { upsertLink } from "@platejs/link"
@@ -447,11 +448,24 @@ export function LinkUrlInput({
 							{ at: path },
 						)
 					}
+
+					const end = editor.api.end(path)
+					if (end) {
+						editor.tf.select({ anchor: end, focus: end })
+					}
 				}
 
-				setHighlightedIndex(-1)
-				api.floatingLink.hide()
-				editor.tf.focus()
+				setTimeout(() => {
+					exitLinkForwardAtSelection(editor, {
+						allowFromInsideLink: true,
+						focusEditor: false,
+						markArrowRightExit: true,
+					})
+
+					setHighlightedIndex(-1)
+					api.floatingLink.hide()
+					editor.tf.focus()
+				}, 0)
 				return
 			}
 


### PR DESCRIPTION
## Summary
- move selection to the end of the updated link node after submit
- defer link-exit handling to the next tick to avoid selection overrides
- close floating link UI and focus editor after moving cursor outside the link

## Testing
- not run (not requested)