### PR TITLE
fix(vault-watch): ignore symlinked paths during sync

### DIFF
--- a/crates/vault-watch/src/normalize/dir_index.rs
+++ b/crates/vault-watch/src/normalize/dir_index.rs
@@ -74,7 +74,10 @@ impl PendingBatch {
         self.known_dirs.insert(rel_path.to_string());
 
         let root_path = vault_root.join(rel_path);
-        let Ok(metadata) = std::fs::metadata(&root_path) else {
+        let Ok(metadata) = std::fs::symlink_metadata(&root_path) else {
+            return;
+        };
+        if metadata.file_type().is_symlink() {
             return;
         };
         if !metadata.is_dir() {
@@ -91,6 +94,10 @@ impl PendingBatch {
                 let Ok(file_type) = entry.file_type() else {
                     continue;
                 };
+                if file_type.is_symlink() {
+                    continue;
+                }
+
                 if !file_type.is_dir() {
                     continue;
                 }
@@ -153,7 +160,10 @@ impl PendingBatch {
             None => vault_root.join(rel_path),
         };
 
-        let metadata = std::fs::metadata(candidate_path).ok()?;
+        let metadata = std::fs::symlink_metadata(candidate_path).ok()?;
+        if metadata.file_type().is_symlink() {
+            return None;
+        }
         if metadata.is_dir() {
             return Some(VaultEntryKind::Directory);
         }

--- a/crates/vault-watch/src/path.rs
+++ b/crates/vault-watch/src/path.rs
@@ -1,4 +1,4 @@
-use std::path::{Component, Path};
+use std::{fs, path::{Component, Path}};
 
 pub(crate) fn to_vault_rel_path(vault_root: &Path, event_path: &Path) -> Option<String> {
     let candidate = if event_path.is_absolute() {
@@ -7,8 +7,38 @@ pub(crate) fn to_vault_rel_path(vault_root: &Path, event_path: &Path) -> Option<
         vault_root.join(event_path)
     };
 
+    if has_symlink_ancestor(vault_root, &candidate) {
+        return None;
+    }
+
     let rel = candidate.strip_prefix(vault_root).ok()?;
     normalize_rel_path(rel)
+}
+
+fn has_symlink_ancestor(vault_root: &Path, candidate: &Path) -> bool {
+    let Ok(relative_path) = candidate.strip_prefix(vault_root) else {
+        return false;
+    };
+
+    let mut cursor = vault_root.to_path_buf();
+    for component in relative_path.components() {
+        match component {
+            Component::CurDir | Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                continue
+            }
+            Component::Normal(part) => {
+                cursor.push(part);
+            }
+        }
+
+        if fs::symlink_metadata(&cursor)
+            .is_ok_and(|metadata| metadata.file_type().is_symlink())
+        {
+            return true;
+        }
+    }
+
+    false
 }
 
 fn normalize_rel_path(path: &Path) -> Option<String> {


### PR DESCRIPTION
## Summary\n- Ignore symlinked paths during vault path normalization and directory traversal\n- Use symlink-safe metadata checks to avoid following symlinks for indexing\n\n## Testing\n- (Already run by commit hook) biome check\n