### PR TITLE
feat: improve workspace watch incremental updates

### DIFF
--- a/apps/desktop/src/store/workspace/actions/workspace-entry-actions.ts
+++ b/apps/desktop/src/store/workspace/actions/workspace-entry-actions.ts
@@ -210,6 +210,7 @@ export const createWorkspaceEntryActions = (
 					sourcePath,
 					destinationDirPath,
 					workspacePath,
+					newPath,
 				),
 			)
 

--- a/apps/desktop/src/store/workspace/actions/workspace-tree-actions.ts
+++ b/apps/desktop/src/store/workspace/actions/workspace-tree-actions.ts
@@ -4,17 +4,14 @@ import {
 	buildWorkspaceEntries,
 	findEntryByPath,
 } from "../helpers/entry-helpers"
-import {
-	syncExpandedDirectoriesWithEntries,
-	toggleExpandedDirectory,
-} from "../helpers/expanded-directories-helpers"
+import { toggleExpandedDirectory } from "../helpers/expanded-directories-helpers"
 import {
 	filterPinsForWorkspace,
-	filterPinsWithEntries,
 	normalizePinnedDirectoriesList,
 } from "../helpers/pinned-directories-helpers"
 import type { WorkspaceActionContext } from "../workspace-action-context"
 import type { WorkspaceSlice } from "../workspace-slice"
