### PR TITLE
perf: lazily render tree children only when expanded

### DIFF
--- a/apps/desktop/src/components/file-explorer/tree/tree-node.tsx
+++ b/apps/desktop/src/components/file-explorer/tree/tree-node.tsx
@@ -8,27 +8,30 @@ export function TreeNode(props: TreeNodeProps) {
 	const { entry } = props
 
 	if (entry.isDirectory) {
-		const childrenTree = entry.children?.map((child) => (
-			<TreeNode
-				key={child.path}
-				entry={child}
-				activeTabPath={props.activeTabPath}
-				depth={props.depth + 1}
-				expandedDirectories={props.expandedDirectories}
-				onDirectoryClick={props.onDirectoryClick}
-				onEntryPrimaryAction={props.onEntryPrimaryAction}
-				onEntryContextMenu={props.onEntryContextMenu}
-				selectedEntryPaths={props.selectedEntryPaths}
-				renamingEntryPath={props.renamingEntryPath}
-				aiRenamingEntryPaths={props.aiRenamingEntryPaths}
-				onRenameSubmit={props.onRenameSubmit}
-				onRenameCancel={props.onRenameCancel}
-				pendingNewFolderPath={props.pendingNewFolderPath}
-				onNewFolderSubmit={props.onNewFolderSubmit}
-				onNewFolderCancel={props.onNewFolderCancel}
-				onCollectionViewOpen={props.onCollectionViewOpen}
-			/>
-		))
+		const isExpanded = props.expandedDirectories.includes(entry.path)
+		const childrenTree = isExpanded
+			? entry.children?.map((child) => (
+					<TreeNode
+						key={child.path}
+						entry={child}
+						activeTabPath={props.activeTabPath}
+						depth={props.depth + 1}
+						expandedDirectories={props.expandedDirectories}
+						onDirectoryClick={props.onDirectoryClick}
+						onEntryPrimaryAction={props.onEntryPrimaryAction}
+						onEntryContextMenu={props.onEntryContextMenu}
+						selectedEntryPaths={props.selectedEntryPaths}
+						renamingEntryPath={props.renamingEntryPath}
+						aiRenamingEntryPaths={props.aiRenamingEntryPaths}
+						onRenameSubmit={props.onRenameSubmit}
+						onRenameCancel={props.onRenameCancel}
+						pendingNewFolderPath={props.pendingNewFolderPath}
+						onNewFolderSubmit={props.onNewFolderSubmit}
+						onNewFolderCancel={props.onNewFolderCancel}
+						onCollectionViewOpen={props.onCollectionViewOpen}
+					/>
+				))
+			: undefined
 
 		return <DirectoryTreeNode {...props} childrenTree={childrenTree} />
 	}


### PR DESCRIPTION
## Summary
- compute file tree children only when a directory is expanded
- avoid building nested TreeNode elements for collapsed directories
- keep rendered behavior unchanged by reusing existing expansion checks

## Testing
- not run (not requested)