### PR TITLE
fix: handle invalid mdx during note open

### DIFF
--- a/apps/desktop/src/components/editor/editor.tsx
+++ b/apps/desktop/src/components/editor/editor.tsx
@@ -1,6 +1,7 @@
+import { createMarkdownDeserializerWithFallback } from "@mdit/editor/markdown"
 import { EditorSurface } from "@mdit/editor/shared"
 import { getCurrentWindow } from "@tauri-apps/api/window"
-import { createSlateEditor, type Value } from "platejs"
+import type { Value } from "platejs"
 import { usePlateEditor } from "platejs/react"
 import {
 	type KeyboardEvent,
@@ -17,7 +18,7 @@ import { Header } from "./header/header"
 import { useAutoRenameOnSave } from "./hooks/use-auto-rename-on-save"
 import { useCommandMenuSelectionRestore } from "./hooks/use-command-menu-selection-restore"
 import { useLinkedTabName } from "./hooks/use-linked-tab-name"
-import { EditorKit } from "./plugins/editor-kit"
+import { EditorKit, EditorKitNoMdx } from "./plugins/editor-kit"
 import {
 	focusEditorAtDefaultSelection,
 	restoreHistorySelection,
@@ -28,16 +29,22 @@ export function Editor({ destroyOnClose }: { destroyOnClose?: boolean }) {
 	const tab = useStore((s) => s.tab)
 	const handleTypingProgress = useStore((s) => s.handleTypingProgress)
 
-	const editor = useMemo(() => {
-		return createSlateEditor({
-			plugins: EditorKit,
-		})
-	}, [])
+	const deserializeWithFallback = useMemo(
+		() =>
+			createMarkdownDeserializerWithFallback({
+				mdxPlugins: EditorKit,
+				noMdxPlugins: EditorKitNoMdx,
+			}),
+		[],
+	)
 
 	const value = useMemo(() => {
 		if (!tab) return
-		return editor.api.markdown.deserialize(tab.content)
-	}, [tab, editor])
+		return deserializeWithFallback({
+			content: tab.content,
+			path: tab.path,
+		})
+	}, [tab, deserializeWithFallback])
 
 	if (!tab || !value)
 		return (

--- a/apps/desktop/src/components/editor/plugins/editor-kit.ts
+++ b/apps/desktop/src/components/editor/plugins/editor-kit.ts
@@ -11,7 +11,11 @@ import { DateKit } from "@mdit/editor/date"
 import { EmojiKit } from "@mdit/editor/emoji"
 import { createFrontmatterKit } from "@mdit/editor/frontmatter"
 import { createLinkKit } from "@mdit/editor/link"
-import { AutoformatKit, MarkdownKit } from "@mdit/editor/markdown"
+import {
+	AutoformatKit,
+	MarkdownKit,
+	MarkdownKitNoMdx,
+} from "@mdit/editor/markdown"
 import { MathKit } from "@mdit/editor/math"
 import { createFilePasteKit, createMediaKit } from "@mdit/editor/media"
 import {
@@ -55,7 +59,11 @@ const desktopFrontmatterHost = createDesktopFrontmatterHost({
 })
 const desktopBlockSelectionHost = createDesktopBlockSelectionHost()
 
-export const EditorKit = [
+type CreateEditorKitOptions = {
+	mdx?: boolean
+}
+
+const createEditorKit = ({ mdx = true }: CreateEditorKitOptions = {}) => [
 	...createAIKit({ host: desktopAIMenuHost }),
 	...createFilePasteKit({ host: desktopFilePasteHost }),
 	...TabMetadataKit,
@@ -74,7 +82,7 @@ export const EditorKit = [
 	...FloatingToolbarKit,
 	...createLinkKit({ host: desktopLinkHost }),
 	...ListKit,
-	...MarkdownKit,
+	...(mdx ? MarkdownKit : MarkdownKitNoMdx),
 	...MathKit,
 	...createMediaKit({ host: desktopMediaHost }),
 	...ShortcutsKit,
@@ -84,3 +92,6 @@ export const EditorKit = [
 	...TocKit,
 	...UtilsKit,
 ]
+
+export const EditorKit = createEditorKit({ mdx: true })
+export const EditorKitNoMdx = createEditorKit({ mdx: false })

--- a/packages/editor/src/markdown/index.ts
+++ b/packages/editor/src/markdown/index.ts
@@ -1,6 +1,16 @@
 export { AutoformatKit } from "./autoformat-kit"
 export {
+	type CreateMarkdownDeserializerWithFallbackOptions,
+	createMarkdownDeserializerWithFallback,
+	createSlateEditorWithPlugins,
+	type DeserializeMarkdownWithFallbackInput,
+} from "./markdown-fallback-deserializer"
+export {
 	MarkdownJoiner,
 	markdownJoinerTransform,
 } from "./markdown-joiner-transform"
-export { MarkdownKit } from "./markdown-kit"
+export {
+	createMarkdownKit,
+	MarkdownKit,
+	MarkdownKitNoMdx,
+} from "./markdown-kit"

--- a/packages/editor/src/markdown/markdown-fallback-deserializer.ts
+++ b/packages/editor/src/markdown/markdown-fallback-deserializer.ts
@@ -1,0 +1,72 @@
+import { createSlateEditor, type Value } from "platejs"
+
+type SlateEditorCreateOptions = Parameters<typeof createSlateEditor>[0]
+type SlatePlugins = NonNullable<SlateEditorCreateOptions>["plugins"]
+
+type MarkdownFallbackLogger = Pick<Console, "warn">
+
+export type CreateMarkdownDeserializerWithFallbackOptions = {
+	mdxPlugins: SlatePlugins
+	noMdxPlugins: SlatePlugins
+	logger?: MarkdownFallbackLogger
+	createFallbackValue?: () => Value
+}
+
+export type DeserializeMarkdownWithFallbackInput = {
+	content: string
+	path?: string
+}
+
+const createDefaultFallbackEditorValue = (): Value => [
+	{
+		type: "p",
+		children: [{ text: "" }],
+	},
+]
+
+export const createSlateEditorWithPlugins = (plugins: SlatePlugins) =>
+	createSlateEditor({
+		plugins,
+	})
+
+export const createMarkdownDeserializerWithFallback = ({
+	mdxPlugins,
+	noMdxPlugins,
+	logger = console,
+	createFallbackValue = createDefaultFallbackEditorValue,
+}: CreateMarkdownDeserializerWithFallbackOptions) => {
+	const mdxEditor = createSlateEditorWithPlugins(mdxPlugins)
+	let noMdxEditor: ReturnType<typeof createSlateEditor> | null = null
+
+	const getOrCreateNoMdxEditor = () => {
+		if (!noMdxEditor) {
+			noMdxEditor = createSlateEditorWithPlugins(noMdxPlugins)
+		}
+
+		return noMdxEditor
+	}
+
+	return ({ content, path }: DeserializeMarkdownWithFallbackInput): Value => {
+		try {
+			return mdxEditor.api.markdown.deserialize(content)
+		} catch (error) {
+			logger.warn(
+				"MDX parse failed while opening note, falling back to no-MDX:",
+				{
+					path,
+					error,
+				},
+			)
+		}
+
+		try {
+			return getOrCreateNoMdxEditor().api.markdown.deserialize(content)
+		} catch (error) {
+			logger.warn("No-MDX fallback parse failed while opening note:", {
+				path,
+				error,
+			})
+			return createFallbackValue()
+		}
+	}
+}

--- a/packages/editor/src/markdown/markdown-kit.test.ts
+++ b/packages/editor/src/markdown/markdown-kit.test.ts
@@ -1,7 +1,7 @@
 import { deserializeMd, serializeMd } from "@platejs/markdown"
 import { createSlateEditor, KEYS } from "platejs"
 import { describe, expect, it } from "vitest"
-import { MarkdownKit } from "./markdown-kit"
+import { MarkdownKit, MarkdownKitNoMdx } from "./markdown-kit"
 
 type LocalStorageLike = Pick<
 	Storage,
@@ -34,9 +34,9 @@ const ensureLocalStorage = () => {
 	globalThis.localStorage = localStorageShim as Storage
 }
 
-const createMarkdownEditor = () => {
+const createMarkdownEditor = ({ mdx = true }: { mdx?: boolean } = {}) => {
 	ensureLocalStorage()
-	return createSlateEditor({ plugins: MarkdownKit })
+	return createSlateEditor({ plugins: mdx ? MarkdownKit : MarkdownKitNoMdx })
 }
 
 const findNodeByType = (nodes: any[], type: string): any | null => {
@@ -264,5 +264,20 @@ describe("markdown-kit deserialization", () => {
 			environment: "equation",
 			texExpression: "E=mc^2",
 		})
+	})
+})
+
+describe("markdown-kit invalid mdx input", () => {
+	it("does not crash on invalid mdx when mdx mode is enabled", async () => {
+		const editor = createMarkdownEditor()
+		const value = deserializeMd(editor, "<callout icon={>Broken</callout>")
+		expect(extractText(value[0] as any)).toContain("Broken")
+	})
+
+	it("treats invalid mdx syntax as plain text when mdx mode is disabled", async () => {
+		const editor = createMarkdownEditor({ mdx: false })
+		const value = deserializeMd(editor, "<callout icon={>Broken</callout>")
+
+		expect(extractText(value[0] as any)).toContain("Broken")
 	})
 })

--- a/packages/editor/src/markdown/markdown-kit.ts
+++ b/packages/editor/src/markdown/markdown-kit.ts
@@ -162,14 +162,20 @@ function isEmptyParagraph(node: MdastNode | undefined): boolean {
 	})
 }
 
-export const MarkdownKit = [
+export type CreateMarkdownKitOptions = {
+	mdx?: boolean
+}
+
+export const createMarkdownKit = ({
+	mdx = true,
+}: CreateMarkdownKitOptions = {}) => [
 	MarkdownPlugin.configure({
 		options: {
 			disallowedNodes: [KEYS.slashCommand],
 			remarkPlugins: [
 				remarkMath,
 				remarkGfm,
-				remarkMdx,
+				...(mdx ? [remarkMdx] : []),
 				remarkMention,
 				remarkFrontmatter,
 				remarkWikiLink,
@@ -441,3 +447,6 @@ export const MarkdownKit = [
 		},
 	}),
 ]
+
+export const MarkdownKit = createMarkdownKit()
+export const MarkdownKitNoMdx = createMarkdownKit({ mdx: false })


### PR DESCRIPTION
## Summary
- add a markdown deserializer fallback that retries with non-MDX remark plugins when MDX parsing fails
- export MDX and non-MDX markdown kits from `@mdit/editor/markdown`
- wire desktop editor initialization to use the fallback deserializer for note loading
- add tests covering invalid MDX input in both MDX-enabled and MDX-disabled modes

## Testing
- pnpm -C packages/editor test
- pnpm ts:check:desktop