### PR TITLE
refactor: extract graph view package

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -29,6 +29,7 @@
 		"@mdit/assets": "workspace:*",
 		"@mdit/credentials": "workspace:*",
 		"@mdit/editor": "workspace:*",
+		"@mdit/graph-view": "workspace:*",
 		"@mdit/git-sync": "workspace:*",
 		"@mdit/license": "workspace:*",
 		"@mdit/local-fs-origin": "workspace:*",

--- a/apps/desktop/src/components/graph-view/graph-view-dialog.tsx
+++ b/apps/desktop/src/components/graph-view/graph-view-dialog.tsx
@@ -1,16 +1,23 @@
+import {
+	GraphCanvas,
+	type GraphNode,
+	type GraphViewData,
+} from "@mdit/graph-view"
 import { Button } from "@mdit/ui/components/button"
 import { Dialog, DialogContent, DialogTitle } from "@mdit/ui/components/dialog"
 import { invoke } from "@tauri-apps/api/core"
-import { resolve } from "pathe"
+import { relative, resolve } from "pathe"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useShallow } from "zustand/shallow"
 import { useStore } from "@/store"
-import { GraphCanvas } from "./graph-canvas"
-import type { GraphNodeOpenAction, GraphViewData } from "./types"
 
 const EMPTY_GRAPH_DATA: GraphViewData = {
 	nodes: [],
 	edges: [],
+}
+
+function normalizeGraphPath(value: string) {
+	return value.replace(/\\/g, "/")
 }
 
 export function GraphViewDialog() {
@@ -19,12 +26,14 @@ export function GraphViewDialog() {
 		setGraphViewDialogOpen,
 		workspacePath,
 		openTab,
+		tabPath,
 	} = useStore(
 		useShallow((state) => ({
 			isGraphViewDialogOpen: state.isGraphViewDialogOpen,
 			setGraphViewDialogOpen: state.setGraphViewDialogOpen,
 			workspacePath: state.workspacePath,
 			openTab: state.openTab,
+			tabPath: state.tab?.path ?? null,
 		})),
 	)
 
@@ -82,9 +91,17 @@ export function GraphViewDialog() {
 		fetchGraphData()
 	}, [fetchGraphData, isGraphViewDialogOpen])
 
