### PR TITLE
fix: disable file explorer drop targets when closed

### DIFF
--- a/apps/desktop/src/components/file-explorer/file-explorer.tsx
+++ b/apps/desktop/src/components/file-explorer/file-explorer.tsx
@@ -140,7 +140,7 @@ export function FileExplorer() {
 			isDirectory: true,
 			depth: -1,
 		},
-		disabled: !workspacePath,
+		disabled: !workspacePath || !isFileExplorerOpen,
 	})
 
 	// Setup external file drop zone for workspace root
@@ -390,6 +390,7 @@ export function FileExplorer() {
 									key={entry.path}
 									entry={entry}
 									activeTabPath={tab?.path ?? null}
+									isFileExplorerOpen={isFileExplorerOpen}
 									depth={0}
 									expandedDirectories={expandedDirectories}
 									onDirectoryClick={toggleDirectory}

--- a/apps/desktop/src/components/file-explorer/tree/directory-tree-node.tsx
+++ b/apps/desktop/src/components/file-explorer/tree/directory-tree-node.tsx
@@ -15,6 +15,7 @@ const INDENTATION_WIDTH = 12
 
 export function DirectoryTreeNode({
 	entry,
+	isFileExplorerOpen,
 	depth,
 	expandedDirectories,
 	onDirectoryClick,
@@ -58,7 +59,7 @@ export function DirectoryTreeNode({
 			isDirectory: entry.isDirectory,
 			depth,
 		},
-		disabled: !entry.isDirectory || isBusy,
+		disabled: !entry.isDirectory || isBusy || !isFileExplorerOpen,
 	})
 
 	const { isOver: isOverExternal, ref: externalDropRef } = useFolderDropZone({

--- a/apps/desktop/src/components/file-explorer/tree/tree-node.tsx
+++ b/apps/desktop/src/components/file-explorer/tree/tree-node.tsx
@@ -15,6 +15,7 @@ export function TreeNode(props: TreeNodeProps) {
 						key={child.path}
 						entry={child}
 						activeTabPath={props.activeTabPath}
+						isFileExplorerOpen={props.isFileExplorerOpen}
 						depth={props.depth + 1}
 						expandedDirectories={props.expandedDirectories}
 						onDirectoryClick={props.onDirectoryClick}

--- a/apps/desktop/src/components/file-explorer/tree/tree-node.types.ts
+++ b/apps/desktop/src/components/file-explorer/tree/tree-node.types.ts
@@ -4,6 +4,7 @@ import type { WorkspaceEntry } from "@/store/workspace/workspace-slice"
 export type TreeNodeProps = {
 	entry: WorkspaceEntry
 	activeTabPath: string | null
+	isFileExplorerOpen: boolean
 	depth: number
 	expandedDirectories: string[]
 	onDirectoryClick: (path: string) => void


### PR DESCRIPTION
## Summary
- disable workspace-root internal drop target when file explorer is closed
- disable directory internal drop targets when file explorer is closed
- thread `isFileExplorerOpen` through tree node props so nested directories follow the same behavior

## Testing
- pnpm -C /Users/hyeongjin/Workspace/Mdit lint:fix
- pnpm -C /Users/hyeongjin/Workspace/Mdit/apps/desktop ts:check

Fixes #312