### PR TITLE
fix: use NSFileManager for macOS trash

### DIFF
--- a/apps/desktop/src-tauri/src/commands/filesystem.rs
+++ b/apps/desktop/src-tauri/src/commands/filesystem.rs
@@ -8,7 +8,7 @@ fn delete_paths(paths: Vec<String>) -> Result<(), trash::Error> {
 
         let mut trash_context = trash::TrashContext::new();
         trash_context.set_delete_method(DeleteMethod::NsFileManager);
-        return trash_context.delete_all(paths);
+        trash_context.delete_all(paths)
     }
 
     #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
## Summary
- add a shared `delete_paths` helper for trash operations
- on macOS, use `trash::TrashContext` with `DeleteMethod::NsFileManager`
- keep non-macOS behavior unchanged via `trash::delete_all`

## Testing
- cargo test -p mdit --manifest-path Cargo.toml --lib