+	const activeRelPath = (() => {
+		if (!workspacePath || !tabPath) {
+			return null
+		}
+
+		return normalizeGraphPath(relative(workspacePath, tabPath))
+	})()
+
 	const handleNodeAction = useCallback(
-		(action: GraphNodeOpenAction) => {
-			if (action.type === "unresolved") {
+		(node: GraphNode) => {
+			if (node.unresolved) {
 				return
 			}
 
@@ -92,7 +109,7 @@ export function GraphViewDialog() {
 				return
 			}
 
-			openTab(resolve(workspacePath, action.relPath))
+			openTab(resolve(workspacePath, node.relPath))
 			setGraphViewDialogOpen(false)
 		},
 		[openTab, setGraphViewDialogOpen, workspacePath],
@@ -136,7 +153,11 @@ export function GraphViewDialog() {
 							</div>
 						</div>
 					) : hasNodes ? (
-						<GraphCanvas data={data} onNodeAction={handleNodeAction} />
+						<GraphCanvas
+							data={data}
+							activeRelPath={activeRelPath}
+							onNodeSelect={handleNodeAction}
+						/>
 					) : isLoading ? null : (
 						<div className="h-full flex items-center justify-center text-sm text-muted-foreground">
 							Empty

--- a/apps/desktop/src/globals.css
+++ b/apps/desktop/src/globals.css
@@ -4,6 +4,7 @@
 
 @source "../../../packages/ui/src/**/*.{ts,tsx}";
 @source "../../../packages/editor/src/**/*.{ts,tsx}";
+@source "../../../packages/graph-view/src/**/*.{ts,tsx}";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/packages/graph-view/package.json
+++ b/packages/graph-view/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "@mdit/graph-view",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module",
+	"scripts": {
+		"test": "vitest run"
+	},
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"dependencies": {
+		"@mdit/ui": "workspace:*",
+		"d3-force": "^3.0.0",
+		"react": "^19.2.4"
+	},
+	"devDependencies": {
+		"@mdit/tsconfig": "workspace:*",
+		"@types/d3-force": "^3.0.10",
+		"@types/react": "^19.2.14",
+		"vitest": "^4.0.9"
+	}
+}

--- a/packages/graph-view/src/graph-canvas.tsx
+++ b/packages/graph-view/src/graph-canvas.tsx
@@ -8,7 +8,6 @@ import {
 	type SimulationLinkDatum,
 	type SimulationNodeDatum,
 } from "d3-force"
-import { relative } from "pathe"
 import {
 	type PointerEvent,
 	useCallback,
@@ -18,17 +17,14 @@ import {
 	useState,
 	type WheelEvent,
 } from "react"
-import { useShallow } from "zustand/shallow"
-import { useStore } from "@/store"
 import {
 	getGraphDegradeProfile,
-	getNodeOpenAction,
 	sampleEdgesForRender,
 	toRenderNodes,
 } from "./graph-utils"
 import type {
 	GraphEdge,
-	GraphNodeOpenAction,
+	GraphNode,
 	GraphRenderNode,
 	GraphViewData,
 } from "./types"
@@ -51,6 +47,13 @@ type ViewState = {
 	scale: number
 }
 
+type GraphCanvasProps = {
+	data: GraphViewData
+	activeRelPath?: string | null
+	onNodeSelect?: (node: GraphNode) => void
+	className?: string
+}
+
 const DEFAULT_WIDTH = 960
 const DEFAULT_HEIGHT = 640
 const MIN_SCALE = 0.2
@@ -61,10 +64,6 @@ const VIEW_INTERPOLATION = 0.24
 
 function clamp(value: number, min: number, max: number) {
 	return Math.min(max, Math.max(min, value))
-}
-
-function normalizeGraphPath(value: string) {
-	return value.replace(/\\/g, "/")
 }
 
 function getNodeRadius(node: Pick<GraphRenderNode, "unresolved" | "degree">) {
@@ -79,11 +78,7 @@ function getFittedView(
 	nodes: PositionedNode[],
 	width: number,
 	height: number,
-): {
-	x: number
-	y: number
-	scale: number
-} {
+): ViewState {
 	if (!nodes.length) {
 		return { x: 0, y: 0, scale: 1 }
 	}
@@ -122,17 +117,10 @@ function getFittedView(
 
 export function GraphCanvas({
 	data,
-	onNodeAction,
-}: {
-	data: GraphViewData
-	onNodeAction: (action: GraphNodeOpenAction) => void
-}) {
-	const { tabPath, workspacePath } = useStore(
-		useShallow((state) => ({
-			tabPath: state.tab?.path ?? null,
-			workspacePath: state.workspacePath,
-		})),
-	)
+	activeRelPath = null,
+	onNodeSelect,
+	className,
+}: GraphCanvasProps) {
 	const containerRef = useRef<HTMLDivElement | null>(null)
 	const svgRef = useRef<SVGSVGElement | null>(null)
 
@@ -252,12 +240,6 @@ export function GraphCanvas({
 		() => getGraphDegradeProfile(data.nodes.length, data.edges.length),
 		[data.edges.length, data.nodes.length],
 	)
-	const currentTabRelPath = useMemo(() => {
-		if (!workspacePath || !tabPath) {
-			return null
-		}
-		return normalizeGraphPath(relative(workspacePath, tabPath))
-	}, [tabPath, workspacePath])
 
 	useEffect(() => {
 		const target = containerRef.current
@@ -549,7 +531,7 @@ export function GraphCanvas({
 		event.currentTarget.releasePointerCapture(event.pointerId)
 
 		if (movedDistance < 4) {
-			onNodeAction(getNodeOpenAction(node))
+			onNodeSelect?.(node)
 		}
 	}
 
@@ -598,7 +580,10 @@ export function GraphCanvas({
 		.filter(Boolean)
 
 	return (
-		<div ref={containerRef} className="h-full w-full bg-muted/15">
+		<div
+			ref={containerRef}
+			className={cn("h-full w-full bg-muted/15", className)}
+		>
 			{size ? (
 				<svg
 					ref={svgRef}
@@ -620,12 +605,12 @@ export function GraphCanvas({
 					<g transform={`translate(${view.x},${view.y}) scale(${view.scale})`}>
 						{renderLines}
 						{nodes.map((node) => {
-							const isCurrentTabNode =
-								currentTabRelPath !== null && node.relPath === currentTabRelPath
+							const isCurrentNode =
+								activeRelPath !== null && node.relPath === activeRelPath
 							const isFocused =
 								hoveredNodeId === node.id || selectedNodeId === node.id
 							const showLabel =
-								isCurrentTabNode ||
+								isCurrentNode ||
 								isFocused ||
 								view.scale >= degradeProfile.labelVisibleScale
 							const radius = getNodeRadius(node)
@@ -648,7 +633,7 @@ export function GraphCanvas({
 										setHoveredNodeId((prev) => (prev === node.id ? null : prev))
 									}
 								>
-									{isCurrentTabNode && (
+									{isCurrentNode && (
 										<circle
 											r={radius + 5.6}
 											className="fill-primary/20 stroke-primary/60 stroke-[1.6]"
@@ -656,13 +641,11 @@ export function GraphCanvas({
 									)}
 									<circle
 										r={
-											radius +
-											(isFocused ? 2.1 : 0) +
-											(isCurrentTabNode ? 2.4 : 0)
+											radius + (isFocused ? 2.1 : 0) + (isCurrentNode ? 2.4 : 0)
 										}
 										className={cn(
 											"transition-colors",
-											isCurrentTabNode
+											isCurrentNode
 												? node.unresolved
 													? "fill-transparent stroke-primary stroke-[2.2]"
 													: "fill-primary/90 stroke-primary stroke-[2.2]"

--- a/packages/graph-view/src/graph-utils.test.ts
+++ b/packages/graph-view/src/graph-utils.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest"
 import {
 	buildNodeDegreeMap,
 	getGraphDegradeProfile,
-	getNodeOpenAction,
 	getNodeVisualState,
 	sampleEdgesForRender,
 	toRenderNodes,
@@ -67,22 +66,6 @@ describe("getNodeVisualState", () => {
 	it("returns unresolved style for ghost nodes", () => {
 		expect(getNodeVisualState(fixture.nodes[2])).toBe("unresolved")
 		expect(getNodeVisualState(fixture.nodes[0])).toBe("resolved")
-	})
-})
-
-describe("getNodeOpenAction", () => {
-	it("returns open action for resolved nodes", () => {
-		expect(getNodeOpenAction(fixture.nodes[0])).toEqual({
-			type: "open",
-			relPath: "a.md",
-		})
-	})
-
-	it("returns unresolved action for ghost nodes", () => {
-		expect(getNodeOpenAction(fixture.nodes[2])).toEqual({
-			type: "unresolved",
-			relPath: "missing.md",
-		})
 	})
 })
 

--- a/packages/graph-view/src/graph-utils.ts
+++ b/packages/graph-view/src/graph-utils.ts
@@ -1,7 +1,6 @@
 import type {
 	GraphEdge,
 	GraphNode,
-	GraphNodeOpenAction,
 	GraphRenderNode,
 	GraphViewData,
 } from "./types"
@@ -115,18 +114,4 @@ export function sampleEdgesForRender(
 
 export function getNodeVisualState(node: GraphNode): "resolved" | "unresolved" {
 	return node.unresolved ? "unresolved" : "resolved"
-}
-
-export function getNodeOpenAction(node: GraphNode): GraphNodeOpenAction {
-	if (node.unresolved) {
-		return {
-			type: "unresolved",
-			relPath: node.relPath,
-		}
-	}
-
-	return {
-		type: "open",
-		relPath: node.relPath,
-	}
 }

--- a/packages/graph-view/src/index.ts
+++ b/packages/graph-view/src/index.ts
@@ -1,0 +1,14 @@
+export { GraphCanvas } from "./graph-canvas"
+export type { GraphDegradeProfile } from "./graph-utils"
+export {
+	buildNodeDegreeMap,
+	getGraphDegradeProfile,
+	sampleEdgesForRender,
+	toRenderNodes,
+} from "./graph-utils"
+export type {
+	GraphEdge,
+	GraphNode,
+	GraphRenderNode,
+	GraphViewData,
+} from "./types"

--- a/packages/graph-view/src/types.ts
+++ b/packages/graph-view/src/types.ts
@@ -16,16 +16,6 @@ export type GraphViewData = {
 	edges: GraphEdge[]
 }
 
-export type GraphNodeOpenAction =
-	| {
-			type: "open"
-			relPath: string
-	  }
-	| {
-			type: "unresolved"
-			relPath: string
-	  }
-
 export type GraphRenderNode = GraphNode & {
 	degree: number
 }

--- a/packages/graph-view/tsconfig.json
+++ b/packages/graph-view/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": "@mdit/tsconfig/react-app"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@mdit/git-sync':
         specifier: workspace:*
         version: link:../../packages/git-sync
+      '@mdit/graph-view':
+        specifier: workspace:*
+        version: link:../../packages/graph-view
       '@mdit/license':
         specifier: workspace:*
         version: link:../../packages/license
@@ -695,6 +698,31 @@ importers:
 
   packages/git-sync:
     devDependencies:
+      vitest:
+        specifier: ^4.0.9
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+
+  packages/graph-view:
+    dependencies:
+      '@mdit/ui':
+        specifier: workspace:*
+        version: link:../ui
+      d3-force:
+        specifier: ^3.0.0
+        version: 3.0.0
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+    devDependencies:
+      '@mdit/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/d3-force':
+        specifier: ^3.0.10
+        version: 3.0.10
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
       vitest:
         specifier: ^4.0.9
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)


### PR DESCRIPTION
## Summary
- extract the graph canvas, graph utils, and graph types into a new `@mdit/graph-view` workspace package
- update the desktop graph dialog to consume the package and pass active file state/open handlers from the app store
- add the desktop Tailwind source entry for the new package so graph-view classes are included in the app build

## Testing
- pnpm --filter @mdit/graph-view test
- pnpm ts:check:desktop