### PR TITLE
fix: wait for unsaved tab before directory rename/delete

### DIFF
--- a/apps/desktop/src/store/workspace/actions/workspace-fs-structure-actions.ts
+++ b/apps/desktop/src/store/workspace/actions/workspace-fs-structure-actions.ts
@@ -1,5 +1,8 @@
 import { dirname, join, relative, resolve } from "pathe"
-import { hasPathConflictWithLockedPaths } from "@/utils/path-utils"
+import {
+	hasPathConflictWithLockedPaths,
+	isPathEqualOrDescendant,
+} from "@/utils/path-utils"
 import {
 	isPathDeletedByTargets,
 	resolveDeletedMarkdownPaths,
@@ -389,7 +392,10 @@ export const createWorkspaceFsStructureActions = (
 		}
 		const activeTabPath = tab?.path
 
-		if (activeTabPath && paths.includes(activeTabPath)) {
+		if (
+			activeTabPath &&
+			paths.some((path) => isPathEqualOrDescendant(activeTabPath, path))
+		) {
 			await waitForUnsavedTabToSettle(activeTabPath, ctx.get)
 		}
 
@@ -507,7 +513,10 @@ export const createWorkspaceFsStructureActions = (
 			return entry.path
 		}
 
-		await waitForUnsavedTabToSettle(entry.path, ctx.get)
+		const activeTabPath = ctx.get().tab?.path
+		if (activeTabPath && isPathEqualOrDescendant(activeTabPath, entry.path)) {
+			await waitForUnsavedTabToSettle(activeTabPath, ctx.get)
+		}
 
 		const directoryPath = dirname(entry.path)
 		const nextPath = join(directoryPath, trimmedName)


### PR DESCRIPTION
## Summary
- wait for unsaved active tab when deleting a parent directory of the active note
- wait for unsaved active tab when renaming a parent directory of the active note
- add regression tests covering descendant-path wait behavior for both delete and rename

## Testing
- pnpm -C apps/desktop test -- src/store/workspace/actions/workspace-fs-structure-actions.test.ts