### PR TITLE
fix: defer editor popover input focus

### DIFF
--- a/packages/editor/src/ai/ai-menu-content.tsx
+++ b/packages/editor/src/ai/ai-menu-content.tsx
@@ -196,6 +196,18 @@ export function AIMenuContent({
 		}
 	}, [input, isLoading, adjustTextareaHeight])
 
+	useEffect(() => {
+		if (isLoading) return
+
+		const frame = requestAnimationFrame(() => {
+			textareaRef.current?.focus({ preventScroll: true })
+		})
+
+		return () => {
+			cancelAnimationFrame(frame)
+		}
+	}, [isLoading])
+
 	const canSubmit = Boolean(
 		chatConfig && !isLoading && !value && isLicenseValid,
 	)
@@ -222,7 +234,6 @@ export function AIMenuContent({
 				>
 					<CommandPrimitive.Input
 						asChild
-						autoFocus
 						data-plate-focus
 						onClick={onInputClick}
 						onKeyDown={(event) => {

--- a/packages/editor/src/math/node-equation.tsx
+++ b/packages/editor/src/math/node-equation.tsx
@@ -299,12 +299,25 @@ const EquationPopoverContent = ({
 	const editor = useEditorRef()
 	const readOnly = useReadOnly()
 	const element = useElement<TEquationElement>()
+	const inputRef = useRef<HTMLTextAreaElement | null>(null)
 
 	useEffect(() => {
 		if (isInline && open) {
 			setOpen(true)
 		}
 	}, [isInline, open, setOpen])
+
+	useEffect(() => {
+		if (!open) return
+
+		const frame = requestAnimationFrame(() => {
+			inputRef.current?.focus({ preventScroll: true })
+		})
+
+		return () => {
+			cancelAnimationFrame(frame)
+		}
+	}, [open])
 
 	if (readOnly) return null
 
@@ -352,12 +365,12 @@ const EquationPopoverContent = ({
 			align="start"
 		>
 			<EquationInput
+				ref={inputRef}
 				className={cn(
 					"max-h-[50vh] grow resize-none p-2 text-sm outline-none",
 					className,
 				)}
 				state={{ isInline, open, onClose }}
-				autoFocus
 				spellCheck={false}
 				autoCapitalize="off"
 				onKeyDown={(e) => {


### PR DESCRIPTION
## Summary
- replace mount-time autofocus with deferred textarea focus in the AI menu
- do the same for equation popovers so focus is applied after the popup is ready
- keep focus handoff non-scrolling with preventScroll

## Testing
- pnpm --filter @mdit/editor test