### PR TITLE
fix: preserve keyboard focus after frontmatter row deletion

### DIFF
--- a/packages/editor/src/frontmatter/node-frontmatter.tsx
+++ b/packages/editor/src/frontmatter/node-frontmatter.tsx
@@ -24,6 +24,12 @@ export function FrontmatterElement(
 
 			if (nextRows.length === 0) {
 				editor.tf.removeNodes({ at: path })
+				requestAnimationFrame(() => {
+					if (editor.children.length > 0) {
+						editor.tf.select([0], { edge: "start" })
+					}
+					editor.tf.focus()
+				})
 				return
 			}
 			editor.tf.setNodes({ data: nextRows }, { at: path })


### PR DESCRIPTION
## Summary
- keep keyboard focus in the frontmatter table when deleting a row via keyboard by moving focus to an adjacent row action button
- when deleting the last remaining frontmatter row, remove the frontmatter node and restore editor focus to the first block

## Testing
- pre-commit hook: `pnpm lint:fix` (Biome check)