### PR TITLE
feat(editor): exclude existing wiki targets in frontmatter suggestions

### DIFF
--- a/packages/editor/src/frontmatter/frontmatter-wiki-suggestion-utils.test.ts
+++ b/packages/editor/src/frontmatter/frontmatter-wiki-suggestion-utils.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest"
+import type { WorkspaceFileOption } from "../link/link-kit-types"
+import {
+	buildFrontmatterWikiSuggestions,
+	getFrontmatterWikiSuggestionTargetKey,
+} from "./frontmatter-wiki-suggestion-utils"
+
+function createWorkspaceFile(relativePath: string): WorkspaceFileOption {
+	const filename = relativePath.split("/").at(-1) ?? relativePath
+	return {
+		absolutePath: `/workspace/${relativePath}`,
+		displayName: filename.replace(/\.mdx?$/i, ""),
+		relativePath,
+		relativePathLower: relativePath.toLowerCase(),
+	}
+}
+
+const baseWorkspaceFiles: WorkspaceFileOption[] = [
+	createWorkspaceFile("docs/guide.md"),
+	createWorkspaceFile("docs/guide-advanced.md"),
+	createWorkspaceFile("notes/todo.md"),
+]
+
+describe("frontmatter-wiki-suggestion-utils", () => {
+	it("keeps query matching behavior", () => {
+		const suggestions = buildFrontmatterWikiSuggestions(
+			baseWorkspaceFiles,
+			"guide",
+		)
+		expect(suggestions.map((entry) => entry.target)).toEqual([
+			"docs/guide",
+			"docs/guide-advanced",
+		])
+	})
+
+	it("excludes targets listed in excludeTargetKeys", () => {
+		const suggestions = buildFrontmatterWikiSuggestions(
+			baseWorkspaceFiles,
+			"guide",
+			{
+				excludeTargetKeys: new Set(["docs/guide"]),
+			},
+		)
+		expect(suggestions.map((entry) => entry.target)).toEqual([
+			"docs/guide-advanced",
+		])
+	})
+
+	it("uses canonical key from case variants, alias, and plain path for exclusion", () => {
+		const existingValues = [
+			"[[Docs/Guide]]",
+			"[[docs/guide|Guide]]",
+			"docs/guide.md",
+		]
+
+		for (const existingValue of existingValues) {
+			const excludeKey = getFrontmatterWikiSuggestionTargetKey(existingValue)
+			expect(excludeKey).toBe("docs/guide")
+			if (!excludeKey) {
+				throw new Error("Expected canonical key to be generated")
+			}
+
+			const suggestions = buildFrontmatterWikiSuggestions(
+				baseWorkspaceFiles,
+				"guide",
+				{
+					excludeTargetKeys: new Set([excludeKey]),
+				},
+			)
+
+			expect(suggestions.map((entry) => entry.target)).toEqual([
+				"docs/guide-advanced",
+			])
+		}
+	})
+
+	it("returns null for mixed text with wiki token", () => {
+		expect(
+			getFrontmatterWikiSuggestionTargetKey("Before [[docs/guide]]"),
+		).toBeNull()
+	})
+
+	it("fills up to 50 suggestions after exclusion", () => {
+		const workspaceFiles = Array.from({ length: 80 }, (_, index) =>
+			createWorkspaceFile(
+				`notes/topic-${String(index + 1).padStart(2, "0")}.md`,
+			),
+		)
+		const suggestions = buildFrontmatterWikiSuggestions(workspaceFiles, "", {
+			excludeTargetKeys: new Set([
+				"notes/topic-01",
+				"notes/topic-02",
+				"notes/topic-03",
+				"notes/topic-04",
+				"notes/topic-05",
+			]),
+		})
+
+		expect(suggestions).toHaveLength(50)
+		expect(suggestions[0]?.target).toBe("notes/topic-06")
+		expect(suggestions.at(-1)?.target).toBe("notes/topic-55")
+	})
+})

