### PR TITLE
refactor: unify command menu note presentation

### DIFF
--- a/packages/command-menu/src/command-menu.tsx
+++ b/packages/command-menu/src/command-menu.tsx
@@ -11,14 +11,15 @@ import { motion } from "motion/react"
 import { useCallback, useDeferredValue, useEffect, useState } from "react"
 import useMeasure from "react-use-measure"
 import { highlightQuery } from "./highlight-query"
-import { getFileNameFromPath, stripMarkdownExtension } from "./path-utils"
+import { resolveNotePresentation } from "./note-presentation"
+import { getFileNameFromPath, getParentPathLabel } from "./path-utils"
 import type {
 	CommandMenuContentSearch,
 	CommandMenuEntry,
 	CommandMenuSemanticSearch,
 } from "./types"
 import { useNoteContentSearch } from "./use-note-content-search"
-import { toRelativePath, useNoteNameSearch } from "./use-note-name-search"
+import { useNoteNameSearch } from "./use-note-name-search"
 import { useSemanticSearch } from "./use-semantic-search"
 
 export type CommandMenuProps = {
@@ -146,7 +147,7 @@ export function CommandMenu({
 									<div className="flex flex-col">
 										<span>{note.label}</span>
 										<span className="text-muted-foreground/80 text-xs">
-											{note.relativePath}
+											{getParentPathLabel(note.relativePath)}
 										</span>
 									</div>
 								</CommandItem>
@@ -157,13 +158,13 @@ export function CommandMenu({
 						<CommandGroup heading="Suggestions">
 							{semanticResults.slice(0, 5).map((result) => {
 								const note = noteResultsByPath.get(result.path)
-								const label =
-									note?.label ||
-									stripMarkdownExtension(result.name).trim() ||
-									result.name
-								const relativePath =
-									note?.relativePath ??
-									toRelativePath(result.path, workspacePath)
+								const { label, relativePath, parentPathLabel } =
+									resolveNotePresentation({
+										note,
+										path: result.path,
+										workspacePath,
+										fallbackName: result.name,
+									})
 								const keywords = [label, relativePath, "semantic", "ai"].filter(
 									Boolean,
 								) as string[]
@@ -181,7 +182,7 @@ export function CommandMenu({
 												<span className="truncate">{label}</span>
 											</div>
 											<span className="text-muted-foreground/80 truncate text-xs">
-												{relativePath}
+												{parentPathLabel}
 											</span>
 										</div>
 									</CommandItem>
@@ -193,12 +194,13 @@ export function CommandMenu({
 						<CommandGroup heading="Content Matches">
 							{contentMatchesByNote.map((group) => {
 								const note = noteResultsByPath.get(group.path)
-								const label =
-									note?.label ??
-									stripMarkdownExtension(getFileNameFromPath(group.path))
-								const relativePath =
-									note?.relativePath ??
-									toRelativePath(group.path, workspacePath)
+								const { label, relativePath, parentPathLabel } =
+									resolveNotePresentation({
+										note,
+										path: group.path,
+										workspacePath,
+										fallbackName: getFileNameFromPath(group.path),
+									})
 								const keywords = [
 									label,
 									relativePath,
@@ -229,7 +231,7 @@ export function CommandMenu({
 												))}
 											</div>
 											<span className="text-muted-foreground text-xs">
-												{relativePath}
+												{parentPathLabel}
 											</span>
 										</div>
 									</CommandItem>

--- a/packages/command-menu/src/note-presentation.test.ts
+++ b/packages/command-menu/src/note-presentation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import { resolveNotePresentation } from "./note-presentation"
+
+describe("resolveNotePresentation", () => {
+	it("reuses note metadata when available", () => {
+		expect(
+			resolveNotePresentation({
+				note: {
+					label: "Existing label",
+					relativePath: "folder/existing.md",
+				},
+				path: "/workspace/folder/existing.md",
+				workspacePath: "/workspace",
+				fallbackName: "ignored.md",
+			}),
+		).toEqual({
+			label: "Existing label",
+			relativePath: "folder/existing.md",
+			parentPathLabel: "folder",
+		})
+	})
+
+	it("derives presentation from path when note metadata is missing", () => {
+		expect(
+			resolveNotePresentation({
+				path: "/workspace/folder/derived.md",
+				workspacePath: "/workspace",
+				fallbackName: "derived.md",
+			}),
+		).toEqual({
+			label: "derived",
+			relativePath: "folder/derived.md",
+			parentPathLabel: "folder",
+		})
+	})
+})

--- a/packages/command-menu/src/note-presentation.ts
+++ b/packages/command-menu/src/note-presentation.ts
@@ -1,0 +1,30 @@
+import { getParentPathLabel, stripMarkdownExtension } from "./path-utils"
+import { toRelativePath } from "./use-note-name-search"
+
+export type NotePresentation = {
+	label: string
+	relativePath: string
+	parentPathLabel: string
+}
+
+export const resolveNotePresentation = ({
+	note,
+	path,
+	workspacePath,
+	fallbackName,
+}: {
+	note?: { label: string; relativePath: string }
+	path: string
+	workspacePath: string | null
+	fallbackName: string
+}): NotePresentation => {
+	const label =
+		note?.label || stripMarkdownExtension(fallbackName).trim() || fallbackName
+	const relativePath = note?.relativePath ?? toRelativePath(path, workspacePath)
+
+	return {
+		label,
+		relativePath,
+		parentPathLabel: getParentPathLabel(relativePath),
+	}
+}

--- a/packages/command-menu/src/path-utils.test.ts
+++ b/packages/command-menu/src/path-utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+import { getParentPathLabel } from "./path-utils"
+
+describe("getParentPathLabel", () => {
+	it("returns the immediate containing folder path for relative note paths", () => {
+		expect(getParentPathLabel("folder/note.md")).toBe("folder")
+		expect(getParentPathLabel("nested/folder/note.md")).toBe("nested/folder")
+	})
+
+	it("returns root label for notes directly under the workspace root", () => {
+		expect(getParentPathLabel("note.md")).toBe("/")
+	})
+
+	it("normalizes windows-style separators before deriving the parent path", () => {
+		expect(getParentPathLabel("nested\\folder\\note.md")).toBe("nested/folder")
+	})
+})

--- a/packages/command-menu/src/path-utils.ts
+++ b/packages/command-menu/src/path-utils.ts
@@ -7,3 +7,12 @@ export const getFileNameFromPath = (path: string) => {
 	const segments = path.split(/[/\\]/)
 	return segments[segments.length - 1] ?? path
 }
+
+export const getParentPathLabel = (path: string) => {
+	const normalizedPath = path.replace(/\\/g, "/")
+	const segments = normalizedPath.split("/")
+	segments.pop()
+
+	const parentPath = segments.join("/").trim()
+	return parentPath || "/"
+}


### PR DESCRIPTION
## Summary
- extract shared note presentation resolution for semantic and content search results
- show parent folder labels consistently across recent notes, suggestions, and content matches
- add focused tests for note presentation and parent path labeling

## Testing
- pnpm --filter @mdit/command-menu test