### PR TITLE
fix: restore ai chat edit selection from block context

### DIFF
--- a/apps/desktop/src/components/editor/ui/ai-menu.tsx
+++ b/apps/desktop/src/components/editor/ui/ai-menu.tsx
@@ -141,15 +141,9 @@ export function AIMenu() {
 			const ancestor = highestBlock[0]
 
 			if (!editor.api.isEmpty(ancestor)) {
-				const [, path] = highestBlock
-				const start = editor.api.start(path)
-				const end = editor.api.end(path)
-				if (start && end) {
-					editor.tf.select({ anchor: start, focus: end })
-					editor
-						.getApi(BlockSelectionPlugin)
-						.blockSelection.set(ancestor.id as string)
-				}
+				editor
+					.getApi(BlockSelectionPlugin)
+					.blockSelection.set(ancestor.id as string)
 			}
 
 			const domNode = editor.api.toDOMNode(ancestor)

--- a/packages/editor/src/plugins/ai-kit.ts
+++ b/packages/editor/src/plugins/ai-kit.ts
@@ -6,7 +6,7 @@ import {
 	streamInsertChunk,
 	useChatChunk,
 } from "@platejs/ai/react"
-import { getPluginType, KEYS, PathApi } from "platejs"
+import { ElementApi, getPluginType, KEYS, PathApi } from "platejs"
 import { type EditableSiblingComponent, usePluginOption } from "platejs/react"
 import { AILoadingBar } from "../components/ai-loading-bar"
 import { AIAnchorElement, AILeaf } from "../nodes/node-ai"
@@ -61,6 +61,35 @@ export const createAIKit = ({
 					}
 
 					if (toolName === "edit" && mode === "chat") {
+						const chatSelection = getOption("chatSelection")
+						if (chatSelection) {
+							editor.tf.setSelection(chatSelection)
+						} else {
+							const chatNodes = getOption("chatNodes")
+							const chatNodeIds = Array.isArray(chatNodes)
+								? chatNodes
+										.map((node) => node?.id)
+										.filter((id): id is string => typeof id === "string")
+								: []
+
+							if (chatNodeIds.length > 0) {
+								const selectedNodes = Array.from(
+									editor.api.nodes({
+										at: [],
+										match: (node) =>
+											ElementApi.isElement(node) &&
+											typeof node.id === "string" &&
+											chatNodeIds.includes(node.id),
+									}),
+								)
+								const range = editor.api.nodesRange(selectedNodes)
+
+								if (range) {
+									editor.tf.setSelection(range)
+								}
+							}
+						}
+
 						withAIBatch(
 							editor,
 							() => {


### PR DESCRIPTION
## Summary
- stop forcing cursor-open AI edit flow to select full block text range in `AIMenu`
- preserve block selection state and restore selection at chunk-apply time in `createAIKit`
- add fallback to reconstruct selection from `chatNodes` IDs when `chatSelection` is unavailable

## Testing
- pnpm -C apps/desktop ts:check