--- a/packages/editor/src/frontmatter/frontmatter-wiki-suggestion-utils.ts
+++ b/packages/editor/src/frontmatter/frontmatter-wiki-suggestion-utils.ts
@@ -3,6 +3,7 @@ import {
 	normalizePathSeparators,
 	normalizeWikiTargetForDisplay,
 } from "../link/link-toolbar-utils"
+import { parseFrontmatterWikiSegments } from "./frontmatter-wiki-link-utils"
 
 export type FrontmatterWikiSuggestionEntry = {
 	displayName: string
@@ -10,25 +11,67 @@ export type FrontmatterWikiSuggestionEntry = {
 	target: string
 }
 
+type BuildFrontmatterWikiSuggestionsOptions = {
+	excludeTargetKeys?: ReadonlySet<string>
+}
+
+const MAX_FRONTMATTER_WIKI_SUGGESTIONS = 50
+
+export function getFrontmatterWikiSuggestionTargetKey(
+	value: string,
+): string | null {
+	const trimmed = value.trim()
+	if (!trimmed) return null
+
+	const segments = parseFrontmatterWikiSegments(trimmed)
+	if (segments.length === 1 && segments[0]?.type === "wikiLink") {
+		const normalizedTarget = normalizeWikiTargetForDisplay(segments[0].target)
+		return normalizedTarget ? normalizedTarget.toLowerCase() : null
+	}
+
+	if (segments.some((segment) => segment.type === "wikiLink")) {
+		return null
+	}
+
+	const normalizedTarget = normalizeWikiTargetForDisplay(trimmed)
+	return normalizedTarget ? normalizedTarget.toLowerCase() : null
+}
+
 export function buildFrontmatterWikiSuggestions(
 	workspaceFiles: WorkspaceFileOption[],
 	query: string,
+	options?: BuildFrontmatterWikiSuggestionsOptions,
 ): FrontmatterWikiSuggestionEntry[] {
 	const normalizedQuery = normalizePathSeparators(query).toLowerCase()
-	const suggestions = workspaceFiles
-		.filter((file) => {
-			if (!normalizedQuery) return true
-			return (
-				file.displayName.toLowerCase().includes(normalizedQuery) ||
-				file.relativePathLower.includes(normalizedQuery)
-			)
-		})
-		.slice(0, 12)
-		.map((file) => ({
+	const excludeTargetKeys = options?.excludeTargetKeys
+	const suggestions: FrontmatterWikiSuggestionEntry[] = []
+
+	for (const file of workspaceFiles) {
+		if (
+			normalizedQuery &&
+			!file.displayName.toLowerCase().includes(normalizedQuery) &&
+			!file.relativePathLower.includes(normalizedQuery)
+		) {
+			continue
+		}
+
+		const target = normalizeWikiTargetForDisplay(file.relativePath)
+		if (!target) continue
+
+		if (excludeTargetKeys?.has(target.toLowerCase())) {
+			continue
+		}
+
+		suggestions.push({
 			displayName: file.displayName,
 			relativePath: file.relativePath,
-			target: normalizeWikiTargetForDisplay(file.relativePath),
-		}))
+			target,
+		})
 
-	return suggestions.filter((item) => Boolean(item.target))
+		if (suggestions.length >= MAX_FRONTMATTER_WIKI_SUGGESTIONS) {
+			break
+		}
+	}
+
+	return suggestions
 }

--- a/packages/editor/src/frontmatter/node-frontmatter-array.tsx
+++ b/packages/editor/src/frontmatter/node-frontmatter-array.tsx
@@ -18,6 +18,7 @@ import { FrontmatterWikiSuggestionPopover } from "./frontmatter-wiki-suggestion-
 import {
 	buildFrontmatterWikiSuggestions,
 	type FrontmatterWikiSuggestionEntry,
+	getFrontmatterWikiSuggestionTargetKey,
 } from "./frontmatter-wiki-suggestion-utils"
 import type { FocusRegistration } from "./node-frontmatter-table"
 
@@ -63,15 +64,6 @@ export function FrontmatterArray({
 		() => getActiveFrontmatterWikiQuery(draft, cursorPosition),
 		[cursorPosition, draft],
 	)
-	const wikiSuggestions = useMemo(() => {
-		if (!activeWikiQuery) return []
-		return buildFrontmatterWikiSuggestions(
-			workspaceFiles,
-			activeWikiQuery.query,
-		)
-	}, [activeWikiQuery, workspaceFiles])
-	const showWikiSuggestionPopover =
-		Boolean(activeWikiQuery) && wikiSuggestions.length > 0
 
 	const items = useMemo(() => {
 		if (Array.isArray(value)) {
@@ -82,6 +74,28 @@ export function FrontmatterArray({
 		}
 		return []
 	}, [value])
+	const excludedWikiTargetKeys = useMemo(() => {
+		const targetKeys = new Set<string>()
+		for (const item of items) {
+			const key = getFrontmatterWikiSuggestionTargetKey(item)
+			if (key) {
+				targetKeys.add(key)
+			}
+		}
+		return targetKeys
+	}, [items])
+	const wikiSuggestions = useMemo(() => {
+		if (!activeWikiQuery) return []
+		return buildFrontmatterWikiSuggestions(
+			workspaceFiles,
+			activeWikiQuery.query,
+			{
+				excludeTargetKeys: excludedWikiTargetKeys,
+			},
+		)
+	}, [activeWikiQuery, excludedWikiTargetKeys, workspaceFiles])
+	const showWikiSuggestionPopover =
+		Boolean(activeWikiQuery) && wikiSuggestions.length > 0
 
 	const addItems = (raw: string) => {
 		const nextItems = parseItems(raw)

--- a/packages/editor/src/frontmatter/node-frontmatter-table.tsx
+++ b/packages/editor/src/frontmatter/node-frontmatter-table.tsx
@@ -72,6 +72,7 @@ import { FrontmatterWikiSuggestionPopover } from "./frontmatter-wiki-suggestion-
 import {
 	buildFrontmatterWikiSuggestions,
 	type FrontmatterWikiSuggestionEntry,
+	getFrontmatterWikiSuggestionTargetKey,
 } from "./frontmatter-wiki-suggestion-utils"
 import { FrontmatterArray } from "./node-frontmatter-array"
 
@@ -238,13 +239,23 @@ function InlineEditableField({
 		if (!isEditing) return null
 		return getActiveFrontmatterWikiQuery(draftValue, cursorPosition)
 	}, [cursorPosition, draftValue, enableWikiSuggestions, isEditing])
+	const excludedWikiTargetKeys = useMemo(() => {
+		const targetKey = getFrontmatterWikiSuggestionTargetKey(value)
+		if (!targetKey) {
+			return undefined
+		}
+		return new Set([targetKey])
+	}, [value])
 	const wikiSuggestions = useMemo(() => {
 		if (!activeWikiQuery) return []
 		return buildFrontmatterWikiSuggestions(
 			workspaceFiles,
 			activeWikiQuery.query,
+			{
+				excludeTargetKeys: excludedWikiTargetKeys,
+			},
 		)
-	}, [activeWikiQuery, workspaceFiles])
+	}, [activeWikiQuery, excludedWikiTargetKeys, workspaceFiles])
 	const showWikiSuggestionPopover =
 		isEditing &&
 		enableWikiSuggestions &&


### PR DESCRIPTION
## Summary
- add canonical target-key extraction for frontmatter wiki values
- exclude already-selected targets from wiki autocomplete in frontmatter string and array fields
- increase suggestion list cap to 50 while preserving query filtering behavior
- add unit tests for exclusion behavior and canonical key normalization

## Testing
- pnpm -C packages/editor test -- src/frontmatter/frontmatter-wiki-suggestion-utils.test.ts