### PR TITLE
fix(editor): prevent link navigation while link popover is open

### DIFF
--- a/packages/editor/src/link/node-link.tsx
+++ b/packages/editor/src/link/node-link.tsx
@@ -24,17 +24,16 @@ export function LinkElement(
 		props.editor.id,
 	)
 	const linkAttributes = getLinkAttributes(props.editor, props.element)
+	const linkAttributeHandlers = linkAttributes as Pick<
+		AnchorHTMLAttributes<HTMLAnchorElement>,
+		"onClick" | "onMouseDown"
+	>
 	const sanitizedHref = sanitizeLinkHref(props.element.url)
 	const defaultOnClick =
-		(props.defaultLinkAttributes
-			?.onClick as MouseEventHandler<HTMLAnchorElement>) ??
-		(linkAttributes.onClick as MouseEventHandler<HTMLAnchorElement> | undefined)
+		props.defaultLinkAttributes?.onClick ?? linkAttributeHandlers.onClick
 	const defaultOnMouseDown =
-		(props.defaultLinkAttributes
-			?.onMouseDown as MouseEventHandler<HTMLAnchorElement>) ??
-		(linkAttributes.onMouseDown as
-			| MouseEventHandler<HTMLAnchorElement>
-			| undefined)
+		props.defaultLinkAttributes?.onMouseDown ??
+		linkAttributeHandlers.onMouseDown
 	const onClick: MouseEventHandler<HTMLAnchorElement> | undefined =
 		isLinkPopoverOpen
 			? (event) => {


### PR DESCRIPTION
## Summary
- make link element aware of LinkPlugin popover open state
- prevent anchor click navigation while the link popover is open
- keep pointer behavior aligned by switching to text cursor while popover is open

## Testing
- pnpm -C packages/editor exec tsc --noEmit --pretty false
- pnpm lint:fix