### PR TITLE
feat: highlight active note in file explorer

### DIFF
--- a/apps/desktop/src/components/file-explorer/file-explorer.tsx
+++ b/apps/desktop/src/components/file-explorer/file-explorer.tsx
@@ -373,6 +373,7 @@ export function FileExplorer() {
 								<TreeNode
 									key={entry.path}
 									entry={entry}
+									activeTabPath={tab?.path ?? null}
 									depth={0}
 									expandedDirectories={expandedDirectories}
 									onDirectoryClick={toggleDirectory}

--- a/apps/desktop/src/components/file-explorer/ui/tree-node.tsx
+++ b/apps/desktop/src/components/file-explorer/ui/tree-node.tsx
@@ -11,6 +11,7 @@ const INDENTATION_WIDTH = 12
 
 type TreeNodeProps = {
 	entry: WorkspaceEntry
+	activeTabPath: string | null
 	depth: number
 	expandedDirectories: string[]
 	onDirectoryClick: (path: string) => void
@@ -35,6 +36,7 @@ type TreeNodeProps = {
 
 export function TreeNode({
 	entry,
+	activeTabPath,
 	depth,
 	expandedDirectories,
 	onDirectoryClick,
@@ -89,6 +91,7 @@ export function TreeNode({
 		() => !entry.isDirectory && extension.toLowerCase() === ".md",
 		[entry.isDirectory, extension],
 	)
+	const isActiveNote = isMarkdown && entry.path === activeTabPath
 
 	const showExtension = !isMarkdown && extension
 
@@ -426,6 +429,7 @@ export function TreeNode({
 								<TreeNode
 									key={child.path}
 									entry={child}
+									activeTabPath={activeTabPath}
 									depth={depth + 1}
 									expandedDirectories={expandedDirectories}
 									onDirectoryClick={onDirectoryClick}
@@ -455,6 +459,7 @@ export function TreeNode({
 					className={cn(
 						getEntryButtonClassName({
 							isSelected,
+							isActive: isActiveNote,
 							isDragging,
 							isRenaming,
 							isAiRenaming,
@@ -463,6 +468,7 @@ export function TreeNode({
 						showExtension && "pr-1",
 					)}
 					style={{ paddingLeft: `${(depth + 1) * INDENTATION_WIDTH}px` }}
+					aria-current={isActiveNote ? "page" : undefined}
 					disabled={isBusy}
 				>
 					<div
@@ -481,7 +487,7 @@ export function TreeNode({
 								inputRef={inputRef}
 								handleRenameKeyDown={handleRenameKeyDown}
 								handleRenameBlur={handleRenameBlur}
-								className="pt-[1px]"
+								className="pt-px"
 							/>
 						)}
 					</div>

--- a/apps/desktop/src/components/file-explorer/utils/entry-classnames.test.ts
+++ b/apps/desktop/src/components/file-explorer/utils/entry-classnames.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { getEntryButtonClassName } from "./entry-classnames"
+
+describe("getEntryButtonClassName", () => {
+	it("keeps selected style priority over active style", () => {
+		const className = getEntryButtonClassName({
+			isSelected: true,
+			isActive: true,
+		})
+
+		expect(className).toContain("bg-background/80")
+		expect(className).not.toContain("bg-background/60")
+	})
+
+	it("applies active style when selected is false", () => {
+		const className = getEntryButtonClassName({
+			isSelected: false,
+			isActive: true,
+		})
+
+		expect(className).toContain("bg-background/60")
+		expect(className).toContain("text-accent-foreground/95")
+		expect(className).not.toContain("bg-background/80")
+	})
+
+	it("uses hover style when both selected and active are false", () => {
+		const className = getEntryButtonClassName({
+			isSelected: false,
+			isActive: false,
+		})
+
+		expect(className).toContain("hover:bg-background/40")
+		expect(className).toContain("group-hover:bg-background/40")
+		expect(className).not.toContain("bg-background/80")
+		expect(className).not.toContain("bg-background/60")
+	})
+})

--- a/apps/desktop/src/components/file-explorer/utils/entry-classnames.ts
+++ b/apps/desktop/src/components/file-explorer/utils/entry-classnames.ts
@@ -2,6 +2,7 @@ import { cn } from "@mdit/ui/lib/utils"
 
 type GetEntryButtonClassNameParams = {
 	isSelected?: boolean
+	isActive?: boolean
 	isDragging?: boolean
 	isRenaming?: boolean
 	isAiRenaming?: boolean
@@ -10,6 +11,7 @@ type GetEntryButtonClassNameParams = {
 
 export function getEntryButtonClassName({
 	isSelected = false,
+	isActive = false,
 	isDragging = false,
 	isRenaming = false,
 	isAiRenaming = false,
@@ -19,7 +21,9 @@ export function getEntryButtonClassName({
 		`${widthClass} text-left flex items-center pr-2 py-0.5 text-accent-foreground/90 min-w-0 rounded-sm transition-opacity cursor-pointer outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[2px]`,
 		isSelected
 			? "bg-background/80 text-accent-foreground"
-			: "hover:bg-background/40 group-hover:bg-background/40",
+			: isActive
+				? "bg-background/60 text-accent-foreground/95"
+				: "hover:bg-background/40 group-hover:bg-background/40",
 		isDragging && "opacity-50 cursor-grabbing",
 		isRenaming && "ring-1 ring-ring/50",
 		isAiRenaming && "animate-pulse",


### PR DESCRIPTION
## Summary
- pass active tab path into file explorer tree nodes
- add active-note visual state and `aria-current="page"` for the active markdown file
- add tests for class name priority (`selected` over `active`) and default hover behavior

## Testing
- pnpm -C apps/desktop test -- entry-classnames
- pnpm -C apps/desktop ts:check