### PR TITLE
refactor(desktop): move hotkey init out of app and harden local API sync

### DIFF
--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -128,6 +128,12 @@ export function App() {
 		let isActive = true
 		const shouldRunLocalApi =
 			localApiEnabled && licenseStatus === "valid" && hasVerifiedLicense
+		const setLocalApiErrorIfActive = (errorMessage: string | null) => {
+			if (!isActive) {
+				return
+			}
+			setLocalApiError(errorMessage)
+		}
 
 		const syncLocalApiServerState = async () => {
 			try {
@@ -136,18 +142,14 @@ export function App() {
 				} else {
 					await stopLocalApiServer()
 				}
-				if (!isActive) {
-					return
-				}
-				setLocalApiError(null)
+				setLocalApiErrorIfActive(null)
 			} catch (error) {
-				if (!isActive) {
-					return
-				}
 				const action = shouldRunLocalApi ? "start" : "stop"
 				const message =
 					error instanceof Error ? error.message : String(error ?? "Unknown")
-				setLocalApiError(`Failed to ${action} local API server: ${message}`)
+				setLocalApiErrorIfActive(
+					`Failed to ${action} local API server: ${message}`,
+				)
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Remove hotkey initialization from `App` and keep it in the existing `<Hotkeys />` component flow.
- Merge workspace and AI initialization side effects into a single startup effect.
- Split local API sync into explicit invalid-license reset and guarded start/stop effect with stale-effect protection.