+import { syncWorkspaceTreeStateWithEntries } from "./workspace-tree-state-sync"
 
 export const createWorkspaceTreeActions = (
 	ctx: WorkspaceActionContext,
@@ -77,38 +74,10 @@ export const createWorkspaceTreeActions = (
 				return
 			}
 
-			const prevPinned = ctx.get().pinnedDirectories
-			const nextPinned = filterPinsWithEntries(
-				filterPinsForWorkspace(prevPinned, workspacePath),
-				entries,
-				workspacePath,
-			)
-			const pinsChanged = !areStringArraysEqual(prevPinned, nextPinned)
-
-			const syncedExpanded = syncExpandedDirectoriesWithEntries(
-				ctx.get().expandedDirectories,
-				entries,
-			)
-			const nextExpanded = syncedExpanded
-
-			ctx.get().updateEntries(entries)
-			ctx.set({
-				isTreeLoading: false,
-				expandedDirectories: syncedExpanded,
-				...(pinsChanged ? { pinnedDirectories: nextPinned } : {}),
+			await syncWorkspaceTreeStateWithEntries(ctx, workspacePath, entries, {
+				persistExpandedWhenUnchanged: true,
 			})
-
-			await ctx.deps.settingsRepository.persistExpandedDirectories(
-				workspacePath,
-				nextExpanded,
-			)
-
-			if (pinsChanged) {
-				await ctx.deps.settingsRepository.persistPinnedDirectories(
-					workspacePath,
-					nextPinned,
-				)
-			}
+			ctx.set({ isTreeLoading: false })
 		} catch (error) {
 			ctx.set({ isTreeLoading: false })
 			throw error

--- a/apps/desktop/src/store/workspace/actions/workspace-tree-reconcile.ts
+++ b/apps/desktop/src/store/workspace/actions/workspace-tree-reconcile.ts
@@ -1,0 +1,142 @@
+import { normalizePathSeparators } from "@/utils/path-utils"
+import { buildWorkspaceEntries } from "../helpers/entry-helpers"
+import type { WorkspaceActionContext } from "../workspace-action-context"
+import type { WorkspaceEntry } from "../workspace-state"
+import { syncWorkspaceTreeStateWithEntries } from "./workspace-tree-state-sync"
+
+const replaceMultipleDirectoryChildren = (
+	entries: WorkspaceEntry[],
+	workspacePath: string,
+	directoryChildrenByPath: ReadonlyMap<string, WorkspaceEntry[]>,
+): WorkspaceEntry[] => {
+	const normalizedWorkspacePath = normalizePathSeparators(workspacePath)
+	if (directoryChildrenByPath.size === 0) {
+		return entries
+	}
+
+	const normalizedDirectoryChildrenByPath = new Map<string, WorkspaceEntry[]>()
+	for (const [directoryPath, children] of directoryChildrenByPath) {
+		normalizedDirectoryChildrenByPath.set(
+			normalizePathSeparators(directoryPath),
+			children,
+		)
+	}
+
+	if (normalizedDirectoryChildrenByPath.has(normalizedWorkspacePath)) {
+		return normalizedDirectoryChildrenByPath.get(normalizedWorkspacePath) ?? []
+	}
+
+	const replaceInTree = (list: WorkspaceEntry[]): WorkspaceEntry[] => {
+		let changed = false
+
+		const updated = list.map((entry) => {
+			if (!entry.isDirectory || !entry.children) {
+				return entry
+			}
+
+			const normalizedEntryPath = normalizePathSeparators(entry.path)
+			if (normalizedDirectoryChildrenByPath.has(normalizedEntryPath)) {
+				changed = true
+				return {
+					...entry,
+					children:
+						normalizedDirectoryChildrenByPath.get(normalizedEntryPath) ?? [],
+				}
+			}
+
+			const updatedChildren = replaceInTree(entry.children)
+			if (updatedChildren !== entry.children) {
+				changed = true
+				return {
+					...entry,
+					children: updatedChildren,
+				}
+			}
+
+			return entry
+		})
+
+		return changed ? updated : list
+	}
+
+	return replaceInTree(entries)
+}
+
+export const replaceDirectoryChildren = (
+	entries: WorkspaceEntry[],
+	workspacePath: string,
+	directoryPath: string,
+	nextChildren: WorkspaceEntry[],
+): WorkspaceEntry[] => {
+	return replaceMultipleDirectoryChildren(
+		entries,
+		workspacePath,
+		new Map([[directoryPath, nextChildren]]),
+	)
+}
+
+export const refreshChangedWorkspaceDirectories = async (
+	ctx: WorkspaceActionContext,
+	workspacePath: string,
+	directoryPaths: string[],
+) => {
+	if (directoryPaths.length === 0) {
+		return
+	}
+
+	const directorySnapshots = await Promise.all(
+		directoryPaths.map(async (directoryPath) => ({
+			directoryPath,
+			children: await buildWorkspaceEntries(
+				directoryPath,
+				ctx.deps.fileSystemRepository,
+			),
+		})),
+	)
+
+	if (ctx.get().workspacePath !== workspacePath) {
+		return
+	}
+
+	const nextEntries = replaceMultipleDirectoryChildren(
+		ctx.get().entries,
+		workspacePath,
+		new Map(
+			directorySnapshots.map(({ directoryPath, children }) => [
+				directoryPath,
+				children,
+			]),
+		),
+	)
+
+	await syncWorkspaceTreeStateWithEntries(ctx, workspacePath, nextEntries)
+}
+
+export const reconcileWorkspaceTreeFromFallback = async (
+	ctx: WorkspaceActionContext,
+	input: {
+		workspacePath: string
+		fallbackDirectoryPaths: string[]
+		requiresFullRefresh: boolean
+	},
+) => {
+	if (input.requiresFullRefresh) {
+		await ctx.get().refreshWorkspaceEntries()
+		return
+	}
+
+	if (input.fallbackDirectoryPaths.length === 0) {
+		return
+	}
+
+	try {
+		await refreshChangedWorkspaceDirectories(
+			ctx,
+			input.workspacePath,
+			input.fallbackDirectoryPaths,
+		)
+	} catch (error) {
+		console.warn("Failed to reconcile workspace tree from fallback:", error)
+		await ctx.get().refreshWorkspaceEntries()
+	}
+}

--- a/apps/desktop/src/store/workspace/actions/workspace-tree-state-sync.ts
+++ b/apps/desktop/src/store/workspace/actions/workspace-tree-state-sync.ts
@@ -1,0 +1,59 @@
+import { areStringArraysEqual } from "@/utils/array-utils"
+import { syncExpandedDirectoriesWithEntries } from "../helpers/expanded-directories-helpers"
+import {
+	filterPinsForWorkspace,
+	filterPinsWithEntries,
+} from "../helpers/pinned-directories-helpers"
+import type { WorkspaceActionContext } from "../workspace-action-context"
+import type { WorkspaceEntry } from "../workspace-state"
+
+type SyncWorkspaceTreeStateOptions = {
+	persistExpandedWhenUnchanged?: boolean
+}
+
+export const syncWorkspaceTreeStateWithEntries = async (
+	ctx: WorkspaceActionContext,
+	workspacePath: string,
+	nextEntries: WorkspaceEntry[],
+	options?: SyncWorkspaceTreeStateOptions,
+) => {
+	const state = ctx.get()
+	const previousExpanded = state.expandedDirectories
+	const previousPinned = state.pinnedDirectories
+
+	const nextExpanded = syncExpandedDirectoriesWithEntries(
+		previousExpanded,
+		nextEntries,
+	)
+	const nextPinned = filterPinsWithEntries(
+		filterPinsForWorkspace(previousPinned, workspacePath),
+		nextEntries,
+		workspacePath,
+	)
+
+	const expandedChanged = !areStringArraysEqual(previousExpanded, nextExpanded)
+	const pinnedChanged = !areStringArraysEqual(previousPinned, nextPinned)
+
+	state.updateEntries(nextEntries)
+
+	if (expandedChanged || pinnedChanged) {
+		ctx.set({
+			...(expandedChanged ? { expandedDirectories: nextExpanded } : {}),
+			...(pinnedChanged ? { pinnedDirectories: nextPinned } : {}),
+		})
+	}
+
+	if (expandedChanged || options?.persistExpandedWhenUnchanged) {
+		await ctx.deps.settingsRepository.persistExpandedDirectories(
+			workspacePath,
+			nextExpanded,
+		)
+	}
+
+	if (pinnedChanged) {
+		await ctx.deps.settingsRepository.persistPinnedDirectories(
+			workspacePath,
+			nextPinned,
+		)
+	}
+}

--- a/apps/desktop/src/store/workspace/helpers/entry-helpers.test.ts
+++ b/apps/desktop/src/store/workspace/helpers/entry-helpers.test.ts
@@ -389,6 +389,25 @@ describe("moveEntryInState", () => {
 		expect(moved?.isDirectory).toBe(false)
 	})
 
+	it("uses explicit newPath for move+rename", () => {
+		const entries: WorkspaceEntry[] = [
+			makeDir("/docs", "docs", [makeFile("/docs/old.md", "old.md")]),
+			makeDir("/archive", "archive", []),
+		]
+
+		const result = moveEntryInState(
+			entries,
+			"/docs/old.md",
+			"/archive",
+			"/",
+			"/archive/new.md",
+		)
+
+		expect(findEntryByPath(result, "/docs/old.md")).toBeNull()
+		const moved = findEntryByPath(result, "/archive/new.md")
+		expect(moved?.name).toBe("new.md")
+	})
+
 	it("moves directories to workspace root and rewrites child paths", () => {
 		const entries: WorkspaceEntry[] = [
 			makeDir("/subdir", "subdir", [
@@ -410,6 +429,16 @@ describe("moveEntryInState", () => {
 		expect(moved?.isDirectory).toBe(true)
 		expect(moved?.children?.[0].path).toBe("/source/note.md")
 		expect(moved?.children?.[1].path).toBe("/source/other.md")
+	})
+
+	it("returns original entries when destination directory is missing", () => {
+		const entries: WorkspaceEntry[] = [
+			makeDir("/docs", "docs", [makeFile("/docs/a.md", "a.md")]),
+		]
+
+		const result = moveEntryInState(entries, "/docs/a.md", "/missing")
+
+		expect(result).toEqual(entries)
 	})
 })
 

--- a/apps/desktop/src/store/workspace/helpers/entry-helpers.ts
+++ b/apps/desktop/src/store/workspace/helpers/entry-helpers.ts
@@ -342,6 +342,7 @@ export function moveEntryInState(
 	sourcePath: string,
 	destinationPath: string,
 	workspacePath?: string,
+	newPath?: string,
 ): WorkspaceEntry[] {
 	// Find the entry to move
 	const entryToMove = findEntryByPath(entries, sourcePath)
@@ -353,23 +354,24 @@ export function moveEntryInState(
 	const filteredEntries = removeEntryFromState(entries, sourcePath)
 
 	// Update paths if it's a directory
-	const fileName = getFileNameFromPath(sourcePath)
 	const normalizedDestinationPath = normalizePathSeparators(destinationPath)
 	// Handle root path construction: avoid double slashes
-	const newPath =
+	const computedNewPath =
 		normalizedDestinationPath === "/" || normalizedDestinationPath === ""
-			? `/${fileName}`
-			: `${normalizedDestinationPath}/${fileName}`
+			? `/${getFileNameFromPath(sourcePath)}`
+			: `${normalizedDestinationPath}/${getFileNameFromPath(sourcePath)}`
+	const targetPath = normalizePathSeparators(newPath ?? computedNewPath)
+	const targetName = getFileNameFromPath(targetPath)
 
 	let updatedEntryToMove: WorkspaceEntry
 	if (entryToMove.isDirectory) {
 		updatedEntryToMove = {
-			path: newPath,
-			name: entryToMove.name,
+			path: targetPath,
+			name: targetName,
 			isDirectory: true,
 			children: entryToMove.children
 				? entryToMove.children.map((child: WorkspaceEntry) =>
-						updateChildPathsForMove(child, sourcePath, newPath),
+						updateChildPathsForMove(child, sourcePath, targetPath),
 					)
 				: EMPTY_CHILDREN,
 			createdAt: entryToMove.createdAt,
@@ -377,8 +379,8 @@ export function moveEntryInState(
 		}
 	} else {
 		updatedEntryToMove = {
-			path: newPath,
-			name: entryToMove.name,
+			path: targetPath,
+			name: targetName,
 			isDirectory: false,
 			children: undefined,
 			createdAt: entryToMove.createdAt,
@@ -399,12 +401,14 @@ export function moveEntryInState(
 	}
 
 	// Add entry to destination subdirectory
+	let inserted = false
 	const addToDestination = (
 		entryList: WorkspaceEntry[],
 		targetPath: string,
 	): WorkspaceEntry[] => {
 		return entryList.map((entry) => {
 			if (entry.path === targetPath && entry.isDirectory) {
+				inserted = true
 				const updatedChildren = entry.children
 					? [...entry.children, updatedEntryToMove]
 					: [updatedEntryToMove]
@@ -423,7 +427,8 @@ export function moveEntryInState(
 		})
 	}
 
-	return addToDestination(filteredEntries, destinationPath)
+	const movedEntries = addToDestination(filteredEntries, destinationPath)
+	return inserted ? movedEntries : entries
 }
 
 export function updateEntryMetadata(

--- a/apps/desktop/src/store/workspace/watch/actions.test.ts
+++ b/apps/desktop/src/store/workspace/watch/actions.test.ts
@@ -29,6 +29,7 @@ describe("watch/actions", () => {
 	const flushQueue = async () => {
 		await Promise.resolve()
 		await Promise.resolve()
+		await new Promise((resolve) => setTimeout(resolve, 0))
 	}
 
 	it("unwatchWorkspace runs unwatch function and clears state", () => {
@@ -140,7 +141,464 @@ describe("watch/actions", () => {
 		expect(getState().refreshWorkspaceEntries).not.toHaveBeenCalled()
 	})
 
-	it("applies only external paths for mixed non-rescan batches", async () => {
+	it("applies file create as entryCreated for external watch changes", async () => {
+		const { context, setState, originJournal, deps, getState } =
+			createWorkspaceActionTestContext()
+		const actions = createWorkspaceWatchActions(context)
+		setState({
+			workspacePath: "/ws",
+			entries: [
+				{
+					path: "/ws/docs",
+					name: "docs",
+					isDirectory: true,
+					children: [],
+				},
+			],
+		})
+
+		listenMock.mockImplementation(() => Promise.resolve(vi.fn()))
+		originJournal.resolve.mockReturnValue({
+			externalRelPaths: ["docs/created.md"],
+			localRelPaths: [],
+		})
+		deps.fileSystemRepository.stat.mockResolvedValueOnce({
+			isDirectory: false,
+			birthtime: 1000,
+			mtime: 2000,
+		})
+
+		await actions.watchWorkspace()
+		const listener = listenMock.mock.calls[0]?.[1] as (event: any) => void
+		listener({
+			payload: {
+				workspacePath: "/ws",
+				batch: {
+					seq: 2,
+					changes: [
+						{
+							type: "created",
+							relPath: "docs/created.md",
+							entryKind: "file",
+						},
+					],
+					rescan: false,
+					emittedAtUnixMs: 1001,
+				},
+			},
+		})
+		await flushQueue()
+
+		expect(getState().entryCreated).toHaveBeenCalledWith({
+			parentPath: "/ws/docs",
+			entry: expect.objectContaining({
+				path: "/ws/docs/created.md",
+				name: "created.md",
+				isDirectory: false,
+			}),
+		})
+		expect(deps.fileSystemRepository.readDir).not.toHaveBeenCalled()
+		expect(getState().refreshWorkspaceEntries).not.toHaveBeenCalled()
+	})
+
+	it("applies directory create as entryCreated with snapshot children", async () => {
+		const { context, setState, originJournal, deps, getState } =
+			createWorkspaceActionTestContext()
+		const actions = createWorkspaceWatchActions(context)
+		setState({
+			workspacePath: "/ws",
+			entries: [
+				{
+					path: "/ws/docs",
+					name: "docs",
+					isDirectory: true,
+					children: [],
+				},
+			],
+		})
+
+		listenMock.mockImplementation(() => Promise.resolve(vi.fn()))
+		originJournal.resolve.mockReturnValue({
+			externalRelPaths: ["docs/new-dir"],
+			localRelPaths: [],
+		})
+		deps.fileSystemRepository.readDir.mockImplementation(
+			async (path: string) => {
+				if (path === "/ws/docs/new-dir") {
+					return [{ name: "note.md", isDirectory: false }]
+				}
+				return []
+			},
+		)
+		deps.fileSystemRepository.stat.mockImplementation(async (path: string) => {
+			if (path === "/ws/docs/new-dir") {
+				return { isDirectory: true, birthtime: 1100, mtime: 2100 }
+			}
+			if (path === "/ws/docs/new-dir/note.md") {
+				return { isDirectory: false, birthtime: 1200, mtime: 2200 }
+			}
+			return { isDirectory: false, birthtime: undefined, mtime: undefined }
+		})
+
+		await actions.watchWorkspace()
+		const listener = listenMock.mock.calls[0]?.[1] as (event: any) => void
+		listener({
+			payload: {
+				workspacePath: "/ws",
+				batch: {
+					seq: 3,
+					changes: [
+						{
+							type: "created",
+							relPath: "docs/new-dir",
+							entryKind: "directory",
+						},
+					],
+					rescan: false,
+					emittedAtUnixMs: 1002,
+				},
+			},
+		})
+		await flushQueue()
+
+		expect(getState().entryCreated).toHaveBeenCalledWith({
+			parentPath: "/ws/docs",
+			entry: expect.objectContaining({
+				path: "/ws/docs/new-dir",
+				name: "new-dir",
+				isDirectory: true,
+				children: [
+					expect.objectContaining({
+						path: "/ws/docs/new-dir/note.md",
+						name: "note.md",
+						isDirectory: false,
+					}),
+				],
+			}),
+		})
+		expect(getState().refreshWorkspaceEntries).not.toHaveBeenCalled()
+	})
+
+	it("applies deleted entries via entriesDeleted", async () => {
+		const { context, setState, originJournal, getState } =
+			createWorkspaceActionTestContext()
+		const actions = createWorkspaceWatchActions(context)
+		setState({ workspacePath: "/ws" })
+
+		listenMock.mockImplementation(() => Promise.resolve(vi.fn()))
+		originJournal.resolve.mockReturnValue({
+			externalRelPaths: ["docs/deleted.md"],
+			localRelPaths: [],
+		})
+
+		await actions.watchWorkspace()
+		const listener = listenMock.mock.calls[0]?.[1] as (event: any) => void
+		listener({
+			payload: {
+				workspacePath: "/ws",
+				batch: {
+					seq: 4,
+					changes: [
+						{
+							type: "deleted",
+							relPath: "docs/deleted.md",
+							entryKind: "file",
+						},
+					],
+					rescan: false,
+					emittedAtUnixMs: 1003,
+				},
+			},
+		})
+		await flushQueue()
+
+		expect(getState().entriesDeleted).toHaveBeenCalledWith({
+			paths: ["/ws/docs/deleted.md"],
+		})
+	})
+
+	it("applies deleted directories via entriesDeleted", async () => {
+		const { context, setState, originJournal, getState } =
+			createWorkspaceActionTestContext()
+		const actions = createWorkspaceWatchActions(context)
+		setState({ workspacePath: "/ws" })
+
+		listenMock.mockImplementation(() => Promise.resolve(vi.fn()))
+		originJournal.resolve.mockReturnValue({
+			externalRelPaths: ["docs"],
+			localRelPaths: [],
+		})
+
+		await actions.watchWorkspace()
+		const listener = listenMock.mock.calls[0]?.[1] as (event: any) => void
+		listener({
+			payload: {
+				workspacePath: "/ws",
+				batch: {
+					seq: 5,
+					changes: [
+						{
+							type: "deleted",
+							relPath: "docs",
+							entryKind: "directory",
+						},
+					],
+					rescan: false,
+					emittedAtUnixMs: 1004,
+				},
+			},
+		})
+		await flushQueue()
+
+		expect(getState().entriesDeleted).toHaveBeenCalledWith({
+			paths: ["/ws/docs"],
+		})
+	})
+
+	it("maps same-parent move to entryRenamed", async () => {
+		const { context, setState, originJournal, getState } =
+			createWorkspaceActionTestContext()
+		const actions = createWorkspaceWatchActions(context)
+		setState({
+			workspacePath: "/ws",
+			entries: [
+				{
+					path: "/ws/docs",
+					name: "docs",
+					isDirectory: true,
+					children: [
+						{
+							path: "/ws/docs/old.md",
+							name: "old.md",
+							isDirectory: false,
+						},
+					],
+				},
+			],
+		})
+
+		listenMock.mockImplementation(() => Promise.resolve(vi.fn()))
+		originJournal.resolve.mockReturnValue({
+			externalRelPaths: ["docs/old.md", "docs/new.md"],
+			localRelPaths: [],
+		})
+
+		await actions.watchWorkspace()
+		const listener = listenMock.mock.calls[0]?.[1] as (event: any) => void
+		listener({
+			payload: {
+				workspacePath: "/ws",
+				batch: {
+					seq: 6,
+					changes: [
+						{
+							type: "moved",
+							fromRel: "docs/old.md",
+							toRel: "docs/new.md",
+							entryKind: "file",
+						},
+					],
+					rescan: false,
+					emittedAtUnixMs: 1005,
+				},
+			},
+		})
+		await flushQueue()
+
+		expect(getState().entryRenamed).toHaveBeenCalledWith({
+			oldPath: "/ws/docs/old.md",
+			newPath: "/ws/docs/new.md",
+			newName: "new.md",
+			isDirectory: false,
+		})
+		expect(getState().entryMoved).not.toHaveBeenCalled()
+	})
+
+	it("maps cross-parent move to entryMoved and preserves newPath", async () => {
+		const { context, setState, originJournal, getState } =
+			createWorkspaceActionTestContext()
+		const actions = createWorkspaceWatchActions(context)
+		setState({
+			workspacePath: "/ws",
+			entries: [
+				{
+					path: "/ws/docs",
+					name: "docs",
+					isDirectory: true,
+					children: [
+						{
+							path: "/ws/docs/old.md",
+							name: "old.md",
+							isDirectory: false,
+						},
+					],
+				},
+				{
+					path: "/ws/archive",
+					name: "archive",
+					isDirectory: true,
+					children: [],
+				},
+			],
+		})
+
+		listenMock.mockImplementation(() => Promise.resolve(vi.fn()))
+		originJournal.resolve.mockReturnValue({
+			externalRelPaths: ["docs/old.md", "archive/renamed.md"],
+			localRelPaths: [],
+		})
+
+		await actions.watchWorkspace()
+		const listener = listenMock.mock.calls[0]?.[1] as (event: any) => void
+		listener({
+			payload: {
+				workspacePath: "/ws",
+				batch: {
+					seq: 7,
+					changes: [
+						{
+							type: "moved",
+							fromRel: "docs/old.md",
+							toRel: "archive/renamed.md",
+							entryKind: "file",
+						},
+					],
+					rescan: false,
+					emittedAtUnixMs: 1006,
+				},
+			},
+		})
+		await flushQueue()
+
+		expect(getState().entryMoved).toHaveBeenCalledWith({
+			sourcePath: "/ws/docs/old.md",
+			destinationDirPath: "/ws/archive",
+			newPath: "/ws/archive/renamed.md",
+			isDirectory: false,
+		})
+		expect(getState().entryRenamed).not.toHaveBeenCalled()
+	})
+
+	it("maps cross-parent directory move+rename to entryMoved", async () => {
+		const { context, setState, originJournal, getState } =
+			createWorkspaceActionTestContext()
+		const actions = createWorkspaceWatchActions(context)
+		setState({
+			workspacePath: "/ws",
+			entries: [
+				{
+					path: "/ws/docs",
+					name: "docs",
+					isDirectory: true,
+					children: [
+						{
+							path: "/ws/docs/folder",
+							name: "folder",
+							isDirectory: true,
+							children: [],
+						},
+					],
+				},
+				{
+					path: "/ws/archive",
+					name: "archive",
+					isDirectory: true,
+					children: [],
+				},
+			],
+		})
+
+		listenMock.mockImplementation(() => Promise.resolve(vi.fn()))
+		originJournal.resolve.mockReturnValue({
+			externalRelPaths: ["docs/folder", "archive/folder-renamed"],
+			localRelPaths: [],
+		})
+
+		await actions.watchWorkspace()
+		const listener = listenMock.mock.calls[0]?.[1] as (event: any) => void
+		listener({
+			payload: {
+				workspacePath: "/ws",
+				batch: {
+					seq: 8,
+					changes: [
+						{
+							type: "moved",
+							fromRel: "docs/folder",
+							toRel: "archive/folder-renamed",
+							entryKind: "directory",
+						},
+					],
+					rescan: false,
+					emittedAtUnixMs: 1007,
+				},
+			},
+		})
+		await flushQueue()
+
+		expect(getState().entryMoved).toHaveBeenCalledWith({
+			sourcePath: "/ws/docs/folder",
+			destinationDirPath: "/ws/archive",
+			newPath: "/ws/archive/folder-renamed",
+			isDirectory: true,
+		})
+	})
+
+	it("updates modified file metadata incrementally", async () => {
+		const { context, setState, originJournal, getState } =
+			createWorkspaceActionTestContext()
+		const actions = createWorkspaceWatchActions(context)
+		setState({
+			workspacePath: "/ws",
+			entries: [
+				{
+					path: "/ws/docs",
+					name: "docs",
+					isDirectory: true,
+					children: [
+						{
+							path: "/ws/docs/a.md",
+							name: "a.md",
+							isDirectory: false,
+						},
+					],
+				},
+			],
+		})
+
+		listenMock.mockImplementation(() => Promise.resolve(vi.fn()))
+		originJournal.resolve.mockReturnValue({
+			externalRelPaths: ["docs/a.md"],
+			localRelPaths: [],
+		})
+
+		await actions.watchWorkspace()
+		const listener = listenMock.mock.calls[0]?.[1] as (event: any) => void
+		listener({
+			payload: {
+				workspacePath: "/ws",
+				batch: {
+					seq: 9,
+					changes: [
+						{
+							type: "modified",
+							relPath: "docs/a.md",
+							entryKind: "file",
+						},
+					],
+					rescan: false,
+					emittedAtUnixMs: 1008,
+				},
+			},
+		})
+		await flushQueue()
+
+		expect(getState().updateEntryModifiedDate).toHaveBeenCalledWith(
+			"/ws/docs/a.md",
+		)
+	})
+
+	it("falls back to partial directory refresh for modified directories", async () => {
 		const { context, setState, originJournal, deps } =
 			createWorkspaceActionTestContext()
 		const actions = createWorkspaceWatchActions(context)
@@ -158,8 +616,8 @@ describe("watch/actions", () => {
 
 		listenMock.mockImplementation(() => Promise.resolve(vi.fn()))
 		originJournal.resolve.mockReturnValue({
-			externalRelPaths: ["docs/external.md"],
-			localRelPaths: ["docs/local.md"],
+			externalRelPaths: ["docs"],
+			localRelPaths: [],
 		})
 
 		await actions.watchWorkspace()
@@ -168,27 +626,78 @@ describe("watch/actions", () => {
 			payload: {
 				workspacePath: "/ws",
 				batch: {
-					seq: 2,
+					seq: 10,
 					changes: [
 						{
-							type: "created",
-							relPath: "docs/local.md",
-							entryKind: "file",
-						},
-						{
-							type: "created",
-							relPath: "docs/external.md",
-							entryKind: "file",
+							type: "modified",
+							relPath: "docs",
+							entryKind: "directory",
 						},
 					],
 					rescan: false,
-					emittedAtUnixMs: 1001,
+					emittedAtUnixMs: 1009,
 				},
 			},
 		})
 		await flushQueue()
 
 		expect(deps.fileSystemRepository.readDir).toHaveBeenCalledWith("/ws/docs")
+	})
+
+	it("falls back to parent directory refresh when move source is missing", async () => {
+		const { context, setState, originJournal, deps } =
+			createWorkspaceActionTestContext()
+		const actions = createWorkspaceWatchActions(context)
+		setState({
+			workspacePath: "/ws",
+			entries: [
+				{
+					path: "/ws/docs",
+					name: "docs",
+					isDirectory: true,
+					children: [],
+				},
+				{
+					path: "/ws/archive",
+					name: "archive",
+					isDirectory: true,
+					children: [],
+				},
+			],
+		})
+
+		listenMock.mockImplementation(() => Promise.resolve(vi.fn()))
+		originJournal.resolve.mockReturnValue({
+			externalRelPaths: ["docs/missing.md", "archive/missing.md"],
+			localRelPaths: [],
+		})
+
+		await actions.watchWorkspace()
+		const listener = listenMock.mock.calls[0]?.[1] as (event: any) => void
+		listener({
+			payload: {
+				workspacePath: "/ws",
+				batch: {
+					seq: 11,
+					changes: [
+						{
+							type: "moved",
+							fromRel: "docs/missing.md",
+							toRel: "archive/missing.md",
+							entryKind: "file",
+						},
+					],
+					rescan: false,
+					emittedAtUnixMs: 1010,
+				},
+			},
+		})
+		await flushQueue()
+
+		expect(deps.fileSystemRepository.readDir).toHaveBeenCalledWith("/ws/docs")
+		expect(deps.fileSystemRepository.readDir).toHaveBeenCalledWith(
+			"/ws/archive",
+		)
 	})
 
 	it("always refreshes on rescan batches without origin filtering", async () => {
@@ -215,6 +724,55 @@ describe("watch/actions", () => {
 		await flushQueue()
 
 		expect(originJournal.resolve).not.toHaveBeenCalled()
+		expect(getState().refreshWorkspaceEntries).toHaveBeenCalledTimes(1)
+	})
+
+	it("falls back to full refresh when partial fallback refresh fails", async () => {
+		const { context, setState, originJournal, getState } =
+			createWorkspaceActionTestContext()
+		const actions = createWorkspaceWatchActions(context)
+		setState({
+			workspacePath: "/ws",
+			entries: [
+				{
+					path: "/ws/docs",
+					name: "docs",
+					isDirectory: true,
+					children: [],
+				},
+			],
+			updateEntries: vi.fn(() => {
+				throw new Error("update failed")
+			}),
+		})
+
+		listenMock.mockImplementation(() => Promise.resolve(vi.fn()))
+		originJournal.resolve.mockReturnValue({
+			externalRelPaths: ["docs"],
+			localRelPaths: [],
+		})
+
+		await actions.watchWorkspace()
+		const listener = listenMock.mock.calls[0]?.[1] as (event: any) => void
+		listener({
+			payload: {
+				workspacePath: "/ws",
+				batch: {
+					seq: 12,
+					changes: [
+						{
+							type: "modified",
+							relPath: "docs",
+							entryKind: "directory",
+						},
+					],
+					rescan: false,
+					emittedAtUnixMs: 1011,
+				},
+			},
+		})
+		await flushQueue()
+
 		expect(getState().refreshWorkspaceEntries).toHaveBeenCalledTimes(1)
 	})
 

--- a/apps/desktop/src/store/workspace/watch/batch-apply.ts
+++ b/apps/desktop/src/store/workspace/watch/batch-apply.ts
@@ -1,0 +1,375 @@
+import { dirname, resolve } from "pathe"
+import {
+	getFileNameFromPath,
+	isPathEqualOrDescendant,
+	normalizePathSeparators,
+} from "@/utils/path-utils"
+import {
+	buildWorkspaceEntries,
+	findEntryByPath,
+	findParentDirectory,
+} from "../helpers/entry-helpers"
+import type { WorkspaceActionContext } from "../workspace-action-context"
+import type { WorkspaceEntry } from "../workspace-state"
+import { collapseDirectoryPaths } from "./tree-patch"
+import type { VaultWatchChange } from "./types"
+
+export type ApplyWatchBatchChangesInput = {
+	workspacePath: string
+	changes: VaultWatchChange[]
+	externalRelPaths: string[]
+}
+
+export type ApplyWatchBatchChangesResult = {
+	fallbackDirectoryPaths: string[]
+	requiresFullRefresh: boolean
+}
+
+const isExternalChange = (
+	change: VaultWatchChange,
+	externalRelPathSet: ReadonlySet<string>,
+): boolean => {
+	if (change.type === "moved") {
+		return (
+			externalRelPathSet.has(normalizePathSeparators(change.fromRel)) ||
+			externalRelPathSet.has(normalizePathSeparators(change.toRel))
+		)
+	}
+
+	return externalRelPathSet.has(normalizePathSeparators(change.relPath))
+}
+
+const toAbsolutePath = (
+	workspacePath: string,
+	normalizedWorkspacePath: string,
+	relPath: string,
+): string | null => {
+	const absolutePath = normalizePathSeparators(resolve(workspacePath, relPath))
+	return isPathEqualOrDescendant(absolutePath, normalizedWorkspacePath)
+		? absolutePath
+		: null
+}
+
+const addFallbackDirectoryPath = (
+	fallbackDirectoryPaths: Set<string>,
+	normalizedWorkspacePath: string,
+	directoryPath: string,
+): boolean => {
+	const normalizedDirectoryPath = normalizePathSeparators(directoryPath)
+	if (
+		!isPathEqualOrDescendant(normalizedDirectoryPath, normalizedWorkspacePath)
+	) {
+		return false
+	}
+
+	fallbackDirectoryPaths.add(normalizedDirectoryPath)
+	return true
+}
+
+const addFallbackParentDirectoryPath = (
+	fallbackDirectoryPaths: Set<string>,
+	normalizedWorkspacePath: string,
+	path: string,
+): boolean =>
+	addFallbackDirectoryPath(
+		fallbackDirectoryPaths,
+		normalizedWorkspacePath,
+		dirname(path),
+	)
+
+const buildCreatedEntrySnapshot = async (
+	ctx: WorkspaceActionContext,
+	path: string,
+	isDirectory: boolean,
+): Promise<WorkspaceEntry> => {
+	const metadata = await ctx.deps.fileSystemRepository.stat(path)
+	const createdAt = metadata.birthtime
+		? new Date(metadata.birthtime)
+		: undefined
+	const modifiedAt = metadata.mtime ? new Date(metadata.mtime) : undefined
+
+	if (isDirectory) {
+		return {
+			path,
+			name: getFileNameFromPath(path),
+			isDirectory: true,
+			children: await buildWorkspaceEntries(
+				path,
+				ctx.deps.fileSystemRepository,
+			),
+			createdAt,
+			modifiedAt,
+		}
+	}
+
+	return {
+		path,
+		name: getFileNameFromPath(path),
+		isDirectory: false,
+		children: undefined,
+		createdAt,
+		modifiedAt,
+	}
+}
+
+const hasDirectoryInEntries = (
+	ctx: WorkspaceActionContext,
+	workspacePath: string,
+	path: string,
+): boolean => {
+	if (path === workspacePath) {
+		return true
+	}
+
+	return Boolean(findParentDirectory(ctx.get().entries, path))
+}
+
+const addBothParentFallbacks = (
+	fallbackDirectoryPaths: Set<string>,
+	normalizedWorkspacePath: string,
+	fromPath: string,
+	toPath: string,
+): boolean => {
+	const addedFrom = addFallbackParentDirectoryPath(
+		fallbackDirectoryPaths,
+		normalizedWorkspacePath,
+		fromPath,
+	)
+	const addedTo = addFallbackParentDirectoryPath(
+		fallbackDirectoryPaths,
+		normalizedWorkspacePath,
+		toPath,
+	)
+
+	return addedFrom || addedTo
+}
+
+export const applyWatchBatchChanges = async (
+	ctx: WorkspaceActionContext,
+	input: ApplyWatchBatchChangesInput,
+): Promise<ApplyWatchBatchChangesResult> => {
+	const normalizedWorkspacePath = normalizePathSeparators(input.workspacePath)
+	const externalRelPathSet = new Set(
+		input.externalRelPaths.map((path) => normalizePathSeparators(path)),
+	)
+	const fallbackDirectoryPaths = new Set<string>()
+	let requiresFullRefresh = false
+
+	for (const change of input.changes) {
+		if (!isExternalChange(change, externalRelPathSet)) {
+			continue
+		}
+
+		if (change.type === "moved") {
+			const fromPath = toAbsolutePath(
+				input.workspacePath,
+				normalizedWorkspacePath,
+				change.fromRel,
+			)
+			const toPath = toAbsolutePath(
+				input.workspacePath,
+				normalizedWorkspacePath,
+				change.toRel,
+			)
+			if (!fromPath || !toPath) {
+				requiresFullRefresh = true
+				continue
+			}
+
+			const sourceEntry = findEntryByPath(ctx.get().entries, fromPath)
+			if (!sourceEntry) {
+				if (
+					!addBothParentFallbacks(
+						fallbackDirectoryPaths,
+						normalizedWorkspacePath,
+						fromPath,
+						toPath,
+					)
+				) {
+					requiresFullRefresh = true
+				}
+				continue
+			}
+
+			const fromParentPath = normalizePathSeparators(dirname(fromPath))
+			const toParentPath = normalizePathSeparators(dirname(toPath))
+			const isDirectory = change.entryKind === "directory"
+
+			if (fromParentPath === toParentPath) {
+				try {
+					await ctx.get().entryRenamed({
+						oldPath: fromPath,
+						newPath: toPath,
+						isDirectory,
+						newName: getFileNameFromPath(toPath),
+					})
+				} catch {
+					if (
+						!addBothParentFallbacks(
+							fallbackDirectoryPaths,
+							normalizedWorkspacePath,
+							fromPath,
+							toPath,
+						)
+					) {
+						requiresFullRefresh = true
+					}
+				}
+				continue
+			}
+
+			if (!hasDirectoryInEntries(ctx, normalizedWorkspacePath, toParentPath)) {
+				if (
+					!addBothParentFallbacks(
+						fallbackDirectoryPaths,
+						normalizedWorkspacePath,
+						fromPath,
+						toPath,
+					)
+				) {
+					requiresFullRefresh = true
+				}
+				continue
+			}
+
+			try {
+				await ctx.get().entryMoved({
+					sourcePath: fromPath,
+					destinationDirPath: toParentPath,
+					newPath: toPath,
+					isDirectory,
+				})
+			} catch {
+				if (
+					!addBothParentFallbacks(
+						fallbackDirectoryPaths,
+						normalizedWorkspacePath,
+						fromPath,
+						toPath,
+					)
+				) {
+					requiresFullRefresh = true
+				}
+			}
+			continue
+		}
+
+		const absolutePath = toAbsolutePath(
+			input.workspacePath,
+			normalizedWorkspacePath,
+			change.relPath,
+		)
+		if (!absolutePath) {
+			requiresFullRefresh = true
+			continue
+		}
+
+		if (change.type === "deleted") {
+			try {
+				await ctx.get().entriesDeleted({ paths: [absolutePath] })
+			} catch {
+				if (
+					!addFallbackParentDirectoryPath(
+						fallbackDirectoryPaths,
+						normalizedWorkspacePath,
+						absolutePath,
+					)
+				) {
+					requiresFullRefresh = true
+				}
+			}
+			continue
+		}
+
+		if (change.type === "modified") {
+			if (change.entryKind === "directory") {
+				if (
+					!addFallbackDirectoryPath(
+						fallbackDirectoryPaths,
+						normalizedWorkspacePath,
+						absolutePath,
+					)
+				) {
+					requiresFullRefresh = true
+				}
+				continue
+			}
+
+			if (!findEntryByPath(ctx.get().entries, absolutePath)) {
+				if (
+					!addFallbackParentDirectoryPath(
+						fallbackDirectoryPaths,
+						normalizedWorkspacePath,
+						absolutePath,
+					)
+				) {
+					requiresFullRefresh = true
+				}
+				continue
+			}
+
+			try {
+				await ctx.get().updateEntryModifiedDate(absolutePath)
+			} catch {
+				if (
+					!addFallbackParentDirectoryPath(
+						fallbackDirectoryPaths,
+						normalizedWorkspacePath,
+						absolutePath,
+					)
+				) {
+					requiresFullRefresh = true
+				}
+			}
+			continue
+		}
+
+		const parentPath = normalizePathSeparators(dirname(absolutePath))
+		if (!hasDirectoryInEntries(ctx, normalizedWorkspacePath, parentPath)) {
+			if (
+				!addFallbackDirectoryPath(
+					fallbackDirectoryPaths,
+					normalizedWorkspacePath,
+					parentPath,
+				)
+			) {
+				requiresFullRefresh = true
+			}
+			continue
+		}
+
+		if (findEntryByPath(ctx.get().entries, absolutePath)) {
+			continue
+		}
+
+		try {
+			const entry = await buildCreatedEntrySnapshot(
+				ctx,
+				absolutePath,
+				change.entryKind === "directory",
+			)
+			await ctx.get().entryCreated({
+				parentPath,
+				entry,
+			})
+		} catch {
+			if (
+				!addFallbackDirectoryPath(
+					fallbackDirectoryPaths,
+					normalizedWorkspacePath,
+					parentPath,
+				)
+			) {
+				requiresFullRefresh = true
+			}
+		}
+	}
+
+	return {
+		fallbackDirectoryPaths: collapseDirectoryPaths(
+			normalizedWorkspacePath,
+			Array.from(fallbackDirectoryPaths),
+		),
+		requiresFullRefresh,
+	}
+}

--- a/apps/desktop/src/store/workspace/watch/batch-refresh.ts
+++ b/apps/desktop/src/store/workspace/watch/batch-refresh.ts
@@ -1,9 +1,7 @@
 import { hasHiddenEntryInPaths } from "@/utils/path-utils"
+import { reconcileWorkspaceTreeFromFallback } from "../actions/workspace-tree-reconcile"
 import type { WorkspaceActionContext } from "../workspace-action-context"
-import {
-	collectRefreshDirectoryPaths,
-	refreshChangedDirectories,
-} from "./tree-patch"
+import { applyWatchBatchChanges } from "./batch-apply"
 import type { EnqueueBatchRefresh, VaultWatchBatchPayload } from "./types"
 
 const collectChangedPaths = (payload: VaultWatchBatchPayload): string[] => {
@@ -78,24 +76,23 @@ export const enqueueBatchPayloadRefresh = (
 		return
 	}
 
-	const directoryPaths = collectRefreshDirectoryPaths(
-		workspacePath,
-		externalRelPaths,
-	)
-
-	if (directoryPaths.length === 0) {
-		enqueueBatchRefresh(payload.batch, () =>
-			ctx.get().refreshWorkspaceEntries(),
-		)
-		return
-	}
-
 	enqueueBatchRefresh(payload.batch, async () => {
 		try {
-			await refreshChangedDirectories(ctx, workspacePath, directoryPaths)
+			const { fallbackDirectoryPaths, requiresFullRefresh } =
+				await applyWatchBatchChanges(ctx, {
+					workspacePath,
+					changes: payload.batch.changes,
+					externalRelPaths,
+				})
+
+			await reconcileWorkspaceTreeFromFallback(ctx, {
+				workspacePath,
+				fallbackDirectoryPaths,
+				requiresFullRefresh,
+			})
 		} catch (error) {
 			console.warn(
-				"Failed to apply partial workspace refresh from watch batch:",
+				"Failed to apply workspace watch batch incrementally:",
 				error,
 			)
 			await ctx.get().refreshWorkspaceEntries()

--- a/apps/desktop/src/store/workspace/watch/tree-patch.test.ts
+++ b/apps/desktop/src/store/workspace/watch/tree-patch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+	collapseDirectoryPaths,
 	collectRefreshDirectoryPaths,
 	replaceDirectoryChildren,
 } from "./tree-patch"
@@ -23,6 +24,16 @@ describe("watch/tree-patch", () => {
 		])
 
 		expect(paths).toEqual(["/ws/a", "/ws/a-archive"])
+	})
+
+	it("collapseDirectoryPaths keeps top-most directories only", () => {
+		const paths = collapseDirectoryPaths("/ws", [
+			"/ws/docs",
+			"/ws/docs/sub",
+			"/ws/archive",
+		])
+
+		expect(paths).toEqual(["/ws/docs", "/ws/archive"])
 	})
 
 	it("replaceDirectoryChildren updates only target directory subtree", () => {

--- a/apps/desktop/src/store/workspace/watch/tree-patch.ts
+++ b/apps/desktop/src/store/workspace/watch/tree-patch.ts
@@ -1,17 +1,10 @@
 import { dirname, resolve } from "pathe"
-import { areStringArraysEqual } from "@/utils/array-utils"
 import {
 	isPathEqualOrDescendant,
 	normalizePathSeparators,
 } from "@/utils/path-utils"
-import { buildWorkspaceEntries } from "../helpers/entry-helpers"
-import { syncExpandedDirectoriesWithEntries } from "../helpers/expanded-directories-helpers"
-import {
-	filterPinsForWorkspace,
-	filterPinsWithEntries,
-} from "../helpers/pinned-directories-helpers"
-import type { WorkspaceActionContext } from "../workspace-action-context"
-import type { WorkspaceEntry } from "../workspace-state"
+
+export { replaceDirectoryChildren } from "../actions/workspace-tree-reconcile"
 
 const hasCollapsedAncestorPath = (
 	path: string,
@@ -58,7 +51,27 @@ export const collectRefreshDirectoryPaths = (
 		parentPaths.add(parentPath)
 	}
 
-	const sorted = Array.from(parentPaths).sort((a, b) => {
+	return collapseDirectoryPaths(
+		normalizedWorkspacePath,
+		Array.from(parentPaths),
+	)
+}
+
+export const collapseDirectoryPaths = (
+	workspacePath: string,
+	directoryPaths: string[],
+): string[] => {
+	const normalizedWorkspacePath = normalizePathSeparators(workspacePath)
+	const inWorkspacePaths = Array.from(
+		new Set(
+			directoryPaths
+				.map((path) => normalizePathSeparators(path))
+				.filter((path) =>
+					isPathEqualOrDescendant(path, normalizedWorkspacePath),
+				),
+		),
+	)
+	const sorted = inWorkspacePaths.sort((a, b) => {
 		if (a.length === b.length) {
 			return a.localeCompare(b)
 		}
@@ -77,149 +90,4 @@ export const collectRefreshDirectoryPaths = (
 	}
 
 	return collapsed
-}
-
-const replaceMultipleDirectoryChildren = (
-	entries: WorkspaceEntry[],
-	workspacePath: string,
-	directoryChildrenByPath: ReadonlyMap<string, WorkspaceEntry[]>,
-): WorkspaceEntry[] => {
-	const normalizedWorkspacePath = normalizePathSeparators(workspacePath)
-	if (directoryChildrenByPath.size === 0) {
-		return entries
-	}
-
-	const normalizedDirectoryChildrenByPath = new Map<string, WorkspaceEntry[]>()
-	for (const [directoryPath, children] of directoryChildrenByPath) {
-		normalizedDirectoryChildrenByPath.set(
-			normalizePathSeparators(directoryPath),
-			children,
-		)
-	}
-
-	if (normalizedDirectoryChildrenByPath.has(normalizedWorkspacePath)) {
-		return normalizedDirectoryChildrenByPath.get(normalizedWorkspacePath) ?? []
-	}
-
-	const replaceInTree = (list: WorkspaceEntry[]): WorkspaceEntry[] => {
-		let changed = false
-
-		const updated = list.map((entry) => {
-			if (!entry.isDirectory || !entry.children) {
-				return entry
-			}
-
-			const normalizedEntryPath = normalizePathSeparators(entry.path)
-			if (normalizedDirectoryChildrenByPath.has(normalizedEntryPath)) {
-				changed = true
-				return {
-					...entry,
-					children:
-						normalizedDirectoryChildrenByPath.get(normalizedEntryPath) ?? [],
-				}
-			}
-
-			const updatedChildren = replaceInTree(entry.children)
-			if (updatedChildren !== entry.children) {
-				changed = true
-				return {
-					...entry,
-					children: updatedChildren,
-				}
-			}
-
-			return entry
-		})
-
-		return changed ? updated : list
-	}
-
-	return replaceInTree(entries)
-}
-
-export const replaceDirectoryChildren = (
-	entries: WorkspaceEntry[],
-	workspacePath: string,
-	directoryPath: string,
-	nextChildren: WorkspaceEntry[],
-): WorkspaceEntry[] => {
-	return replaceMultipleDirectoryChildren(
-		entries,
-		workspacePath,
-		new Map([[directoryPath, nextChildren]]),
-	)
-}
-
-export const refreshChangedDirectories = async (
-	ctx: WorkspaceActionContext,
-	workspacePath: string,
-	directoryPaths: string[],
-) => {
-	if (directoryPaths.length === 0) {
-		return
-	}
-
-	const directorySnapshots = await Promise.all(
-		directoryPaths.map(async (directoryPath) => ({
-			directoryPath,
-			children: await buildWorkspaceEntries(
-				directoryPath,
-				ctx.deps.fileSystemRepository,
-			),
-		})),
-	)
-
-	if (ctx.get().workspacePath !== workspacePath) {
-		return
-	}
-
-	const nextEntries = replaceMultipleDirectoryChildren(
-		ctx.get().entries,
-		workspacePath,
-		new Map(
-			directorySnapshots.map(({ directoryPath, children }) => [
-				directoryPath,
-				children,
-			]),
-		),
-	)
-
-	const state = ctx.get()
-	const previousExpanded = state.expandedDirectories
-	const previousPinned = state.pinnedDirectories
-
-	const nextExpanded = syncExpandedDirectoriesWithEntries(
-		previousExpanded,
-		nextEntries,
-	)
-	const nextPinned = filterPinsWithEntries(
-		filterPinsForWorkspace(previousPinned, workspacePath),
-		nextEntries,
-		workspacePath,
-	)
-	const expandedChanged = !areStringArraysEqual(previousExpanded, nextExpanded)
-	const pinnedChanged = !areStringArraysEqual(previousPinned, nextPinned)
-
-	state.updateEntries(nextEntries)
-
-	if (expandedChanged || pinnedChanged) {
-		ctx.set({
-			...(expandedChanged ? { expandedDirectories: nextExpanded } : {}),
-			...(pinnedChanged ? { pinnedDirectories: nextPinned } : {}),
-		})
-	}
-
-	if (expandedChanged) {
-		await ctx.deps.settingsRepository.persistExpandedDirectories(
-			workspacePath,
-			nextExpanded,
-		)
-	}
-
-	if (pinnedChanged) {
-		await ctx.deps.settingsRepository.persistPinnedDirectories(
-			workspacePath,
-			nextPinned,
-		)
-	}
 }

--- a/apps/desktop/src/store/workspace/workspace-slice.ts
+++ b/apps/desktop/src/store/workspace/workspace-slice.ts
@@ -67,6 +67,7 @@ export type WorkspaceSlice = WorkspaceState & {
 	entryMoved: (input: {
 		sourcePath: string
 		destinationDirPath: string
+		// `newPath` may include rename semantics when move+rename happen together.
 		newPath: string
 		isDirectory: boolean
 		refreshContent?: boolean


### PR DESCRIPTION
## Summary
- Refactor workspace tree sync to share state reconciliation logic.
- Add incremental watch batch application with targeted fallback refresh.
- Add coverage for move/rename/create/delete watch event handling.

## Testing
- Not run; commit created from staged changes with formatter/lint hook.