### PR TITLE
refactor: compact settings controls

### DIFF
--- a/apps/desktop/src/components/settings/ui/ai-tab.tsx
+++ b/apps/desktop/src/components/settings/ui/ai-tab.tsx
@@ -5,7 +5,6 @@ import {
 	CREDENTIAL_PROVIDER_IDS,
 	type ProviderId,
 } from "@mdit/ai"
-import { Button } from "@mdit/ui/components/button"
 import {
 	Field,
 	FieldContent,
@@ -15,13 +14,6 @@ import {
 	FieldLegend,
 	FieldSet,
 } from "@mdit/ui/components/field"
-import { Input } from "@mdit/ui/components/input"
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-} from "@mdit/ui/components/select"
 import { Switch } from "@mdit/ui/components/switch"
 import { openUrl } from "@tauri-apps/plugin-opener"
 import { ExternalLink, Loader2Icon, RefreshCcwIcon } from "lucide-react"
@@ -34,6 +26,14 @@ import {
 	handleChatModelSelectChange,
 	resolveSelectedChatModelSelectValue,
 } from "./ai-tab-chat-model"
+import { SettingsButton } from "./settings-button"
+import { SettingsInput } from "./settings-input"
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SettingsSelectTrigger,
+} from "./settings-select"
 
 export function AITab() {
 	const {
@@ -144,7 +144,7 @@ export function AITab() {
 								}}
 								disabled={enabledChatModels.length === 0}
 							>
-								<SelectTrigger size="sm">
+								<SettingsSelectTrigger className="w-[240px]">
 									{selectedChatModelLabel ?? (
 										<span className="text-muted-foreground">
 											{enabledChatModels.length === 0
@@ -152,7 +152,7 @@ export function AITab() {
 												: "Select model"}
 										</span>
 									)}
-								</SelectTrigger>
+								</SettingsSelectTrigger>
 								<SelectContent align="end">
 									{chatModelSelectOptions.map(({ model, value }) => (
 										<SelectItem key={value} value={value}>
@@ -252,7 +252,7 @@ export function AITab() {
 
 								{definition.authKind === "oauth" ? (
 									<div className="flex items-center gap-2">
-										<Button
+										<SettingsButton
 											variant="outline"
 											disabled={isBusy}
 											onClick={() => {
@@ -272,7 +272,7 @@ export function AITab() {
 												: isConnected
 													? "Disconnect"
 													: "Connect"}
-										</Button>
+										</SettingsButton>
 									</div>
 								) : (
 									<ConnectProvider
@@ -302,9 +302,8 @@ export function AITab() {
 								Fetch models from your local Ollama instance when needed
 							</FieldDescription>
 						</FieldContent>
-						<Button
+						<SettingsButton
 							variant="outline"
-							size="sm"
 							disabled={isRefreshingModels}
 							onClick={() => void refreshOllamaModels()}
 						>
@@ -314,7 +313,7 @@ export function AITab() {
 								<RefreshCcwIcon className="size-4" />
 							)}
 							Refresh
-						</Button>
+						</SettingsButton>
 					</Field>
 				</FieldGroup>
 			</FieldSet>
@@ -358,7 +357,7 @@ function ConnectProvider({
 
 	return (
 		<div className="flex items-center gap-2">
-			<Input
+			<SettingsInput
 				ref={inputRef}
 				defaultValue={isConnected ? "****************" : undefined}
 				type="password"
@@ -367,13 +366,13 @@ function ConnectProvider({
 				spellCheck="false"
 				disabled={isBusy}
 			/>
-			<Button
+			<SettingsButton
 				variant="outline"
 				onClick={() => void handleConnect()}
 				disabled={isBusy}
 			>
 				{isBusy ? "Processing..." : isConnected ? "Disconnect" : "Connect"}
-			</Button>
+			</SettingsButton>
 		</div>
 	)
 }

--- a/apps/desktop/src/components/settings/ui/api-mcp-tab.tsx
+++ b/apps/desktop/src/components/settings/ui/api-mcp-tab.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@mdit/ui/components/button"
 import {
 	Field,
 	FieldContent,
@@ -8,7 +7,6 @@ import {
 	FieldLegend,
 	FieldSet,
 } from "@mdit/ui/components/field"
-import { Input } from "@mdit/ui/components/input"
 import { Switch } from "@mdit/ui/components/switch"
 import { Check, Copy } from "lucide-react"
 import { useEffect, useState } from "react"
@@ -20,6 +18,8 @@ import {
 	rotateLocalApiAuthToken,
 } from "@/lib/local-api-auth"
 import { useStore } from "@/store"
+import { SettingsButton } from "./settings-button"
+import { SettingsInput } from "./settings-input"
 
 const REST_APIS = [
 	{
@@ -219,18 +219,18 @@ export function ApiMcpTab() {
 						</FieldContent>
 						<div className="flex items-center gap-2 mt-2">
 							<div className="relative flex-1">
-								<Input
+								<SettingsInput
 									readOnly
 									type="text"
 									value={token}
 									placeholder="Loading token..."
-									className="font-mono text-xs pr-10"
+									className="font-mono pr-10"
 								/>
 								<div className="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5">
-									<Button
+									<SettingsButton
 										variant="ghost"
-										size="icon"
-										className="h-7 w-7 text-muted-foreground hover:text-foreground"
+										mode="icon"
+										className="text-muted-foreground hover:text-foreground"
 										onClick={handleCopyToken}
 										disabled={!token}
 										title="Copy Token"
@@ -240,16 +240,16 @@ export function ApiMcpTab() {
 										) : (
 											<Copy className="size-4" />
 										)}
-									</Button>
+									</SettingsButton>
 								</div>
 							</div>
-							<Button
+							<SettingsButton
 								variant="secondary"
 								className="shrink-0"
 								onClick={handleRotateToken}
 							>
 								Regenerate
-							</Button>
+							</SettingsButton>
 						</div>
 					</Field>
 				</FieldGroup>
@@ -313,10 +313,10 @@ export function ApiMcpTab() {
 										? client.snippet.replace(/<TOKEN>/g, token)
 										: client.snippet}
 								</pre>
-								<Button
+								<SettingsButton
 									variant="ghost"
-									size="icon"
-									className="absolute right-2 top-2 h-6 w-6 text-muted-foreground hover:text-foreground opacity-0 group-hover\/snippet:opacity-100 transition-opacity"
+									mode="icon"
+									className="absolute right-2 top-2 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover/snippet:opacity-100"
 									onClick={() =>
 										copyToClipboard(
 											token
@@ -329,7 +329,7 @@ export function ApiMcpTab() {
 									title="Copy Snippet"
 								>
 									<Copy className="size-3" />
-								</Button>
+								</SettingsButton>
 							</div>
 						</Field>
 					))}

--- a/apps/desktop/src/components/settings/ui/hotkeys-tab.tsx
+++ b/apps/desktop/src/components/settings/ui/hotkeys-tab.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@mdit/ui/components/button"
 import {
 	Field,
 	FieldContent,
@@ -24,6 +23,7 @@ import {
 	type AppHotkeyCategory,
 } from "@/lib/hotkeys"
 import { useStore } from "@/store"
+import { SettingsButton } from "./settings-button"
 
 const HOTKEY_LABEL_BY_ID: Record<AppHotkeyActionId, string> =
 	APP_HOTKEY_DEFINITIONS.reduce(
@@ -132,29 +132,28 @@ export function HotkeysTab() {
 
 	return (
 		<div className="flex-1 overflow-y-auto p-12">
-			<FieldSet>
-				<div className="flex items-start justify-between gap-3">
+			<FieldSet className="gap-4">
+				<div className="flex items-start justify-between gap-3 px-2">
 					<div>
-						<FieldLegend>Hotkeys</FieldLegend>
-						<FieldDescription>
+						<FieldLegend className="mb-1 text-sm">Hotkeys</FieldLegend>
+						<FieldDescription className="text-xs">
 							Customize keyboard shortcuts used throughout the app
 						</FieldDescription>
 					</div>
-					<Button
+					<SettingsButton
 						variant="ghost"
-						size="sm"
 						onClick={() => void resetAllBindings()}
 					>
 						Reset to defaults
-					</Button>
+					</SettingsButton>
 				</div>
 
 				{groupedDefinitions.map((group) => (
-					<div key={group.category} className="mt-8 first:mt-0">
-						<h3 className="text-sm font-medium text-muted-foreground">
+					<div key={group.category} className="mt-4 first:mt-0">
+						<h3 className="px-2 pb-1 text-xs font-medium text-muted-foreground">
 							{APP_HOTKEY_CATEGORY_LABELS[group.category]}
 						</h3>
-						<FieldGroup className="mt-3">
+						<FieldGroup className="mt-1 flex flex-col gap-0.5">
 							{group.definitions.map((definition) => {
 								const isRecording =
 									recorder.isRecording && recordingActionId === definition.id
@@ -166,21 +165,23 @@ export function HotkeysTab() {
 									<Field
 										key={definition.id}
 										orientation="horizontal"
-										className="items-start"
+										className="items-center rounded px-2 py-1 transition-colors hover:bg-muted/50"
 									>
 										<FieldContent>
-											<FieldLabel>{definition.label}</FieldLabel>
+											<FieldLabel className="text-sm font-medium text-foreground/80">
+												{definition.label}
+											</FieldLabel>
 											{errors[definition.id] && (
-												<FieldDescription className="text-destructive">
+												<FieldDescription className="text-destructive text-xs">
 													{errors[definition.id]}
 												</FieldDescription>
 											)}
 										</FieldContent>
-										<div className="flex flex-wrap items-center justify-end gap-2">
+										<div className="flex flex-wrap items-center justify-end gap-1.5">
 											{!isDefaultBinding && (
-												<Button
+												<SettingsButton
 													variant="ghost"
-													size="icon"
+													mode="icon"
 													onClick={() =>
 														void restoreDefaultBinding(
 															definition.id,
@@ -189,8 +190,8 @@ export function HotkeysTab() {
 													}
 													title="Restore default shortcut"
 												>
-													<IconRefresh className="size-4" />
-												</Button>
+													<IconRefresh className="size-3.5" />
+												</SettingsButton>
 											)}
 											{hasBinding ? (
 												<HotkeyKbd binding={binding} />
@@ -199,9 +200,9 @@ export function HotkeysTab() {
 													Unassigned
 												</span>
 											)}
-											<Button
+											<SettingsButton
 												variant="secondary"
-												size="icon"
+												mode="icon"
 												onClick={() => {
 													if (isRecording) {
 														cancelRecording()
@@ -218,7 +219,7 @@ export function HotkeysTab() {
 												) : (
 													<IconCircleFilled className="size-3 text-red-500/90" />
 												)}
-											</Button>
+											</SettingsButton>
 										</div>
 									</Field>
 								)

--- a/apps/desktop/src/components/settings/ui/indexing-tab.tsx
+++ b/apps/desktop/src/components/settings/ui/indexing-tab.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@mdit/ui/components/button"
 import {
 	Field,
 	FieldContent,
@@ -8,13 +7,6 @@ import {
 	FieldLegend,
 	FieldSet,
 } from "@mdit/ui/components/field"
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@mdit/ui/components/select"
 import { Loader2Icon, RefreshCcwIcon } from "lucide-react"
 import { useCallback, useEffect, useMemo } from "react"
 import { useShallow } from "zustand/shallow"
@@ -23,6 +15,14 @@ import { calculateIndexingProgress } from "@/store/indexing/helpers/indexing-uti
 import type { WorkspaceEntry } from "@/store/workspace/workspace-slice"
 import { useOllamaModelRefresh } from "../hooks/use-ollama-model-refresh"
 import { EmbeddingModelChangeDialog } from "./embedding-model-change-dialog"
+import { SettingsButton } from "./settings-button"
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectValue,
+	SettingsSelectTrigger,
+} from "./settings-select"
 
 export function IndexingTab() {
 	const {
@@ -226,13 +226,13 @@ export function IndexingTab() {
 									onValueChange={handleEmbeddingModelChange}
 									disabled={!isLicenseValid}
 								>
-									<SelectTrigger size="sm">
+									<SettingsSelectTrigger className="w-[240px]">
 										<SelectValue
 											placeholder={
 												isLicenseValid ? "Select a model" : "License required"
 											}
 										/>
-									</SelectTrigger>
+									</SettingsSelectTrigger>
 									<SelectContent align="end">
 										{ollamaEmbeddingModels.length > 0 ? (
 											ollamaEmbeddingModels.map((model) => {
@@ -249,9 +249,8 @@ export function IndexingTab() {
 										)}
 									</SelectContent>
 								</Select>
-								<Button
+								<SettingsButton
 									variant="outline"
-									size="sm"
 									disabled={isRefreshingModels}
 									onClick={() => void refreshOllamaModels()}
 								>
@@ -261,7 +260,7 @@ export function IndexingTab() {
 										<RefreshCcwIcon className="size-4" />
 									)}
 									Refresh
-								</Button>
+								</SettingsButton>
 							</div>
 						</Field>
 
@@ -293,26 +292,24 @@ export function IndexingTab() {
 								</p>
 							</div>
 							<div className="flex flex-wrap items-center justify-end gap-2 mt-4">
-								<Button
+								<SettingsButton
 									onClick={() => runIndex(false)}
 									variant="outline"
-									size="sm"
 									disabled={isIndexButtonDisabled}
 								>
 									{isIndexing && (
 										<Loader2Icon className="size-4 animate-spin" />
 									)}
 									{isIndexing ? "Indexing..." : "Manually Index"}
-								</Button>
-								<Button
+								</SettingsButton>
+								<SettingsButton
 									onClick={() => runIndex(true)}
 									variant="destructive"
-									size="sm"
 									disabled={isIndexing}
 								>
 									<RefreshCcwIcon className="size-4" />
 									Force Rebuild
-								</Button>
+								</SettingsButton>
 							</div>
 						</Field>
 					</FieldGroup>

--- a/apps/desktop/src/components/settings/ui/license-tab.tsx
+++ b/apps/desktop/src/components/settings/ui/license-tab.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@mdit/ui/components/button"
 import {
 	Field,
 	FieldContent,
@@ -8,12 +7,13 @@ import {
 	FieldLegend,
 	FieldSet,
 } from "@mdit/ui/components/field"
-import { Input } from "@mdit/ui/components/input"
 import { openUrl } from "@tauri-apps/plugin-opener"
 import { CheckCircle2, Loader2, XCircle } from "lucide-react"
 import { type ChangeEvent, useState } from "react"
 import { useShallow } from "zustand/shallow"
 import { useStore } from "@/store"
+import { SettingsButton } from "./settings-button"
+import { SettingsInput } from "./settings-input"
 
 export function LicenseTab() {
 	const {
@@ -110,7 +110,7 @@ export function LicenseTab() {
 								</FieldDescription>
 							</FieldContent>
 							<div className="flex items-start gap-2 mt-2">
-								<Button
+								<SettingsButton
 									variant="outline"
 									onClick={handleDeactivate}
 									disabled={isLoading}
@@ -123,7 +123,7 @@ export function LicenseTab() {
 									) : (
 										"Deactivate License"
 									)}
-								</Button>
+								</SettingsButton>
 							</div>
 							{error && (
 								<p className="text-sm text-destructive mt-2">{error}</p>
@@ -141,7 +141,7 @@ export function LicenseTab() {
 							</FieldContent>
 							<div className="flex items-start gap-2 mt-2">
 								<div className="flex-1">
-									<Input
+									<SettingsInput
 										id="license-key"
 										type="text"
 										placeholder="XXXX-XXXX-XXXX-XXXX"
@@ -159,7 +159,7 @@ export function LicenseTab() {
 										<p className="text-sm text-destructive mt-2">{error}</p>
 									)}
 								</div>
-								<Button
+								<SettingsButton
 									variant="outline"
 									onClick={handleActivate}
 									disabled={isLoading || !licenseKey}
@@ -172,7 +172,7 @@ export function LicenseTab() {
 									) : (
 										"Activate"
 									)}
-								</Button>
+								</SettingsButton>
 							</div>
 						</Field>
 					)}

--- a/apps/desktop/src/components/settings/ui/preferences-tab.tsx
+++ b/apps/desktop/src/components/settings/ui/preferences-tab.tsx
@@ -7,15 +7,15 @@ import {
 	FieldLegend,
 	FieldSet,
 } from "@mdit/ui/components/field"
+import { Monitor, Moon, Sun } from "lucide-react"
+import { useTheme } from "@/contexts/theme-context"
 import {
 	Select,
 	SelectContent,
 	SelectItem,
-	SelectTrigger,
 	SelectValue,
-} from "@mdit/ui/components/select"
-import { Monitor, Moon, Sun } from "lucide-react"
-import { useTheme } from "@/contexts/theme-context"
+	SettingsSelectTrigger,
+} from "./settings-select"
 
 export function PreferencesTab() {
 	const { theme, setTheme } = useTheme()
@@ -49,9 +49,9 @@ export function PreferencesTab() {
 								setTheme(value as "light" | "dark" | "system")
 							}
 						>
-							<SelectTrigger size="sm">
+							<SettingsSelectTrigger className="w-32">
 								<SelectValue />
-							</SelectTrigger>
+							</SettingsSelectTrigger>
 							<SelectContent align="end">
 								{themeOptions.map((option) => (
 									<SelectItem key={option.value} value={option.value}>

--- a/apps/desktop/src/components/settings/ui/settings-button.tsx
+++ b/apps/desktop/src/components/settings/ui/settings-button.tsx
@@ -1,0 +1,28 @@
+import { Button } from "@mdit/ui/components/button"
+import { cn } from "@mdit/ui/lib/utils"
+import type * as React from "react"
+
+export type SettingsButtonProps = React.ComponentProps<typeof Button> & {
+	mode?: "compact" | "icon"
+}
+
+export function SettingsButton({
+	mode = "compact",
+	className,
+	size,
+	...props
+}: SettingsButtonProps) {
+	const resolvedSize = mode === "icon" ? "icon" : size
+
+	return (
+		<Button
+			size={resolvedSize}
+			className={cn(
+				"rounded-sm text-sm h-7",
+				mode === "icon" ? "size-7" : "px-2!",
+				className,
+			)}
+			{...props}
+		/>
+	)
+}

--- a/apps/desktop/src/components/settings/ui/settings-input.tsx
+++ b/apps/desktop/src/components/settings/ui/settings-input.tsx
@@ -1,0 +1,14 @@
+import { Input } from "@mdit/ui/components/input"
+import { cn } from "@mdit/ui/lib/utils"
+import type * as React from "react"
+
+export type SettingsInputProps = React.ComponentProps<typeof Input>
+
+export function SettingsInput({ className, ...props }: SettingsInputProps) {
+	return (
+		<Input
+			className={cn("h-7 rounded-sm px-2 text-sm", className)}
+			{...props}
+		/>
+	)
+}

--- a/apps/desktop/src/components/settings/ui/settings-select.tsx
+++ b/apps/desktop/src/components/settings/ui/settings-select.tsx
@@ -1,0 +1,30 @@
+import {
+	Select as BaseSelect,
+	SelectContent as BaseSelectContent,
+	SelectItem as BaseSelectItem,
+	SelectTrigger as BaseSelectTrigger,
+	SelectValue as BaseSelectValue,
+} from "@mdit/ui/components/select"
+import { cn } from "@mdit/ui/lib/utils"
+import type * as React from "react"
+
+export const Select = BaseSelect
+export const SelectContent = BaseSelectContent
+export const SelectItem = BaseSelectItem
+export const SelectValue = BaseSelectValue
+
+export type SettingsSelectTriggerProps = React.ComponentProps<
+	typeof BaseSelectTrigger
+>
+
+export function SettingsSelectTrigger({
+	className,
+	...props
+}: SettingsSelectTriggerProps) {
+	return (
+		<BaseSelectTrigger
+			className={cn("h-7! rounded-sm px-2 text-sm", className)}
+			{...props}
+		/>
+	)
+}

--- a/apps/desktop/src/components/settings/ui/sync-tab.tsx
+++ b/apps/desktop/src/components/settings/ui/sync-tab.tsx
@@ -7,12 +7,12 @@ import {
 	FieldLegend,
 	FieldSet,
 } from "@mdit/ui/components/field"
-import { Input } from "@mdit/ui/components/input"
 import { Switch } from "@mdit/ui/components/switch"
 import { Textarea } from "@mdit/ui/components/textarea"
 import { useEffect, useState } from "react"
 import { useShallow } from "zustand/shallow"
 import { useStore } from "@/store"
+import { SettingsInput } from "./settings-input"
 
 export function SyncTab() {
 	const {
@@ -112,7 +112,7 @@ export function SyncTab() {
 								use the current branch.
 							</FieldDescription>
 						</FieldContent>
-						<Input
+						<SettingsInput
 							value={branchName}
 							onChange={(e) => handleBranchNameChange(e.target.value)}
 							placeholder="Leave empty to use current branch"
@@ -132,6 +132,7 @@ export function SyncTab() {
 							onChange={(e) => handleCommitMessageChange(e.target.value)}
 							placeholder="Leave empty to use default message"
 							rows={4}
+							className="rounded px-2 py-1.5 text-xs"
 						/>
 					</Field>
 				</FieldGroup>

--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -9,8 +9,8 @@ function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
 		<fieldset
 			data-slot="field-set"
 			className={cn(
-				"flex flex-col gap-6",
-				"has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+				"flex flex-col gap-4",
+				"has-[>[data-slot=checkbox-group]]:gap-2 has-[>[data-slot=radio-group]]:gap-2",
 				className,
 			)}
 			{...props}
@@ -28,9 +28,9 @@ function FieldLegend({
 			data-slot="field-legend"
 			data-variant={variant}
 			className={cn(
-				"mb-3 font-medium",
-				"data-[variant=legend]:text-base",
-				"data-[variant=label]:text-sm",
+				"mb-1.5 font-medium",
+				"data-[variant=legend]:text-sm",
+				"data-[variant=label]:text-xs",
 				className,
 			)}
 			{...props}
@@ -52,18 +52,18 @@ function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 const fieldVariants = cva(
-	"group/field flex w-full gap-3 data-[invalid=true]:text-destructive",
+	"group/field flex w-full gap-2 data-[invalid=true]:text-destructive",
 	{
 		variants: {
 			orientation: {
 				vertical: ["flex-col [&>*]:w-full [&>.sr-only]:w-auto"],
 				horizontal: [
-					"flex-row items-center",
+					"flex-row items-center rounded px-2 py-1.5 transition-colors hover:bg-muted/50 -mx-2 w-[calc(100%+1rem)]",
 					"[&>[data-slot=field-label]]:flex-auto",
 					"has-[>[data-slot=field-content]]:items-start has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
 				],
 				responsive: [
-					"flex-col [&>*]:w-full [&>.sr-only]:w-auto @md/field-group:flex-row @md/field-group:items-center @md/field-group:[&>*]:w-auto",
+					"flex-col [&>*]:w-full [&>.sr-only]:w-auto @md/field-group:flex-row @md/field-group:items-center @md/field-group:rounded @md/field-group:px-2 @md/field-group:py-1.5 @md/field-group:transition-colors @md/field-group:hover:bg-muted/50 @md/field-group:-mx-2 @md/field-group:w-[calc(100%+1rem)] @md/field-group:[&>*]:w-auto",
 					"@md/field-group:[&>[data-slot=field-label]]:flex-auto",
 					"@md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
 				],
@@ -96,7 +96,7 @@ function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
 		<div
 			data-slot="field-content"
 			className={cn(
-				"group/field-content flex flex-1 flex-col gap-1.5 leading-snug",
+				"group/field-content flex flex-1 flex-col gap-0.5 leading-snug",
 				className,
 			)}
 			{...props}
@@ -113,6 +113,7 @@ function FieldLabel({
 			data-slot="field-label"
 			className={cn(
 				"group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50",
+				"text-sm font-medium text-foreground/80",
 				"has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border *:data-[slot=field]:p-4",
 				"has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10",
 				className,
@@ -140,8 +141,8 @@ function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
 		<p
 			data-slot="field-description"
 			className={cn(
-				"text-muted-foreground text-sm leading-normal font-normal select-text group-has-data-[orientation=horizontal]/field:text-balance",
-				"last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5",
+				"text-muted-foreground text-xs leading-normal font-medium select-text group-has-data-[orientation=horizontal]/field:text-balance",
+				"last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1",
 				"[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
 				className,
 			)}

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -7,7 +7,7 @@ function Switch({ className, ...props }: SwitchPrimitive.Root.Props) {
 		<SwitchPrimitive.Root
 			data-slot="switch"
 			className={cn(
-				"peer data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-unchecked:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] data-disabled:cursor-not-allowed data-disabled:opacity-50",
+				"peer data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-unchecked:bg-input/80 inline-flex h-4 w-7 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] data-disabled:cursor-not-allowed data-disabled:opacity-50",
 				"cursor-pointer",
 				className,
 			)}
@@ -16,7 +16,7 @@ function Switch({ className, ...props }: SwitchPrimitive.Root.Props) {
 			<SwitchPrimitive.Thumb
 				data-slot="switch-thumb"
 				className={cn(
-					"bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-checked:translate-x-[calc(100%-2px)] data-unchecked:translate-x-0",
+					"bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground pointer-events-none block size-3.5 rounded-full ring-0 transition-transform data-checked:translate-x-[calc(100%-2px)] data-unchecked:translate-x-0",
 				)}
 			/>
 		</SwitchPrimitive.Root>


### PR DESCRIPTION
## Summary
- add settings-specific wrappers for button/input/select trigger styling
- migrate settings tabs to use compact control primitives for consistent sizing
- tighten field and switch sizing for denser settings rows
- map icon-mode settings buttons to Button size="icon" to avoid default padding

## Testing
- pnpm -C /Users/hyeongjin/Workspace/Mdit lint:fix
- pnpm -C /Users/hyeongjin/Workspace/Mdit ts:check:desktop