### PR TITLE
feat: open slash menu from insert handle

### DIFF
--- a/packages/editor/src/selection/block-draggable.tsx
+++ b/packages/editor/src/selection/block-draggable.tsx
@@ -2,10 +2,11 @@ import { useDraggable, useDroppable } from "@dnd-kit/react"
 import { cn } from "@mdit/ui/lib/utils"
 import { BlockSelectionPlugin } from "@platejs/selection/react"
 import { GripVertical, Plus } from "lucide-react"
-import { KEYS, PathApi } from "platejs"
+import { KEYS, type TElement } from "platejs"
 import { type PlateElementProps, usePluginOption } from "platejs/react"
 import type { MouseEvent } from "react"
 import { FRONTMATTER_KEY } from "../frontmatter"
+import { insertSlashMenuBelow } from "../slash/insert-slash-menu"
 
 const headingTopMap: Record<string, string> = {
 	[KEYS.h1]: "top-13",
@@ -153,38 +154,14 @@ export function Draggable(
 	}
 
 	const handleInsertBelow = () => {
-		const entry = props.editor.api.node({
+		const entry = props.editor.api.node<TElement>({
 			at: [],
 			block: true,
 			match: (node) => node.id === elementId,
 		})
 		if (!entry) return
 
-		const [node, currentPath] = entry
-		if (currentPath.length !== 1) return
-
-		const listStyleType = (node as { listStyleType?: string }).listStyleType
-		const indent = (node as { indent?: number }).indent ?? 1
-
-		const insertPath = PathApi.next(currentPath)
-		const blockProps = listStyleType
-			? {
-					indent,
-					listStyleType,
-					...(listStyleType === KEYS.listTodo && { checked: false }),
-				}
-			: {}
-
-		props.editor.tf.insertNodes(
-			props.editor.api.create.block({
-				type: props.editor.getType(KEYS.p),
-				children: [{ text: "" }],
-				...blockProps,
-			}),
-			{ at: insertPath },
-		)
-		props.editor.tf.select(insertPath, { edge: "start" })
-		props.editor.tf.focus()
+		insertSlashMenuBelow(props.editor, entry)
 	}
 
 	return (

--- a/packages/editor/src/shared/inline-combobox.tsx
+++ b/packages/editor/src/shared/inline-combobox.tsx
@@ -38,7 +38,17 @@ type FilterFn = (
 	search: string,
 ) => boolean
 
+export type InlineComboboxCancelCause =
+	| "arrowLeft"
+	| "arrowRight"
+	| "backspace"
+	| "blur"
+	| "deselect"
+	| "escape"
+	| "manual"
+
 type InlineComboboxContextValue = {
+	containerRef: React.RefObject<HTMLSpanElement | null>
 	filter: FilterFn | false
 	inputProps: UseComboboxInputResult["props"]
 	inputRef: React.RefObject<HTMLInputElement | null>
@@ -71,6 +81,12 @@ type InlineComboboxProps = {
 	trigger: string
 	filter?: FilterFn | false
 	hideWhenNoValue?: boolean
+	onCancelInput?: (context: {
+		cause: InlineComboboxCancelCause
+		insertPoint: Point | null
+		trigger: string
+		value: string
+	}) => boolean | undefined
 	showTrigger?: boolean
 	value?: string
 	setValue?: (value: string) => void
@@ -81,11 +97,13 @@ const InlineCombobox = ({
 	element,
 	filter = defaultFilter,
 	hideWhenNoValue = false,
+	onCancelInput,
 	setValue: setValueProp,
 	showTrigger = true,
 	trigger,
 	value: valueProp,
 }: InlineComboboxProps) => {
+	const containerRef = useRef<HTMLSpanElement>(null)
 	const editor = useEditorRef()
 	const inputRef = useRef<HTMLInputElement>(null)
 	const cursorState = useHTMLInputCursorState(inputRef)
@@ -133,9 +151,19 @@ const InlineCombobox = ({
 		cursorState,
 		ref: inputRef,
 		onCancelInput: (cause) => {
+			if (
+				onCancelInput?.({
+					cause,
+					insertPoint: insertPoint.current,
+					trigger,
+					value,
+				})
+			) {
+				return
+			}
 			if (cause !== "backspace") {
 				editor.tf.insertText(trigger + value, {
-					at: insertPoint?.current ?? undefined,
+					at: insertPoint.current ?? undefined,
 				})
 			}
 			if (cause === "arrowLeft" || cause === "arrowRight") {
@@ -151,6 +179,7 @@ const InlineCombobox = ({
 
 	const contextValue: InlineComboboxContextValue = useMemo(
 		() => ({
+			containerRef,
 			filter,
 			inputProps,
 			inputRef,
@@ -211,6 +240,7 @@ const InlineComboboxInput = ({
 	triggerClassName?: string
 } & React.ComponentPropsWithoutRef<typeof Combobox>) => {
 	const {
+		containerRef,
 		inputProps,
 		inputRef: contextRef,
 		showTrigger,
@@ -245,7 +275,10 @@ const InlineComboboxInput = ({
 	 */
 
 	return (
-		<span className={cn("inline-flex items-center", containerClassName)}>
+		<span
+			ref={containerRef}
+			className={cn("inline-flex items-center", containerClassName)}
+		>
 			{showTrigger && <span className={triggerClassName}>{trigger}</span>}
 
 			<span className="relative min-h-lh">
@@ -281,6 +314,7 @@ const InlineComboboxContent: typeof ComboboxPopover = ({
 	className,
 	...props
 }) => {
+	const { containerRef } = useContext(InlineComboboxContext)
 	const store = useComboboxContext()!
 	const currentPlacement = store.useState("currentPlacement")
 	const side = currentPlacement?.split("-")[0]
@@ -298,6 +332,9 @@ const InlineComboboxContent: typeof ComboboxPopover = ({
 					"z-500 max-h-[288px] w-[300px] overflow-y-auto rounded-md bg-popover shadow-lg border",
 					className,
 				)}
+				getAnchorRect={() => {
+					return containerRef.current?.getBoundingClientRect() ?? null
+				}}
 				render={
 					<motion.div
 						key={side ?? "bottom"}

--- a/packages/editor/src/slash/insert-slash-menu.ts
+++ b/packages/editor/src/slash/insert-slash-menu.ts
@@ -1,0 +1,50 @@
+import { KEYS, type NodeEntry, PathApi, type TElement } from "platejs"
+import type { PlateEditor } from "platejs/react"
+import { createSlashInputNode } from "./slash-input"
+
+export const insertSlashMenuBelow = (
+	editor: PlateEditor,
+	entry: NodeEntry<TElement>,
+) => {
+	const [node, currentPath] = entry
+
+	if (currentPath.length !== 1) return false
+
+	const listStyleType = (node as { listStyleType?: string }).listStyleType
+	const indent = (node as { indent?: number }).indent ?? 1
+	const insertPath = PathApi.next(currentPath)
+	const blockProps = listStyleType
+		? {
+				indent,
+				listStyleType,
+				...(listStyleType === KEYS.listTodo && { checked: false }),
+			}
+		: {}
+
+	editor.tf.withoutNormalizing(() => {
+		editor.tf.insertNodes(
+			editor.api.create.block({
+				type: editor.getType(KEYS.p) || KEYS.p,
+				children: [{ text: "" }],
+				...blockProps,
+			}),
+			{ at: insertPath },
+		)
+
+		const start = editor.api.start(insertPath)
+
+		if (!start) return
+
+		editor.tf.select(start)
+		editor.tf.insertNodes(
+			createSlashInputNode({
+				source: "insert-handle",
+				type: editor.getType(KEYS.slashInput) ?? KEYS.slashInput,
+			}),
+			{ at: start },
+		)
+		editor.tf.focus()
+	})
+
+	return true
+}

--- a/packages/editor/src/slash/node-slash.tsx
+++ b/packages/editor/src/slash/node-slash.tsx
@@ -21,7 +21,7 @@ import {
 	TypeIcon,
 } from "lucide-react"
 import type { NodeComponent } from "platejs"
-import { KEYS, PointApi, type TComboboxInputElement } from "platejs"
+import { KEYS, PointApi } from "platejs"
 import type { PlateEditor, PlateElementProps } from "platejs/react"
 import { PlateElement } from "platejs/react"
 import { applyPreviousCodeBlockLanguage } from "../code/code-block-language"
@@ -41,8 +41,16 @@ import {
 	InlineComboboxInput,
 	InlineComboboxItem,
 } from "../shared/inline-combobox"
+import {
+	getSlashInputCancelBehavior,
+	type SlashInputElement as SlashInputNode,
+} from "../slash/slash-input"
 import type { SlashHostDeps } from "../slash/slash-kit-types"
-import { insertBlock, insertInlineElement } from "../slash/transforms"
+import {
+	getBlockType,
+	insertBlock,
+	insertInlineElement,
+} from "../slash/transforms"
 
 function insertImageNode(
 	editor: PlateEditor,
@@ -377,10 +385,18 @@ export const createSlashInputElement = (
 ): NodeComponent => {
 	const groups = createSlashGroups(host)
 
-	return function SlashInputElement(
-		props: PlateElementProps<TComboboxInputElement>,
-	) {
+	return function SlashInputElement(props: PlateElementProps<SlashInputNode>) {
 		const { editor, element } = props
+		const source = element.source
+		const shouldReuseCurrentBlock = (type: string) => {
+			const currentBlock = editor.api.block()
+
+			if (!currentBlock || !editor.api.isEmpty(currentBlock[0])) {
+				return false
+			}
+
+			return getBlockType(currentBlock[0]) === type
+		}
 
 		const elementPath = editor.api.findPath(element)
 		const beforePoint = elementPath ? editor.api.before(elementPath) : null
@@ -397,14 +413,41 @@ export const createSlashInputElement = (
 
 		return (
 			<PlateElement {...props} as="span">
-				<InlineCombobox element={element} trigger="/">
+				<InlineCombobox
+					element={element}
+					trigger="/"
+					showTrigger={source !== "insert-handle"}
+					onCancelInput={({ cause, insertPoint, trigger, value }) => {
+						const behavior = getSlashInputCancelBehavior({
+							cause,
+							source,
+							trigger,
+							value,
+						})
+
+						if (behavior.restoreText) {
+							editor.tf.insertText(behavior.restoreText, {
+								at: insertPoint ?? undefined,
+							})
+						}
+
+						if (behavior.move) {
+							editor.tf.move({
+								distance: 1,
+								reverse: behavior.move === "left",
+							})
+						}
+
+						return true
+					}}
+				>
 					<InlineComboboxInput
 						containerClassName="inline-flex items-center rounded-md bg-muted px-1 py-0.5 -ml-1 -mt-0.5"
 						className="placeholder:text-muted-foreground"
 						placeholder="Type to search"
 					/>
 
-					<InlineComboboxContent>
+					<InlineComboboxContent gutter={4}>
 						<InlineComboboxEmpty>No results</InlineComboboxEmpty>
 
 						{groups
@@ -432,6 +475,13 @@ export const createSlashInputElement = (
 													key={value}
 													value={value}
 													onClick={() => {
+														if (
+															group === "Basic blocks" &&
+															shouldReuseCurrentBlock(value)
+														) {
+															return
+														}
+
 														void onSelect(editor, value)
 													}}
 													label={label}

--- a/packages/editor/src/slash/slash-input.ts
+++ b/packages/editor/src/slash/slash-input.ts
@@ -1,0 +1,65 @@
+import { KEYS, type TComboboxInputElement } from "platejs"
+
+export type SlashInputSource = "slash-trigger" | "insert-handle"
+
+export type SlashInputElement = TComboboxInputElement & {
+	source?: SlashInputSource
+}
+
+export type SlashInputCancelCause =
+	| "arrowLeft"
+	| "arrowRight"
+	| "backspace"
+	| "blur"
+	| "deselect"
+	| "escape"
+	| "manual"
+
+export type SlashInputCancelBehavior = {
+	move?: "left" | "right"
+	restoreText: string | null
+}
+
+export const createSlashInputNode = ({
+	source = "slash-trigger",
+	type = KEYS.slashInput,
+}: {
+	source?: SlashInputSource
+	type?: string
+} = {}): SlashInputElement => ({
+	type,
+	value: "",
+	children: [{ text: "" }],
+	source,
+})
+
+export const getSlashInputCancelBehavior = ({
+	cause,
+	source,
+	trigger,
+	value,
+}: {
+	cause: SlashInputCancelCause
+	source?: SlashInputSource
+	trigger: string
+	value: string
+}): SlashInputCancelBehavior => {
+	const move =
+		cause === "arrowLeft"
+			? "left"
+			: cause === "arrowRight"
+				? "right"
+				: undefined
+
+	if (source === "insert-handle") {
+		return {
+			move,
+			restoreText: cause === "backspace" ? null : value,
+		}
+	}
+
+	return {
+		move,
+		restoreText: cause === "backspace" ? null : `${trigger}${value}`,
+	}
+}

--- a/packages/editor/src/slash/slash-kit.ts
+++ b/packages/editor/src/slash/slash-kit.ts
@@ -1,6 +1,7 @@
 import { SlashInputPlugin, SlashPlugin } from "@platejs/slash-command/react"
 import { KEYS } from "platejs"
 import { createSlashInputElement } from "../slash/node-slash"
+import { createSlashInputNode } from "../slash/slash-input"
 import type { SlashHostDeps } from "./slash-kit-types"
 
 export type { SlashHostDeps } from "./slash-kit-types"
@@ -12,6 +13,7 @@ type CreateSlashKitOptions = {
 export const createSlashKit = ({ host }: CreateSlashKitOptions = {}) => [
 	SlashPlugin.configure({
 		options: {
+			createComboboxInput: () => createSlashInputNode(),
 			triggerQuery: (editor) => {
 				// Don't trigger in code blocks
 				if (


### PR DESCRIPTION
## Summary
- open the slash menu when inserting a block from the draggable plus handle
- reuse the current empty block for matching basic block selections to avoid duplicate empty paragraphs
- anchor the inline combobox popover to the rendered input container for the new slash input flow

## Testing
- pnpm ts:check:all
- pnpm lint:fix

## Notes
- insert-handle cancel behavior remains unchanged in this PR apart from the duplicate paragraph fix