### PR TITLE
fix(editor): stabilize frontmatter row sync

### DIFF
--- a/packages/editor/src/frontmatter/frontmatter-kit.ts
+++ b/packages/editor/src/frontmatter/frontmatter-kit.ts
@@ -1,6 +1,6 @@
 import { PointApi } from "platejs"
 import { createPlatePlugin } from "platejs/react"
-import { createElement, memo } from "react"
+import { createElement } from "react"
 import type { LinkWorkspaceState } from "../link/link-kit-types"
 import { requestFrontmatterFocus } from "./frontmatter-focus"
 import { FrontmatterElement } from "./node-frontmatter"
@@ -23,16 +23,13 @@ export type CreateFrontmatterKitOptions = {
 export function createFrontmatterPlugin({
 	host,
 }: CreateFrontmatterKitOptions = {}) {
-	const FrontmatterNode = memo(
-		(props: Parameters<typeof FrontmatterElement>[0]) =>
-			createElement(FrontmatterElement, {
-				...props,
-				onOpenWikiLink: host?.onOpenWikiLink,
-				getLinkWorkspaceState: host?.getLinkWorkspaceState,
-				resolveWikiLinkTarget: host?.resolveWikiLinkTarget,
-			}),
-		() => true,
-	)
+	const FrontmatterNode = (props: Parameters<typeof FrontmatterElement>[0]) =>
+		createElement(FrontmatterElement, {
+			...props,
+			onOpenWikiLink: host?.onOpenWikiLink,
+			getLinkWorkspaceState: host?.getLinkWorkspaceState,
+			resolveWikiLinkTarget: host?.resolveWikiLinkTarget,
+		})
 
 	return createPlatePlugin({
 		key: FRONTMATTER_KEY,

--- a/packages/editor/src/frontmatter/frontmatter-row-equality.test.ts
+++ b/packages/editor/src/frontmatter/frontmatter-row-equality.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest"
+import { areFrontmatterRowsEqual } from "./frontmatter-row-equality"
+
+describe("frontmatter-row-equality", () => {
+	it("returns true for equivalent primitive rows", () => {
+		expect(
+			areFrontmatterRowsEqual(
+				[{ id: "1", key: "title", type: "string", value: "hello" }],
+				[{ id: "1", key: "title", type: "string", value: "hello" }],
+			),
+		).toBe(true)
+	})
+
+	it("returns false when date values differ", () => {
+		expect(
+			areFrontmatterRowsEqual(
+				[
+					{
+						id: "1",
+						key: "published",
+						type: "date",
+						value: new Date("2026-01-01"),
+					},
+				],
+				[
+					{
+						id: "1",
+						key: "published",
+						type: "date",
+						value: new Date("2026-01-02"),
+					},
+				],
+			),
+		).toBe(false)
+	})
+
+	it("returns true for equivalent nested array/object values", () => {
+		expect(
+			areFrontmatterRowsEqual(
+				[
+					{
+						id: "1",
+						key: "meta",
+						type: "array",
+						value: [{ slug: "a" }, ["b", "c"]],
+					},
+				],
+				[
+					{
+						id: "1",
+						key: "meta",
+						type: "array",
+						value: [{ slug: "a" }, ["b", "c"]],
+					},
+				],
+			),
+		).toBe(true)
+	})
+
+	it("returns true for equivalent cyclic values without stack overflow", () => {
+		const leftCycle: Record<string, unknown> = { label: "same" }
+		leftCycle.self = leftCycle
+
+		const rightCycle: Record<string, unknown> = { label: "same" }
+		rightCycle.self = rightCycle
+
+		expect(
+			areFrontmatterRowsEqual(
+				[{ id: "1", key: "meta", type: "object", value: leftCycle }],
+				[{ id: "1", key: "meta", type: "object", value: rightCycle }],
+			),
+		).toBe(true)
+	})
+
+	it("returns false for cyclic values with different nested data", () => {
+		const leftCycle: Record<string, unknown> = { label: "left" }
+		leftCycle.self = leftCycle
+
+		const rightCycle: Record<string, unknown> = { label: "right" }
+		rightCycle.self = rightCycle
+
+		expect(
+			areFrontmatterRowsEqual(
+				[{ id: "1", key: "meta", type: "object", value: leftCycle }],
+				[{ id: "1", key: "meta", type: "object", value: rightCycle }],
+			),
+		).toBe(false)
+	})
+})

--- a/packages/editor/src/frontmatter/frontmatter-row-equality.ts
+++ b/packages/editor/src/frontmatter/frontmatter-row-equality.ts
@@ -1,0 +1,89 @@
+export type FrontmatterComparableRow = {
+	id: string
+	key: string
+	type: string
+	value: unknown
+}
+
+const isObjectValue = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null
+
+type SeenPairs = WeakMap<object, WeakSet<object>>
+
+const isSeenPair = (
+	seenPairs: SeenPairs,
+	left: object,
+	right: object,
+): boolean => {
+	const seenRightItems = seenPairs.get(left)
+	if (seenRightItems?.has(right)) return true
+	if (seenRightItems) {
+		seenRightItems.add(right)
+	} else {
+		const nextSeenRightItems = new WeakSet<object>()
+		nextSeenRightItems.add(right)
+		seenPairs.set(left, nextSeenRightItems)
+	}
+	return false
+}
+
+const isSameValue = (left: unknown, right: unknown): boolean => {
+	const seenPairs: SeenPairs = new WeakMap()
+
+	const compare = (leftValue: unknown, rightValue: unknown): boolean => {
+		if (Object.is(leftValue, rightValue)) return true
+
+		if (leftValue instanceof Date && rightValue instanceof Date) {
+			return leftValue.getTime() === rightValue.getTime()
+		}
+
+		if (Array.isArray(leftValue) && Array.isArray(rightValue)) {
+			if (isSeenPair(seenPairs, leftValue, rightValue)) return true
+			if (leftValue.length !== rightValue.length) return false
+			for (let index = 0; index < leftValue.length; index += 1) {
+				if (!compare(leftValue[index], rightValue[index])) return false
+			}
+			return true
+		}
+
+		if (isObjectValue(leftValue) && isObjectValue(rightValue)) {
+			if (isSeenPair(seenPairs, leftValue, rightValue)) return true
+			const leftKeys = Object.keys(leftValue)
+			const rightKeys = Object.keys(rightValue)
+			if (leftKeys.length !== rightKeys.length) return false
+			for (const key of leftKeys) {
+				if (!(key in rightValue)) return false
+				if (!compare(leftValue[key], rightValue[key])) return false
+			}
+			return true
+		}
+
+		return false
+	}
+
+	return compare(left, right)
+}
+
+export const areFrontmatterRowsEqual = (
+	leftRows: FrontmatterComparableRow[],
+	rightRows: FrontmatterComparableRow[],
+) => {
+	if (leftRows === rightRows) return true
+	if (leftRows.length !== rightRows.length) return false
+
+	for (let index = 0; index < leftRows.length; index += 1) {
+		const left = leftRows[index]
+		const right = rightRows[index]
+
+		if (
+			left.id !== right.id ||
+			left.key !== right.key ||
+			left.type !== right.type ||
+			!isSameValue(left.value, right.value)
+		) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/packages/editor/src/frontmatter/node-frontmatter.tsx
+++ b/packages/editor/src/frontmatter/node-frontmatter.tsx
@@ -1,6 +1,6 @@
 import type { PlateElementProps } from "platejs/react"
 import { PlateElement, useEditorRef } from "platejs/react"
-import { useCallback } from "react"
+import { useCallback, useRef } from "react"
 import type { LinkWorkspaceState } from "../link/link-kit-types"
 import {
 	type FrontmatterResolveWikiLinkTargetHandler,
@@ -25,11 +25,13 @@ export function FrontmatterElement(
 	},
 ) {
 	const editor = useEditorRef()
-	const element = props.element as TFrontmatterElement
+	const element = props.element
+	const elementRef = useRef<TFrontmatterElement>(element)
+	elementRef.current = element
 
 	const handleDataChange = useCallback(
 		(nextRows: KVRow[]) => {
-			const path = props.api.findPath(element)
+			const path = props.api.findPath(elementRef.current)
 			if (!path) return
 
 			if (nextRows.length === 0) {
@@ -44,7 +46,7 @@ export function FrontmatterElement(
 			}
 			editor.tf.setNodes({ data: nextRows }, { at: path })
 		},
-		[editor, element, props.api],
+		[editor, props.api],
 	)
 
 	return (


### PR DESCRIPTION
## Summary
- replace the frontmatter node wrapper memoization with a normal component wrapper so updates are not suppressed
- stabilize `FrontmatterTable` state sync by deferring `onChange` until local state is committed and skipping no-op updates
- add `areFrontmatterRowsEqual` deep comparison with cycle-safe traversal to avoid stack overflow on cyclic values
- add regression tests for primitive, nested, and cyclic row values

## Testing
- pnpm -C /Users/hyeongjin/Workspace/Mdit/packages/editor test src/frontmatter/frontmatter-row-equality.test.ts
- pnpm -C /Users/hyeongjin/Workspace/Mdit/packages/editor test src/frontmatter