### PR TITLE
feat: add tag search and editor tag interactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6721,6 +6721,7 @@ dependencies = [
  "pulldown-cmark",
  "rusqlite",
  "serde",
+ "serde_yaml",
  "tiktoken-rs",
  "vault-indexing-api",
  "walkdir",

--- a/apps/desktop/src-tauri/src/commands/vault_indexing.rs
+++ b/apps/desktop/src-tauri/src/commands/vault_indexing.rs
@@ -3,9 +3,10 @@ use std::path::{Path, PathBuf};
 use app_storage::vault::VaultEmbeddingConfig;
 use mdit_vault_indexing::{
     delete_indexed_note, get_backlinks, get_graph_view_data, get_indexing_meta, get_related_notes,
-    index_note, index_workspace, rename_indexed_note, resolve_wiki_link, search_notes_for_query,
-    BacklinkEntry, GraphViewData, IndexSummary, IndexingMeta, RelatedNoteEntry,
-    ResolveWikiLinkRequest, ResolveWikiLinkResult, SemanticNoteEntry,
+    index_note, index_workspace, rename_indexed_note, resolve_wiki_link, search_notes_by_tag,
+    search_notes_for_query, BacklinkEntry, GraphViewData, IndexSummary, IndexingMeta,
+    RelatedNoteEntry, ResolveWikiLinkRequest, ResolveWikiLinkResult, SemanticNoteEntry,
+    TagNoteEntry,
 };
 use tauri::{AppHandle, Runtime};
 
@@ -146,6 +147,18 @@ pub async fn search_query_entries_command(
         )
     })
     .await
+}
+
+#[tauri::command]
+pub async fn search_tag_entries_command(
+    app_handle: tauri::AppHandle,
+    workspace_path: String,
+    tag_query: String,
+) -> Result<Vec<TagNoteEntry>, String> {
+    let db_path = crate::persistence::run_app_migrations(&app_handle)?;
+    let workspace_path = PathBuf::from(workspace_path);
+
+    run_blocking(move || search_notes_by_tag(&workspace_path, &db_path, &tag_query)).await
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -57,6 +57,7 @@ pub fn run() {
             commands::vault_indexing::delete_indexed_note_command,
             commands::vault_indexing::get_indexing_meta_command,
             commands::vault_indexing::search_query_entries_command,
+            commands::vault_indexing::search_tag_entries_command,
             commands::vault_indexing::resolve_wiki_link_command,
             commands::vault_indexing::get_backlinks_command,
             commands::vault_indexing::get_related_notes_command,

--- a/apps/desktop/src/components/command-menu/command-menu.tsx
+++ b/apps/desktop/src/components/command-menu/command-menu.tsx
@@ -1,6 +1,7 @@
 import {
 	type CommandMenuContentMatch,
 	type CommandMenuSemanticResult,
+	type CommandMenuTagResult,
 	CommandMenu as SharedCommandMenu,
 } from "@mdit/command-menu"
 import { invoke } from "@tauri-apps/api/core"
@@ -17,12 +18,19 @@ type QuerySearchEntry = {
 	similarity: number
 }
 
+type QueryTagEntry = {
+	path: string
+	name: string
+	modifiedAt?: number
+}
+
 export function CommandMenu() {
 	const {
 		entries,
 		workspacePath,
 		openTab,
 		isCommandMenuOpen,
+		commandMenuInitialQuery,
 		setCommandMenuOpen,
 		getIndexingConfig,
 	} = useStore(
@@ -31,6 +39,7 @@ export function CommandMenu() {
 			workspacePath: state.workspacePath,
 			openTab: state.openTab,
 			isCommandMenuOpen: state.isCommandMenuOpen,
+			commandMenuInitialQuery: state.commandMenuInitialQuery,
 			setCommandMenuOpen: state.setCommandMenuOpen,
 			getIndexingConfig: state.getIndexingConfig,
 		})),
@@ -92,6 +101,31 @@ export function CommandMenu() {
 		[],
 	)
 
+	const searchTags = useCallback(
+		async (
+			query: string,
+			currentWorkspacePath: string,
+		): Promise<CommandMenuTagResult[]> => {
+			const results = await invoke<QueryTagEntry[]>(
+				"search_tag_entries_command",
+				{
+					workspacePath: currentWorkspacePath,
+					tagQuery: query,
+				},
+			)
+
+			return results.map((entry) => ({
+				path: entry.path,
+				name: entry.name,
+				modifiedAt:
+					typeof entry.modifiedAt === "number"
+						? new Date(entry.modifiedAt)
+						: undefined,
+			}))
+		},
+		[],
+	)
+
 	return (
 		<SharedCommandMenu
 			open={isCommandMenuOpen}
@@ -99,8 +133,10 @@ export function CommandMenu() {
 			workspacePath={workspacePath}
 			entries={entries}
 			onSelectPath={handleSelectNote}
+			initialQuery={commandMenuInitialQuery}
 			searchContent={searchContent}
 			searchSemantic={searchSemantic}
+			searchTags={searchTags}
 		/>
 	)
 }

--- a/apps/desktop/src/components/editor/hosts/frontmatter-host.ts
+++ b/apps/desktop/src/components/editor/hosts/frontmatter-host.ts
@@ -4,15 +4,19 @@ import {
 	normalizeWikiTargetForDisplay,
 	openEditorLink,
 } from "@mdit/editor/link"
+import type { TagHostDeps } from "@mdit/editor/tag"
 import { createDesktopLinkHost } from "./link-host"
+import { createDesktopTagHost } from "./tag-host"
 
 type DesktopFrontmatterHostRuntimeDeps = {
 	linkHost: LinkHostDeps
+	tagHost: TagHostDeps
 	onResolveWikiLinkError?: (error: unknown) => void
 }
 
 const defaultRuntimeDeps: DesktopFrontmatterHostRuntimeDeps = {
 	linkHost: createDesktopLinkHost(),
+	tagHost: createDesktopTagHost(),
 	onResolveWikiLinkError: (error) => {
 		console.warn(
 			"Failed to resolve frontmatter wiki link via invoke; using fallback:",
@@ -22,43 +26,51 @@ const defaultRuntimeDeps: DesktopFrontmatterHostRuntimeDeps = {
 }
 
 export const createDesktopFrontmatterHost = (
-	runtimeDeps: DesktopFrontmatterHostRuntimeDeps = defaultRuntimeDeps,
-): FrontmatterHostDeps => ({
-	onOpenWikiLink: (target) =>
-		openEditorLink({
-			href: target,
-			wiki: true,
-			wikiTarget: target,
-			host: runtimeDeps.linkHost,
-			workspaceState: runtimeDeps.linkHost.getWorkspaceState(),
-		}),
-	getLinkWorkspaceState: runtimeDeps.linkHost.getWorkspaceState,
-	resolveWikiLinkTarget: async (rawTarget, fallbackTarget) => {
-		const workspaceState = runtimeDeps.linkHost.getWorkspaceState()
-		const workspacePath = workspaceState.workspacePath
-		const currentTabPath = workspaceState.tab?.path ?? null
-		if (!workspacePath) {
-			return fallbackTarget
-		}
+	runtimeDeps: Partial<DesktopFrontmatterHostRuntimeDeps> = defaultRuntimeDeps,
+): FrontmatterHostDeps => {
+	const deps = {
+		...defaultRuntimeDeps,
+		...runtimeDeps,
+	}
 
-		try {
-			const resolved = await runtimeDeps.linkHost.resolveWikiLink({
-				workspacePath,
-				currentNotePath: currentTabPath,
-				rawTarget,
-			})
-			const canonicalTarget = normalizeWikiTargetForDisplay(
-				resolved.canonicalTarget,
-			)
-			if (resolved.unresolved) {
-				return fallbackTarget || canonicalTarget
+	return {
+		onOpenWikiLink: (target) =>
+			openEditorLink({
+				href: target,
+				wiki: true,
+				wikiTarget: target,
+				host: deps.linkHost,
+				workspaceState: deps.linkHost.getWorkspaceState(),
+			}),
+		getLinkWorkspaceState: deps.linkHost.getWorkspaceState,
+		resolveWikiLinkTarget: async (rawTarget, fallbackTarget) => {
+			const workspaceState = deps.linkHost.getWorkspaceState()
+			const workspacePath = workspaceState.workspacePath
+			const currentTabPath = workspaceState.tab?.path ?? null
+			if (!workspacePath) {
+				return fallbackTarget
 			}
-			return canonicalTarget || fallbackTarget
-		} catch (error) {
-			runtimeDeps.onResolveWikiLinkError?.(error)
-			return fallbackTarget
-		}
-	},
-})
+
+			try {
+				const resolved = await deps.linkHost.resolveWikiLink({
+					workspacePath,
+					currentNotePath: currentTabPath,
+					rawTarget,
+				})
+				const canonicalTarget = normalizeWikiTargetForDisplay(
+					resolved.canonicalTarget,
+				)
+				if (resolved.unresolved) {
+					return fallbackTarget || canonicalTarget
+				}
+				return canonicalTarget || fallbackTarget
+			} catch (error) {
+				deps.onResolveWikiLinkError?.(error)
+				return fallbackTarget
+			}
+		},
+		onOpenTagSearch: deps.tagHost.openTagSearch,
+	}
+}
 
 export const desktopFrontmatterHost = createDesktopFrontmatterHost()

--- a/apps/desktop/src/components/editor/hosts/tag-host.ts
+++ b/apps/desktop/src/components/editor/hosts/tag-host.ts
@@ -1,0 +1,8 @@
+import type { TagHostDeps } from "@mdit/editor/tag"
+import { useStore } from "@/store"
+
+export const createDesktopTagHost = (): TagHostDeps => ({
+	openTagSearch: (query) => {
+		useStore.getState().openCommandMenuWithQuery(query)
+	},
+})

--- a/apps/desktop/src/components/editor/plugins/editor-kit.ts
+++ b/apps/desktop/src/components/editor/plugins/editor-kit.ts
@@ -28,6 +28,7 @@ import {
 import { createSlashKit } from "@mdit/editor/slash"
 import { SuggestionKit } from "@mdit/editor/suggestion"
 import { TableKit } from "@mdit/editor/table"
+import { createTagKit } from "@mdit/editor/tag"
 import { TocKit } from "@mdit/editor/toc"
 import type { RenderNodeWrapper } from "platejs/react"
 import { useStore } from "@/store"
@@ -38,6 +39,7 @@ import { createDesktopFrontmatterHost } from "../hosts/frontmatter-host"
 import { createDesktopLinkHost } from "../hosts/link-host"
 import { desktopMediaHost } from "../hosts/media-host"
 import { desktopSlashHost } from "../hosts/slash-host"
+import { createDesktopTagHost } from "../hosts/tag-host"
 import { TabMetadataKit } from "./tab-metadata-kit"
 
 const AppBlockDraggable: RenderNodeWrapper = (props) => {
@@ -54,8 +56,10 @@ const DndKit = [
 ]
 
 const desktopLinkHost = createDesktopLinkHost()
+const desktopTagHost = createDesktopTagHost()
 const desktopFrontmatterHost = createDesktopFrontmatterHost({
 	linkHost: desktopLinkHost,
+	tagHost: desktopTagHost,
 })
 const desktopBlockSelectionHost = createDesktopBlockSelectionHost()
 
@@ -88,6 +92,7 @@ const createEditorKit = ({ mdx = true }: CreateEditorKitOptions = {}) => [
 	...ShortcutsKit,
 	...createSlashKit({ host: desktopSlashHost }),
 	...SuggestionKit,
+	...createTagKit({ host: desktopTagHost }),
 	...TableKit,
 	...TocKit,
 	...UtilsKit,

--- a/apps/desktop/src/store/ui/ui-slice.test.ts
+++ b/apps/desktop/src/store/ui/ui-slice.test.ts
@@ -113,3 +113,34 @@ describe("ui-slice note info panel", () => {
 		expect(store.getState().isNoteInfoOpen).toBe(false)
 	})
 })
+
+describe("ui-slice command menu seed query", () => {
+	it("opens the command menu with a seeded query", () => {
+		const store = createUISliceStore()
+
+		store.getState().openCommandMenuWithQuery("#project/docs")
+
+		expect(store.getState().isCommandMenuOpen).toBe(true)
+		expect(store.getState().commandMenuInitialQuery).toBe("#project/docs")
+	})
+
+	it("clears the seeded query when the menu closes", () => {
+		const store = createUISliceStore()
+
+		store.getState().openCommandMenuWithQuery("#project")
+		store.getState().closeCommandMenu()
+
+		expect(store.getState().isCommandMenuOpen).toBe(false)
+		expect(store.getState().commandMenuInitialQuery).toBeNull()
+	})
+
+	it("opens the command menu without a seed for normal entry", () => {
+		const store = createUISliceStore()
+
+		store.getState().openCommandMenuWithQuery("#project")
+		store.getState().openCommandMenu()
+
+		expect(store.getState().isCommandMenuOpen).toBe(true)
+		expect(store.getState().commandMenuInitialQuery).toBeNull()
+	})
+})

--- a/apps/desktop/src/store/ui/ui-slice.ts
+++ b/apps/desktop/src/store/ui/ui-slice.ts
@@ -21,8 +21,10 @@ export type UISlice = {
 	settingsInitialTab: SettingsTab | null
 	openSettingsWithTab: (tab: SettingsTab) => void
 	isCommandMenuOpen: boolean
+	commandMenuInitialQuery: string | null
 	setCommandMenuOpen: (isOpen: boolean) => void
 	openCommandMenu: () => void
+	openCommandMenuWithQuery: (query: string) => void
 	closeCommandMenu: () => void
 	toggleCommandMenu: () => void
 	isUpdateReady: boolean
@@ -100,11 +102,34 @@ export const prepareUISlice =
 				settingsInitialTab: tab,
 			}),
 		isCommandMenuOpen: false,
-		setCommandMenuOpen: (isOpen) => set({ isCommandMenuOpen: isOpen }),
-		openCommandMenu: () => set({ isCommandMenuOpen: true }),
-		closeCommandMenu: () => set({ isCommandMenuOpen: false }),
+		commandMenuInitialQuery: null,
+		setCommandMenuOpen: (isOpen) =>
+			set((state) => ({
+				isCommandMenuOpen: isOpen,
+				commandMenuInitialQuery: isOpen ? state.commandMenuInitialQuery : null,
+			})),
+		openCommandMenu: () =>
+			set({
+				isCommandMenuOpen: true,
+				commandMenuInitialQuery: null,
+			}),
+		openCommandMenuWithQuery: (query) =>
+			set({
+				isCommandMenuOpen: true,
+				commandMenuInitialQuery: query.trim() || null,
+			}),
+		closeCommandMenu: () =>
+			set({
+				isCommandMenuOpen: false,
+				commandMenuInitialQuery: null,
+			}),
 		toggleCommandMenu: () =>
-			set((state) => ({ isCommandMenuOpen: !state.isCommandMenuOpen })),
+			set((state) => ({
+				isCommandMenuOpen: !state.isCommandMenuOpen,
+				commandMenuInitialQuery: state.isCommandMenuOpen
+					? null
+					: state.commandMenuInitialQuery,
+			})),
 		isUpdateReady: false,
 		isUpdateDownloading: false,
 		setUpdateReady: (ready) => set({ isUpdateReady: ready }),

--- a/crates/app-storage/migrations/0002_doc_tags.sql
+++ b/crates/app-storage/migrations/0002_doc_tags.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `doc_tag` (
+	`doc_id` integer NOT NULL,
+	`tag` text NOT NULL,
+	`normalized_tag` text NOT NULL,
+	FOREIGN KEY (`doc_id`) REFERENCES `doc`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uniq_doc_tag_doc_normalized` ON `doc_tag` (`doc_id`,`normalized_tag`);
+--> statement-breakpoint
+CREATE INDEX `idx_doc_tag_normalized_doc` ON `doc_tag` (`normalized_tag`,`doc_id`);

--- a/crates/app-storage/src/migrations.rs
+++ b/crates/app-storage/src/migrations.rs
@@ -11,6 +11,8 @@ use rusqlite::Connection;
 
 use crate::sqlite_ext;
 
+// Keep SQL migrations embedded in the binary so desktop/test environments do not
+// depend on external migration files at runtime.
 static MIGRATIONS_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/migrations");
 
 const RELEASE_DB_FILE_NAME: &str = "appdata.db";

--- a/crates/vault-indexing/Cargo.toml
+++ b/crates/vault-indexing/Cargo.toml
@@ -12,6 +12,7 @@ ollama-client = { path = '../ollama-client' }
 pulldown-cmark = { version = '0.13.0', default-features = false, features = ['simd'] }
 rusqlite = { version = '0.31', features = ['bundled'] }
 serde = { version = '1', features = ['derive'] }
+serde_yaml = '0.9'
 tiktoken-rs = '0.5'
 walkdir = '2'
 vault-indexing-api = { path = '../vault-indexing-api' }

--- a/crates/vault-indexing/src/vault_indexing/embedding.rs
+++ b/crates/vault-indexing/src/vault_indexing/embedding.rs
@@ -13,6 +13,8 @@ pub(crate) struct EmbeddingVector {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum EmbeddingProvider {
     Ollama,
+    #[cfg(test)]
+    Test,
 }
 
 impl EmbeddingProvider {
@@ -20,6 +22,8 @@ impl EmbeddingProvider {
     fn from_str(value: &str) -> Result<Self> {
         match value.trim().to_lowercase().as_str() {
             "ollama" => Ok(Self::Ollama),
+            #[cfg(test)]
+            "test" => Ok(Self::Test),
             provider => Err(anyhow!(
                 "Unsupported embedding provider '{}'. Only 'ollama' is currently supported.",
                 provider
@@ -30,6 +34,8 @@ impl EmbeddingProvider {
 
 enum EmbeddingBackend {
     Ollama(BlockingOllamaEmbeddingClient),
+    #[cfg(test)]
+    Test,
 }
 
 pub(crate) struct EmbeddingClient {
@@ -51,6 +57,8 @@ impl EmbeddingClient {
                     .context("Failed to initialize Ollama embedding client")?;
                 EmbeddingBackend::Ollama(client)
             }
+            #[cfg(test)]
+            EmbeddingProvider::Test => EmbeddingBackend::Test,
         };
 
         Ok(Self {
@@ -67,6 +75,8 @@ impl EmbeddingClient {
     pub(crate) fn generate(&self, text: &str) -> Result<EmbeddingVector> {
         match &self.backend {
             EmbeddingBackend::Ollama(client) => self.generate_with_ollama(client, text),
+            #[cfg(test)]
+            EmbeddingBackend::Test => self.generate_with_test(text),
         }
     }
 
@@ -78,6 +88,30 @@ impl EmbeddingClient {
         let mut vector = client
             .generate_embedding(&self.model, text)
             .context("Failed to generate embeddings with Ollama")?;
+
+        l2_normalize(&mut vector).with_context(|| {
+            format!(
+                "Embedding vector for model '{}' contained invalid values",
+                self.model
+            )
+        })?;
+
+        let dim = i32::try_from(vector.len())
+            .map_err(|_| anyhow!("Embedding dimension {} exceeds i32::MAX", vector.len()))?;
+
+        Ok(EmbeddingVector {
+            dim,
+            bytes: f32_slice_to_le_bytes(&vector),
+        })
+    }
+
+    #[cfg(test)]
+    fn generate_with_test(&self, text: &str) -> Result<EmbeddingVector> {
+        let mut vector = vec![
+            text.len().max(1) as f32,
+            text.bytes().map(f32::from).sum::<f32>().max(1.0),
+            1.0,
+        ];
 
         l2_normalize(&mut vector).with_context(|| {
             format!(

--- a/crates/vault-indexing/src/vault_indexing/mod.rs
+++ b/crates/vault-indexing/src/vault_indexing/mod.rs
@@ -27,11 +27,12 @@ mod files;
 mod links;
 mod search;
 mod sync;
+mod tags;
 
 use embedding::{resolve_embedding_dimension, EmbeddingClient};
 use files::collect_markdown_files;
 use links::resolve_wiki_link_target;
-pub use search::{search_notes_for_query, SemanticNoteEntry};
+pub use search::{search_notes_by_tag, search_notes_for_query, SemanticNoteEntry, TagNoteEntry};
 use sync::{clear_segment_vectors_for_vault, sync_documents_with_prune};
 pub use vault_indexing_api::{BacklinkEntry, ResolveWikiLinkRequest, ResolveWikiLinkResult};
 

--- a/crates/vault-indexing/src/vault_indexing/search.rs
+++ b/crates/vault-indexing/src/vault_indexing/search.rs
@@ -12,7 +12,7 @@ use anyhow::{anyhow, Context, Result};
 use rusqlite::{params, Connection};
 use serde::Serialize;
 
-use super::embedding::EmbeddingClient;
+use super::{embedding::EmbeddingClient, tags::normalize_tag_query};
 
 const VECTOR_WEIGHT: f32 = 0.7;
 const BM25_WEIGHT: f32 = 0.3;
@@ -28,6 +28,15 @@ pub struct SemanticNoteEntry {
     pub created_at: Option<i64>,
     pub modified_at: Option<i64>,
     pub similarity: f32,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TagNoteEntry {
+    pub path: String,
+    pub name: String,
+    pub created_at: Option<i64>,
+    pub modified_at: Option<i64>,
 }
 
 #[derive(Debug, Default)]
@@ -138,6 +147,31 @@ pub fn search_notes_for_query(
         .collect::<Vec<_>>();
     let ranked_candidates = rank_score_inputs(candidates);
     materialize_ranked_entries(workspace_root, ranked_candidates)
+}
+
+pub fn search_notes_by_tag(
+    workspace_root: &Path,
+    db_path: &Path,
+    tag_query: &str,
+) -> Result<Vec<TagNoteEntry>> {
+    if !workspace_root.exists() {
+        return Err(anyhow!(
+            "Workspace path does not exist: {}",
+            workspace_root.display()
+        ));
+    }
+
+    let Some(normalized_tag) = normalize_tag_query(tag_query) else {
+        return Ok(Vec::new());
+    };
+
+    let conn = open_search_connection(db_path)?;
+    let Some(vault_id) = super::find_vault_id(&conn, workspace_root)? else {
+        return Ok(Vec::new());
+    };
+
+    let rel_paths = load_tag_scores(&conn, vault_id, &normalized_tag)?;
+    materialize_tag_entries(workspace_root, rel_paths)
 }
 
 fn open_search_connection(db_path: &Path) -> Result<Connection> {
@@ -256,6 +290,37 @@ fn load_vector_scores(
     Ok(output)
 }
 
+fn load_tag_scores(conn: &Connection, vault_id: i64, normalized_tag: &str) -> Result<Vec<String>> {
+    let descendant_pattern = format!("{}/%", escape_like_pattern(normalized_tag));
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT DISTINCT d.rel_path \
+             FROM doc_tag dt \
+             JOIN doc d ON d.id = dt.doc_id \
+             WHERE d.vault_id = ?1 \
+               AND (dt.normalized_tag = ?2 OR dt.normalized_tag LIKE ?3 ESCAPE '\\')",
+        )
+        .context("Failed to prepare tag search query")?;
+
+    let rows = stmt
+        .query_map(
+            params![vault_id, normalized_tag, descendant_pattern],
+            |row| row.get::<_, String>(0),
+        )
+        .context("Failed to run tag search query")?;
+
+    let mut output = Vec::new();
+    for row in rows {
+        let rel_path = row?;
+        if is_markdown(&rel_path) {
+            output.push(rel_path);
+        }
+    }
+
+    Ok(output)
+}
+
 fn segment_vec_table_exists(conn: &Connection) -> Result<bool> {
     let exists: i64 = conn
         .query_row(
@@ -362,10 +427,33 @@ pub(super) fn materialize_ranked_entries(
     let mut entries = Vec::new();
     for candidate in ranked_candidates {
         let absolute_path = workspace_root.join(&candidate.rel_path);
-        if let Some(entry) = build_entry(absolute_path, candidate.similarity)? {
+        if let Some(entry) = build_semantic_entry(absolute_path, candidate.similarity)? {
             entries.push(entry);
         }
     }
+    Ok(entries)
+}
+
+pub(super) fn materialize_tag_entries(
+    workspace_root: &Path,
+    rel_paths: Vec<String>,
+) -> Result<Vec<TagNoteEntry>> {
+    let mut entries = Vec::new();
+    for rel_path in rel_paths {
+        let absolute_path = workspace_root.join(rel_path);
+        if let Some(entry) = build_tag_entry(absolute_path)? {
+            entries.push(entry);
+        }
+    }
+
+    entries.sort_by(|left, right| {
+        right
+            .modified_at
+            .cmp(&left.modified_at)
+            .then_with(|| right.created_at.cmp(&left.created_at))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+
     Ok(entries)
 }
 
@@ -393,7 +481,42 @@ fn is_markdown(path: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn build_entry(path: PathBuf, similarity: f32) -> Result<Option<SemanticNoteEntry>> {
+fn build_semantic_entry(path: PathBuf, similarity: f32) -> Result<Option<SemanticNoteEntry>> {
+    let Some(entry) = build_fs_entry(path, Some(MIN_NOTE_BYTES))? else {
+        return Ok(None);
+    };
+
+    Ok(Some(SemanticNoteEntry {
+        path: entry.path,
+        name: entry.name,
+        created_at: entry.created_at,
+        modified_at: entry.modified_at,
+        similarity,
+    }))
+}
+
+fn build_tag_entry(path: PathBuf) -> Result<Option<TagNoteEntry>> {
+    let Some(entry) = build_fs_entry(path, None)? else {
+        return Ok(None);
+    };
+
+    Ok(Some(TagNoteEntry {
+        path: entry.path,
+        name: entry.name,
+        created_at: entry.created_at,
+        modified_at: entry.modified_at,
+    }))
+}
+
+#[derive(Debug)]
+struct FsNoteEntry {
+    path: String,
+    name: String,
+    created_at: Option<i64>,
+    modified_at: Option<i64>,
+}
+
+fn build_fs_entry(path: PathBuf, min_bytes: Option<u64>) -> Result<Option<FsNoteEntry>> {
     if !path.exists() {
         return Ok(None);
     }
@@ -403,7 +526,7 @@ fn build_entry(path: PathBuf, similarity: f32) -> Result<Option<SemanticNoteEntr
         Err(_) => return Ok(None),
     };
 
-    if metadata.len() < MIN_NOTE_BYTES {
+    if min_bytes.is_some_and(|min_bytes| metadata.len() < min_bytes) {
         return Ok(None);
     }
 
@@ -416,13 +539,26 @@ fn build_entry(path: PathBuf, similarity: f32) -> Result<Option<SemanticNoteEntr
         .map(|value| value.to_string())
         .unwrap_or_else(|| path.to_string_lossy().into_owned());
 
-    Ok(Some(SemanticNoteEntry {
+    Ok(Some(FsNoteEntry {
         path: path.to_string_lossy().into_owned(),
         name,
         created_at,
         modified_at,
-        similarity,
     }))
+}
+
+fn escape_like_pattern(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '\\' | '%' | '_' => {
+                output.push('\\');
+                output.push(ch);
+            }
+            _ => output.push(ch),
+        }
+    }
+    output
 }
 
 fn system_time_to_millis(time: SystemTime) -> Option<i64> {
@@ -435,7 +571,7 @@ fn system_time_to_millis(time: SystemTime) -> Option<i64> {
 mod tests {
     use rusqlite::{params, Connection};
 
-    use super::load_vector_scores;
+    use super::{escape_like_pattern, load_tag_scores, load_vector_scores};
 
     fn embedding_bytes(dim: usize) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(dim * 4);
@@ -458,6 +594,11 @@ mod tests {
                  rel_path TEXT NOT NULL, \
                  last_embedding_model TEXT, \
                  last_embedding_dim INTEGER \
+             ); \
+             CREATE TABLE doc_tag ( \
+                 doc_id INTEGER NOT NULL, \
+                 tag TEXT NOT NULL, \
+                 normalized_tag TEXT NOT NULL \
              ); \
              CREATE TABLE segment ( \
                  id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, \
@@ -501,5 +642,40 @@ mod tests {
             .expect("vector score loading should not fail");
 
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn load_tag_scores_matches_exact_and_descendant_tags() {
+        let conn = open_connection();
+        conn.execute(
+            "INSERT INTO doc (id, vault_id, rel_path) VALUES (?1, ?2, ?3)",
+            params![1, 10, "alpha.md"],
+        )
+        .expect("failed to insert alpha doc");
+        conn.execute(
+            "INSERT INTO doc (id, vault_id, rel_path) VALUES (?1, ?2, ?3)",
+            params![2, 10, "beta.md"],
+        )
+        .expect("failed to insert beta doc");
+        conn.execute(
+            "INSERT INTO doc_tag (doc_id, tag, normalized_tag) VALUES (?1, ?2, ?3)",
+            params![1, "Project", "project"],
+        )
+        .expect("failed to insert exact tag");
+        conn.execute(
+            "INSERT INTO doc_tag (doc_id, tag, normalized_tag) VALUES (?1, ?2, ?3)",
+            params![2, "Project/Alpha", "project/alpha"],
+        )
+        .expect("failed to insert descendant tag");
+
+        let results =
+            load_tag_scores(&conn, 10, "project").expect("tag score loading should succeed");
+
+        assert_eq!(results, vec!["alpha.md".to_string(), "beta.md".to_string()]);
+    }
+
+    #[test]
+    fn escape_like_pattern_escapes_like_metacharacters() {
+        assert_eq!(escape_like_pattern("pro_ject%"), "pro\\_ject\\%");
     }
 }

--- a/crates/vault-indexing/src/vault_indexing/sync.rs
+++ b/crates/vault-indexing/src/vault_indexing/sync.rs
@@ -18,6 +18,7 @@ mod doc_repo;
 mod link_refresh;
 mod policy;
 mod segment_sync;
+mod tag_refresh;
 
 use doc_repo::{
     ensure_docs_for_files, load_docs, remove_deleted_docs, update_full_metadata,
@@ -29,6 +30,7 @@ use link_refresh::{
 };
 use policy::{decide_file_sync_action, embedding_target_changed, FileSyncAction};
 use segment_sync::{rebuild_doc_chunks, sync_segments_for_doc};
+use tag_refresh::replace_tags_for_doc;
 
 pub(super) fn clear_segment_vectors_for_vault(conn: &Connection, vault_id: i64) -> Result<()> {
     segment_sync::clear_segment_vectors_for_vault(conn, vault_id)
@@ -127,6 +129,7 @@ fn process_file(
 
     let doc_id = doc_record.id;
     let hash_changed = !doc_record.links_up_to_date(&doc_hash);
+    let note_tags = super::tags::extract_note_tags(&contents);
 
     if force_link_refresh_for_doc || hash_changed {
         let resolution = link_resolver.resolve_links_with_dependencies(file, &contents);
@@ -135,6 +138,7 @@ fn process_file(
 
     let Some(embedding) = embedding else {
         if hash_changed {
+            replace_tags_for_doc(conn, doc_id, &note_tags)?;
             update_hash_and_content(conn, doc_record, &doc_hash, &indexed_content, file)?;
         } else if source_stat_changed {
             update_source_stat(conn, doc_record, file)?;
@@ -152,6 +156,7 @@ fn process_file(
         let chunks = chunk_document(&contents, TARGET_CHUNKING_VERSION);
         // Chunking algorithm changed, rebuild every segment and embedding.
         rebuild_doc_chunks(conn, doc_id, &chunks, &embedding.embedder, summary)?;
+        replace_tags_for_doc(conn, doc_id, &note_tags)?;
         update_full_metadata(
             conn,
             doc_record,
@@ -186,6 +191,7 @@ fn process_file(
         embedding_target_changed,
         summary,
     )?;
+    replace_tags_for_doc(conn, doc_id, &note_tags)?;
     update_full_metadata(
         conn,
         doc_record,

--- a/crates/vault-indexing/src/vault_indexing/sync/tag_refresh.rs
+++ b/crates/vault-indexing/src/vault_indexing/sync/tag_refresh.rs
@@ -1,0 +1,106 @@
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection};
+
+use crate::vault_indexing::tags::NoteTag;
+
+pub(super) fn replace_tags_for_doc(
+    conn: &mut Connection,
+    doc_id: i64,
+    tags: &[NoteTag],
+) -> Result<()> {
+    let tx = conn
+        .transaction()
+        .with_context(|| format!("Failed to start tag transaction for doc {}", doc_id))?;
+
+    tx.execute("DELETE FROM doc_tag WHERE doc_id = ?1", params![doc_id])
+        .with_context(|| format!("Failed to clear tags for doc {}", doc_id))?;
+
+    {
+        let mut stmt = tx
+            .prepare(
+                "INSERT INTO doc_tag (doc_id, tag, normalized_tag) \
+                 VALUES (?1, ?2, ?3)",
+            )
+            .with_context(|| format!("Failed to prepare tag insert for doc {}", doc_id))?;
+
+        for tag in tags {
+            stmt.execute(params![
+                doc_id,
+                tag.tag.as_str(),
+                tag.normalized_tag.as_str()
+            ])
+            .with_context(|| {
+                format!(
+                    "Failed to insert tag '{}' for doc {}",
+                    tag.normalized_tag, doc_id
+                )
+            })?;
+        }
+    }
+
+    tx.commit()
+        .with_context(|| format!("Failed to commit tags for doc {}", doc_id))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::{params, Connection};
+
+    use super::replace_tags_for_doc;
+    use crate::vault_indexing::tags::NoteTag;
+
+    fn open_connection() -> Connection {
+        let conn = Connection::open_in_memory().expect("failed to open in-memory db");
+        conn.pragma_update(None, "foreign_keys", 1)
+            .expect("failed to enable foreign keys");
+        conn.execute_batch(
+            "CREATE TABLE doc (
+                 id INTEGER PRIMARY KEY
+             );
+             CREATE TABLE doc_tag (
+                 doc_id INTEGER NOT NULL,
+                 tag TEXT NOT NULL,
+                 normalized_tag TEXT NOT NULL,
+                 FOREIGN KEY (doc_id) REFERENCES doc(id) ON DELETE CASCADE
+             );",
+        )
+        .expect("failed to create tag tables");
+        conn
+    }
+
+    #[test]
+    fn replace_tags_for_doc_rewrites_existing_rows() {
+        let mut conn = open_connection();
+        conn.execute("INSERT INTO doc (id) VALUES (?1)", params![1])
+            .expect("failed to insert doc");
+        conn.execute(
+            "INSERT INTO doc_tag (doc_id, tag, normalized_tag) VALUES (?1, ?2, ?3)",
+            params![1, "Old", "old"],
+        )
+        .expect("failed to insert old tag");
+
+        replace_tags_for_doc(
+            &mut conn,
+            1,
+            &[NoteTag {
+                tag: "Project".to_string(),
+                normalized_tag: "project".to_string(),
+            }],
+        )
+        .expect("tag refresh should succeed");
+
+        let rows = conn
+            .prepare("SELECT tag, normalized_tag FROM doc_tag WHERE doc_id = ?1")
+            .expect("failed to prepare query")
+            .query_map(params![1], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .expect("failed to query rows")
+            .map(|row| row.expect("failed to decode row"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(rows, vec![("Project".to_string(), "project".to_string())]);
+    }
+}

--- a/crates/vault-indexing/src/vault_indexing/tags.rs
+++ b/crates/vault-indexing/src/vault_indexing/tags.rs
@@ -1,0 +1,393 @@
+use std::collections::HashSet;
+
+use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+use serde_yaml::{Mapping, Value};
+
+const BOM: char = '\u{FEFF}';
+const ZERO_WIDTH_SPACE: char = '\u{200B}';
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NoteTag {
+    pub(crate) tag: String,
+    pub(crate) normalized_tag: String,
+}
+
+pub(crate) fn extract_note_tags(source: &str) -> Vec<NoteTag> {
+    if source.trim().is_empty() {
+        return Vec::new();
+    }
+
+    let cleaned = strip_hidden_chars(source);
+    let (frontmatter, body) = split_frontmatter(&cleaned);
+
+    let mut seen = HashSet::new();
+    let mut tags = Vec::new();
+
+    if let Some(frontmatter) = frontmatter {
+        collect_frontmatter_tags(frontmatter, &mut seen, &mut tags);
+    }
+    collect_inline_tags(body, &mut seen, &mut tags);
+
+    tags
+}
+
+pub(crate) fn normalize_tag_query(raw: &str) -> Option<String> {
+    normalize_tag_value(raw).map(|(_, normalized)| normalized)
+}
+
+fn strip_hidden_chars(raw: &str) -> String {
+    raw.chars()
+        .filter(|ch| *ch != BOM && *ch != ZERO_WIDTH_SPACE)
+        .collect()
+}
+
+fn split_frontmatter(raw: &str) -> (Option<&str>, &str) {
+    let trimmed = raw.trim_start();
+    if !trimmed.starts_with("---") {
+        return (None, raw);
+    }
+
+    let Some(rest_index) = frontmatter_rest_index(trimmed) else {
+        return (None, raw);
+    };
+
+    let leading_ws_len = raw.len() - trimmed.len();
+    let frontmatter_end = leading_ws_len + rest_index;
+    let frontmatter = &raw[leading_ws_len..frontmatter_end];
+    let body = &raw[frontmatter_end..];
+
+    (Some(frontmatter), body)
+}
+
+fn frontmatter_rest_index(input: &str) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let mut line_start = 0usize;
+    let mut i = 0usize;
+    let mut line_no = 0usize;
+    let mut has_yaml_hint = false;
+
+    loop {
+        if i == bytes.len() || bytes[i] == b'\n' {
+            let line = &input[line_start..i];
+            let line_trimmed = line.trim_end_matches('\r');
+            if line_no == 0 {
+                if !is_frontmatter_delimiter(line_trimmed) {
+                    return None;
+                }
+            } else {
+                if line_trimmed.contains(':') || line_trimmed.trim_start().starts_with("- ") {
+                    has_yaml_hint = true;
+                }
+                if is_frontmatter_delimiter(line_trimmed) && (has_yaml_hint || line_no == 1) {
+                    let rest_start = if i < bytes.len() { i + 1 } else { i };
+                    return Some(rest_start);
+                }
+            }
+
+            line_no += 1;
+            if i == bytes.len() {
+                break;
+            }
+            line_start = i + 1;
+        }
+        i += 1;
+    }
+
+    None
+}
+
+fn is_frontmatter_delimiter(line: &str) -> bool {
+    line.trim() == "---"
+}
+
+fn collect_frontmatter_tags(
+    frontmatter: &str,
+    seen: &mut HashSet<String>,
+    output: &mut Vec<NoteTag>,
+) {
+    let payload = frontmatter_payload(frontmatter);
+    let Ok(value) = serde_yaml::from_str::<Value>(&payload) else {
+        return;
+    };
+
+    let Some(tags_value) = lookup_mapping_value(&value, "tags") else {
+        return;
+    };
+
+    match tags_value {
+        Value::String(value) => push_tag(value, seen, output),
+        Value::Sequence(items) => {
+            for item in items {
+                if let Value::String(value) = item {
+                    push_tag(value, seen, output);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn frontmatter_payload(frontmatter: &str) -> String {
+    let lines: Vec<&str> = frontmatter.lines().collect();
+    if lines.len() >= 2 && lines[0].trim() == "---" {
+        let last = lines.len() - 1;
+        if lines[last].trim() == "---" {
+            return lines[1..last].join("\n");
+        }
+    }
+
+    frontmatter.to_string()
+}
+
+fn lookup_mapping_value<'a>(value: &'a Value, key: &str) -> Option<&'a Value> {
+    let Value::Mapping(map) = value else {
+        return None;
+    };
+
+    lookup_mapping_case_insensitive(map, key)
+}
+
+fn lookup_mapping_case_insensitive<'a>(map: &'a Mapping, key: &str) -> Option<&'a Value> {
+    map.iter().find_map(|(map_key, value)| {
+        let Value::String(name) = map_key else {
+            return None;
+        };
+        if name.eq_ignore_ascii_case(key) {
+            Some(value)
+        } else {
+            None
+        }
+    })
+}
+
+fn collect_inline_tags(body: &str, seen: &mut HashSet<String>, output: &mut Vec<NoteTag>) {
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_TABLES);
+    options.insert(Options::ENABLE_STRIKETHROUGH);
+    options.insert(Options::ENABLE_TASKLISTS);
+
+    let parser = Parser::new_ext(body, options);
+    let mut skip_depth = 0usize;
+
+    for event in parser {
+        match event {
+            Event::Start(tag) => match tag {
+                Tag::CodeBlock(_) | Tag::Link { .. } | Tag::Image { .. } => {
+                    skip_depth = skip_depth.saturating_add(1);
+                }
+                _ => {}
+            },
+            Event::End(tag_end) => match tag_end {
+                TagEnd::CodeBlock | TagEnd::Link | TagEnd::Image => {
+                    skip_depth = skip_depth.saturating_sub(1);
+                }
+                _ => {}
+            },
+            Event::Text(text) if skip_depth == 0 => {
+                collect_inline_tags_from_text(&text, seen, output);
+            }
+            Event::Code(_) => {}
+            Event::Html(_) | Event::InlineHtml(_) => {}
+            _ => {}
+        }
+    }
+}
+
+fn collect_inline_tags_from_text(
+    text: &str,
+    seen: &mut HashSet<String>,
+    output: &mut Vec<NoteTag>,
+) {
+    let mut search_index = 0usize;
+
+    while search_index < text.len() {
+        let Some(relative_hash) = text[search_index..].find('#') else {
+            break;
+        };
+        let hash_index = search_index + relative_hash;
+        let prev = text[..hash_index].chars().next_back();
+
+        if is_tag_boundary(prev) {
+            let tag_start = hash_index + '#'.len_utf8();
+            if let Some((tag_end, raw_tag)) = parse_inline_tag(text, tag_start) {
+                push_tag(raw_tag, seen, output);
+                search_index = tag_end;
+                continue;
+            }
+        }
+
+        search_index = hash_index + '#'.len_utf8();
+    }
+}
+
+fn is_tag_boundary(prev: Option<char>) -> bool {
+    match prev {
+        None => true,
+        Some(ch) => !is_tag_char(ch) && ch != '/' && ch != '#',
+    }
+}
+
+fn parse_inline_tag(text: &str, start: usize) -> Option<(usize, &str)> {
+    let mut end = start;
+    let mut has_any_segment = false;
+    let mut segment_len = 0usize;
+
+    for (offset, ch) in text[start..].char_indices() {
+        let absolute = start + offset;
+        if is_tag_char(ch) {
+            segment_len += 1;
+            has_any_segment = true;
+            end = absolute + ch.len_utf8();
+            continue;
+        }
+
+        if ch == '/' {
+            if segment_len == 0 {
+                return None;
+            }
+            segment_len = 0;
+            end = absolute + ch.len_utf8();
+            continue;
+        }
+
+        break;
+    }
+
+    if !has_any_segment || segment_len == 0 {
+        return None;
+    }
+
+    Some((end, &text[start..end]))
+}
+
+fn push_tag(raw: &str, seen: &mut HashSet<String>, output: &mut Vec<NoteTag>) {
+    let Some((tag, normalized_tag)) = normalize_tag_value(raw) else {
+        return;
+    };
+
+    if seen.insert(normalized_tag.clone()) {
+        output.push(NoteTag {
+            tag,
+            normalized_tag,
+        });
+    }
+}
+
+fn normalize_tag_value(raw: &str) -> Option<(String, String)> {
+    let trimmed = raw.trim();
+    let trimmed = trimmed.strip_prefix('#').unwrap_or(trimmed).trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let mut tag = String::new();
+    let mut normalized = String::new();
+    let mut segment_len = 0usize;
+
+    for ch in trimmed.chars() {
+        if is_tag_char(ch) {
+            tag.push(ch);
+            normalized.extend(ch.to_lowercase());
+            segment_len += 1;
+            continue;
+        }
+
+        if ch == '/' {
+            if segment_len == 0 {
+                return None;
+            }
+            tag.push(ch);
+            normalized.push(ch);
+            segment_len = 0;
+            continue;
+        }
+
+        return None;
+    }
+
+    if segment_len == 0 || tag.is_empty() {
+        return None;
+    }
+
+    Some((tag, normalized))
+}
+
+fn is_tag_char(ch: char) -> bool {
+    ch.is_alphanumeric() || ch == '_' || ch == '-'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_note_tags, normalize_tag_query};
+
+    #[test]
+    fn extracts_inline_and_frontmatter_tags_case_insensitively() {
+        let raw = [
+            "---",
+            "tags:",
+            "  - Project",
+            "  - '#Project/Alpha'",
+            "---",
+            "Body #project and #Project/Beta",
+        ]
+        .join("\n");
+
+        let tags = extract_note_tags(&raw);
+
+        assert_eq!(
+            tags.into_iter()
+                .map(|tag| (tag.tag, tag.normalized_tag))
+                .collect::<Vec<_>>(),
+            vec![
+                ("Project".to_string(), "project".to_string()),
+                ("Project/Alpha".to_string(), "project/alpha".to_string()),
+                ("Project/Beta".to_string(), "project/beta".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_false_boundaries_code_links_and_urls() {
+        let raw = [
+            "# Heading",
+            "C# is not a tag and neither is https://example.com/#anchor.",
+            "`#code` [#link](https://example.com) ![#alt](image.png)",
+            "Keep #valid and (#nested/tag).",
+        ]
+        .join("\n");
+
+        let tags = extract_note_tags(&raw);
+
+        assert_eq!(
+            tags.into_iter()
+                .map(|tag| tag.normalized_tag)
+                .collect::<Vec<_>>(),
+            vec!["valid".to_string(), "nested/tag".to_string()]
+        );
+    }
+
+    #[test]
+    fn ignores_invalid_or_truncated_tags() {
+        let raw = "Skip #, #/, #tag/, and #tag//child but keep #done";
+
+        let tags = extract_note_tags(raw);
+
+        assert_eq!(
+            tags.into_iter()
+                .map(|tag| tag.normalized_tag)
+                .collect::<Vec<_>>(),
+            vec!["done".to_string()]
+        );
+    }
+
+    #[test]
+    fn normalizes_queries_with_optional_hash_prefix() {
+        assert_eq!(
+            normalize_tag_query("#Project/Alpha"),
+            Some("project/alpha".to_string())
+        );
+        assert_eq!(normalize_tag_query("Project"), Some("project".to_string()));
+        assert_eq!(normalize_tag_query("#project/"), None);
+        assert_eq!(normalize_tag_query(""), None);
+    }
+}

--- a/crates/vault-indexing/src/vault_indexing/tests/mod.rs
+++ b/crates/vault-indexing/src/vault_indexing/tests/mod.rs
@@ -4,5 +4,6 @@ mod link_scenarios;
 mod note_scenarios;
 mod search_scenarios;
 mod sync_scenarios;
+mod tag_scenarios;
 mod test_support;
 mod workspace_scenarios;

--- a/crates/vault-indexing/src/vault_indexing/tests/tag_scenarios.rs
+++ b/crates/vault-indexing/src/vault_indexing/tests/tag_scenarios.rs
@@ -1,0 +1,160 @@
+use std::{thread, time::Duration};
+
+use super::super::{delete_indexed_note, rename_indexed_note};
+use super::test_support::IndexingHarness;
+
+#[test]
+fn given_inline_and_frontmatter_tags_when_indexing_then_doc_tags_are_merged_and_deduped() {
+    let harness = IndexingHarness::new("mdit-vault-indexing-tags-merged");
+    let contents = [
+        "---",
+        "tags:",
+        "  - Project",
+        "  - '#Project/Alpha'",
+        "---",
+        "Body #project and #Project/Beta",
+    ]
+    .join("\n");
+    harness.write_note("note.md", &contents);
+
+    harness.run_workspace_index();
+
+    assert_eq!(
+        harness.doc_tags("note.md"),
+        vec![
+            ("Project".to_string(), "project".to_string()),
+            ("Project/Alpha".to_string(), "project/alpha".to_string()),
+            ("Project/Beta".to_string(), "project/beta".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn given_parent_tag_query_when_searching_then_descendants_are_included_in_modified_order() {
+    let harness = IndexingHarness::new("mdit-vault-indexing-tags-parent-search");
+    harness.write_note("older.md", "Body #project");
+    thread::sleep(Duration::from_millis(20));
+    harness.write_note("newer.md", "Body #project/alpha");
+
+    harness.run_workspace_index();
+
+    assert_eq!(
+        harness.search_tags("#project"),
+        vec![
+            harness
+                .root()
+                .join("newer.md")
+                .to_string_lossy()
+                .into_owned(),
+            harness
+                .root()
+                .join("older.md")
+                .to_string_lossy()
+                .into_owned(),
+        ]
+    );
+}
+
+#[test]
+fn given_renamed_or_deleted_note_when_searching_tags_then_doc_tag_rows_follow_doc_lifecycle() {
+    let harness = IndexingHarness::new("mdit-vault-indexing-tags-lifecycle");
+    harness.write_note("old.md", "Body #project/alpha");
+    harness.run_workspace_index();
+
+    std::fs::rename(harness.root().join("old.md"), harness.root().join("new.md"))
+        .expect("failed to rename note on disk");
+
+    let renamed = rename_indexed_note(
+        harness.root(),
+        harness.db_path(),
+        &harness.root().join("old.md"),
+        &harness.root().join("new.md"),
+    )
+    .expect("rename should succeed");
+
+    assert!(renamed);
+    assert_eq!(
+        harness.search_tags("#project"),
+        vec![harness.root().join("new.md").to_string_lossy().into_owned()]
+    );
+
+    std::fs::remove_file(harness.root().join("new.md")).expect("failed to remove renamed note");
+    let deleted = delete_indexed_note(
+        harness.root(),
+        harness.db_path(),
+        &harness.root().join("new.md"),
+    )
+    .expect("delete should succeed");
+
+    assert!(deleted);
+    assert!(harness.search_tags("#project").is_empty());
+}
+
+#[test]
+fn given_heading_markers_and_non_tag_hashes_when_indexing_then_only_real_tags_are_persisted() {
+    let harness = IndexingHarness::new("mdit-vault-indexing-tags-false-positives");
+    let contents = [
+        "# Heading",
+        "C# is not a tag.",
+        "Ignore https://example.com/#anchor and `#code` and [#link](https://example.com).",
+        "Keep #valid and #nested/tag.",
+    ]
+    .join("\n");
+    harness.write_note("note.md", &contents);
+
+    harness.run_workspace_index();
+
+    assert_eq!(
+        harness.doc_tags("note.md"),
+        vec![
+            ("nested/tag".to_string(), "nested/tag".to_string()),
+            ("valid".to_string(), "valid".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn given_chunking_version_drift_when_reindexing_with_embeddings_then_doc_tags_are_preserved() {
+    let harness = IndexingHarness::new("mdit-vault-indexing-tags-chunk-drift");
+    harness.write_note("note.md", "Body #project/alpha");
+
+    harness.run_workspace_index_with_embeddings("test", "model-a");
+    harness.set_doc_chunking_version("note.md", 0);
+
+    harness.run_workspace_index_with_embeddings("test", "model-a");
+
+    assert_eq!(
+        harness.doc_tags("note.md"),
+        vec![("project/alpha".to_string(), "project/alpha".to_string())]
+    );
+    assert_eq!(
+        harness.search_tags("#project"),
+        vec![harness
+            .root()
+            .join("note.md")
+            .to_string_lossy()
+            .into_owned()]
+    );
+}
+
+#[test]
+fn given_embedding_model_drift_when_reindexing_with_embeddings_then_doc_tags_are_preserved() {
+    let harness = IndexingHarness::new("mdit-vault-indexing-tags-embedding-drift");
+    harness.write_note("note.md", "Body #project/alpha");
+
+    harness.run_workspace_index_with_embeddings("test", "model-a");
+    harness.run_workspace_index_with_embeddings("test", "model-b");
+
+    assert_eq!(
+        harness.doc_tags("note.md"),
+        vec![("project/alpha".to_string(), "project/alpha".to_string())]
+    );
+    assert_eq!(
+        harness.search_tags("#project"),
+        vec![harness
+            .root()
+            .join("note.md")
+            .to_string_lossy()
+            .into_owned()]
+    );
+}

--- a/crates/vault-indexing/src/vault_indexing/tests/test_support.rs
+++ b/crates/vault-indexing/src/vault_indexing/tests/test_support.rs
@@ -6,8 +6,8 @@ use rusqlite::{params, Connection, OptionalExtension};
 use app_storage::migrations;
 
 use super::super::{
-    find_vault_id, get_backlinks, get_indexing_meta, index_note, index_workspace, BacklinkEntry,
-    IndexSummary, IndexingMeta,
+    find_vault_id, get_backlinks, get_indexing_meta, index_note, index_workspace,
+    search_notes_by_tag, BacklinkEntry, IndexSummary, IndexingMeta,
 };
 
 pub(super) struct IndexingHarness {
@@ -61,6 +61,21 @@ impl IndexingHarness {
             .expect("workspace indexing should succeed")
     }
 
+    pub(super) fn run_workspace_index_with_embeddings(
+        &self,
+        embedding_provider: &str,
+        embedding_model: &str,
+    ) -> IndexSummary {
+        index_workspace(
+            &self.root,
+            &self.db_path,
+            embedding_provider,
+            embedding_model,
+            false,
+        )
+        .expect("workspace indexing with embeddings should succeed")
+    }
+
     pub(super) fn run_note_index(&self, rel_path: &str) -> Result<IndexSummary> {
         self.run_note_index_for_path(&self.root.join(rel_path))
     }
@@ -76,6 +91,39 @@ impl IndexingHarness {
     pub(super) fn backlinks(&self, rel_path: &str) -> Vec<BacklinkEntry> {
         get_backlinks(&self.root, &self.db_path, &self.root.join(rel_path))
             .expect("failed to query backlinks")
+    }
+
+    pub(super) fn search_tags(&self, tag_query: &str) -> Vec<String> {
+        search_notes_by_tag(&self.root, &self.db_path, tag_query)
+            .expect("failed to search tags")
+            .into_iter()
+            .map(|entry| entry.path)
+            .collect()
+    }
+
+    pub(super) fn doc_tags(&self, rel_path: &str) -> Vec<(String, String)> {
+        let Some((conn, vault_id)) = self.open_vault_connection() else {
+            return Vec::new();
+        };
+
+        let mut stmt = conn
+            .prepare(
+                "SELECT dt.tag, dt.normalized_tag \
+                 FROM doc_tag dt \
+                 JOIN doc d ON d.id = dt.doc_id \
+                 WHERE d.vault_id = ?1 AND d.rel_path = ?2 \
+                 ORDER BY dt.normalized_tag",
+            )
+            .expect("failed to prepare tag query");
+
+        let rows = stmt
+            .query_map(params![vault_id, rel_path], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .expect("failed to query tag rows");
+
+        rows.map(|row| row.expect("failed to decode tag row"))
+            .collect()
     }
 
     pub(super) fn link_targets_for(&self, source_rel_path: &str) -> Vec<String> {
@@ -190,6 +238,11 @@ impl IndexingHarness {
             .set_source_stat(rel_path, size, mtime_ns);
     }
 
+    pub(super) fn set_doc_chunking_version(&self, rel_path: &str, chunking_version: i64) {
+        self.doc_mutations()
+            .set_chunking_version(rel_path, chunking_version);
+    }
+
     fn doc_queries(&self) -> DocQueries<'_> {
         DocQueries { harness: self }
     }
@@ -278,6 +331,17 @@ impl DocMutations<'_> {
             params![size, mtime_ns, vault_id, rel_path],
         )
         .expect("failed to update doc source stat");
+    }
+
+    fn set_chunking_version(&self, rel_path: &str, chunking_version: i64) {
+        let Some((conn, vault_id)) = self.harness.open_vault_connection() else {
+            return;
+        };
+        conn.execute(
+            "UPDATE doc SET chunking_version = ?1 WHERE vault_id = ?2 AND rel_path = ?3",
+            params![chunking_version, vault_id, rel_path],
+        )
+        .expect("failed to update doc chunking version");
     }
 }
 

--- a/packages/command-menu/src/command-menu.tsx
+++ b/packages/command-menu/src/command-menu.tsx
@@ -13,14 +13,17 @@ import useMeasure from "react-use-measure"
 import { highlightQuery } from "./highlight-query"
 import { resolveNotePresentation } from "./note-presentation"
 import { getFileNameFromPath, getParentPathLabel } from "./path-utils"
+import { getTagOnlySearchQuery } from "./tag-query"
 import type {
 	CommandMenuContentSearch,
 	CommandMenuEntry,
 	CommandMenuSemanticSearch,
+	CommandMenuTagSearch,
 } from "./types"
 import { useNoteContentSearch } from "./use-note-content-search"
 import { useNoteNameSearch } from "./use-note-name-search"
 import { useSemanticSearch } from "./use-semantic-search"
+import { useTagSearch } from "./use-tag-search"
 
 export type CommandMenuProps = {
 	open: boolean
@@ -28,8 +31,10 @@ export type CommandMenuProps = {
 	workspacePath: string | null
 	entries: CommandMenuEntry[]
 	onSelectPath: (path: string) => void
+	initialQuery?: string | null
 	searchContent?: CommandMenuContentSearch
 	searchSemantic?: CommandMenuSemanticSearch
+	searchTags?: CommandMenuTagSearch
 }
 
 export function CommandMenu({
@@ -38,33 +43,43 @@ export function CommandMenu({
 	workspacePath,
 	entries,
 	onSelectPath,
+	initialQuery,
 	searchContent,
 	searchSemantic,
+	searchTags,
 }: CommandMenuProps) {
-	const [query, setQuery] = useState("")
+	const [query, setQuery] = useState(initialQuery ?? "")
 	const [isInitialMeasureDebounced, setIsInitialMeasureDebounced] =
 		useState(false)
 	const deferredQuery = useDeferredValue(query)
 	const debouncedQuery = useDebounce(query, 250)
+	const activeTagQuery = getTagOnlySearchQuery(query)
+	const debouncedTagQuery = getTagOnlySearchQuery(debouncedQuery)
 	const { filteredNoteResults, noteResultsByPath } = useNoteNameSearch(
 		entries,
 		workspacePath,
-		deferredQuery,
+		activeTagQuery ? "" : deferredQuery,
 	)
 	const { trimmedSearchTerm, contentMatchesByNote } = useNoteContentSearch(
-		debouncedQuery,
+		activeTagQuery ? "" : debouncedQuery,
 		workspacePath,
 		searchContent,
 	)
 	const { results: semanticResults } = useSemanticSearch(
-		debouncedQuery,
+		activeTagQuery ? "" : debouncedQuery,
 		workspacePath,
 		searchSemantic,
+	)
+	const { results: tagResults } = useTagSearch(
+		debouncedTagQuery,
+		workspacePath,
+		searchTags,
 	)
 
 	const hasNoteMatches = filteredNoteResults.length > 0
 	const hasContentMatches = contentMatchesByNote.length > 0
 	const hasSemanticMatches = semanticResults.length > 0
+	const hasTagMatches = tagResults.length > 0
 
 	useEffect(() => {
 		if (!open) {
@@ -77,6 +92,17 @@ export function CommandMenu({
 			}
 		}
 	}, [open])
+
+	useEffect(() => {
+		if (!open) {
+			return
+		}
+
+		const nextQuery = initialQuery ?? ""
+		setQuery((currentQuery) =>
+			currentQuery === nextQuery ? currentQuery : nextQuery,
+		)
+	}, [initialQuery, open])
 
 	const handleSelectNote = useCallback(
 		(notePath: string) => {
@@ -121,7 +147,7 @@ export function CommandMenu({
 			<CommandInput
 				value={query}
 				onValueChange={setQuery}
-				placeholder="Search notes..."
+				placeholder="Search notes or tags..."
 				autoFocus
 			/>
 			<motion.div
@@ -132,7 +158,46 @@ export function CommandMenu({
 			>
 				<CommandList ref={listRef} className="max-h-88">
 					<CommandEmpty>No results found</CommandEmpty>
-					{hasNoteMatches && (
+					{activeTagQuery && hasTagMatches && (
+						<CommandGroup heading="Tag Matches">
+							{tagResults.map((result) => {
+								const note = noteResultsByPath.get(result.path)
+								const { label, relativePath, parentPathLabel } =
+									resolveNotePresentation({
+										note,
+										path: result.path,
+										workspacePath,
+										fallbackName: result.name,
+									})
+								const keywords = [
+									label,
+									relativePath,
+									activeTagQuery,
+									"tag",
+								].filter(Boolean) as string[]
+
+								return (
+									<CommandItem
+										key={`${result.path}:tag`}
+										value={`${result.path}:tag`}
+										keywords={keywords}
+										onSelect={() => handleSelectNote(result.path)}
+										className="data-[selected=true]:bg-accent-foreground/10"
+									>
+										<div className="flex max-w-full flex-col gap-0.5">
+											<div className="flex items-center gap-2 truncate text-sm">
+												<span className="truncate">{label}</span>
+											</div>
+											<span className="text-muted-foreground/80 truncate text-xs">
+												{parentPathLabel}
+											</span>
+										</div>
+									</CommandItem>
+								)
+							})}
+						</CommandGroup>
+					)}
+					{!activeTagQuery && hasNoteMatches && (
 						<CommandGroup
 							heading={deferredQuery.trim() ? "Notes" : "Recent Notes"}
 						>
@@ -154,7 +219,7 @@ export function CommandMenu({
 							))}
 						</CommandGroup>
 					)}
-					{hasSemanticMatches && (
+					{!activeTagQuery && hasSemanticMatches && (
 						<CommandGroup heading="Suggestions">
 							{semanticResults.slice(0, 5).map((result) => {
 								const note = noteResultsByPath.get(result.path)
@@ -190,7 +255,7 @@ export function CommandMenu({
 							})}
 						</CommandGroup>
 					)}
-					{hasContentMatches && (
+					{!activeTagQuery && hasContentMatches && (
 						<CommandGroup heading="Content Matches">
 							{contentMatchesByNote.map((group) => {
 								const note = noteResultsByPath.get(group.path)

--- a/packages/command-menu/src/index.ts
+++ b/packages/command-menu/src/index.ts
@@ -6,4 +6,6 @@ export type {
 	CommandMenuEntry,
 	CommandMenuSemanticResult,
 	CommandMenuSemanticSearch,
+	CommandMenuTagResult,
+	CommandMenuTagSearch,
 } from "./types"

--- a/packages/command-menu/src/tag-query.test.ts
+++ b/packages/command-menu/src/tag-query.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+import {
+	getTagOnlySearchQuery,
+	isTagOnlyQuery,
+	normalizeTagSearchQuery,
+	normalizeTagSearchValue,
+} from "./tag-query"
+
+describe("normalizeTagSearchValue", () => {
+	it("normalizes leading hashes and casing", () => {
+		expect(normalizeTagSearchValue("#Project/Docs")).toBe("project/docs")
+		expect(normalizeTagSearchQuery("#Project/Docs")).toBe("#project/docs")
+	})
+
+	it("rejects invalid or empty segments", () => {
+		expect(normalizeTagSearchValue("#")).toBeNull()
+		expect(normalizeTagSearchValue("#project/")).toBeNull()
+		expect(normalizeTagSearchValue("#project//docs")).toBeNull()
+		expect(normalizeTagSearchValue("#project,docs")).toBeNull()
+	})
+})
+
+describe("isTagOnlyQuery", () => {
+	it("accepts a single normalized tag token", () => {
+		expect(isTagOnlyQuery("#Project/Docs")).toBe(true)
+	})
+
+	it("rejects mixed or malformed queries", () => {
+		expect(isTagOnlyQuery("project")).toBe(false)
+		expect(isTagOnlyQuery("#project docs")).toBe(false)
+		expect(isTagOnlyQuery("#project/")).toBe(false)
+	})
+})
+
+describe("getTagOnlySearchQuery", () => {
+	it("returns null for plain note queries", () => {
+		expect(getTagOnlySearchQuery("project")).toBeNull()
+		expect(getTagOnlySearchQuery("docs/guide")).toBeNull()
+	})
+
+	it("returns a normalized query for tag-only inputs", () => {
+		expect(getTagOnlySearchQuery("#Project")).toBe("#project")
+		expect(getTagOnlySearchQuery("#Project/Docs")).toBe("#project/docs")
+	})
+})

--- a/packages/command-menu/src/tag-query.ts
+++ b/packages/command-menu/src/tag-query.ts
@@ -1,0 +1,49 @@
+const TAG_SEGMENT_REGEX = /^[\p{L}\p{N}_-]+$/u
+
+export function normalizeTagSearchValue(raw: string): string | null {
+	let value = raw.trim()
+	if (value.startsWith("#")) {
+		value = value.slice(1)
+	}
+
+	value = value.trim().toLowerCase()
+	if (!value) {
+		return null
+	}
+
+	const segments = value.split("/")
+	if (
+		segments.length === 0 ||
+		segments.some((segment) => !segment || !TAG_SEGMENT_REGEX.test(segment))
+	) {
+		return null
+	}
+
+	return segments.join("/")
+}
+
+export function normalizeTagSearchQuery(raw: string): string | null {
+	const normalized = normalizeTagSearchValue(raw)
+	return normalized ? `#${normalized}` : null
+}
+
+export function getTagOnlySearchQuery(raw: string): string | null {
+	if (!isTagOnlyQuery(raw)) {
+		return null
+	}
+
+	return normalizeTagSearchQuery(raw)
+}
+
+export function isTagOnlyQuery(raw: string): boolean {
+	const trimmed = raw.trim()
+	if (!trimmed.startsWith("#")) {
+		return false
+	}
+
+	if (/\s/.test(trimmed)) {
+		return false
+	}
+
+	return normalizeTagSearchQuery(trimmed) !== null
+}

--- a/packages/command-menu/src/types.ts
+++ b/packages/command-menu/src/types.ts
@@ -20,6 +20,12 @@ export type CommandMenuSemanticResult = {
 	modifiedAt?: Date
 }
 
+export type CommandMenuTagResult = {
+	path: string
+	name: string
+	modifiedAt?: Date
+}
+
 export type CommandMenuContentSearch = (
 	query: string,
 	workspacePath: string,
@@ -29,3 +35,8 @@ export type CommandMenuSemanticSearch = (
 	query: string,
 	workspacePath: string,
 ) => Promise<CommandMenuSemanticResult[]>
+
+export type CommandMenuTagSearch = (
+	query: string,
+	workspacePath: string,
+) => Promise<CommandMenuTagResult[]>

--- a/packages/command-menu/src/use-tag-search.ts
+++ b/packages/command-menu/src/use-tag-search.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from "react"
+import type { CommandMenuTagResult, CommandMenuTagSearch } from "./types"
+
+export const useTagSearch = (
+	query: string | null,
+	workspacePath: string | null,
+	searchTags?: CommandMenuTagSearch,
+) => {
+	const [results, setResults] = useState<CommandMenuTagResult[]>([])
+	const requestIdRef = useRef(0)
+
+	useEffect(() => {
+		const requestId = requestIdRef.current + 1
+		requestIdRef.current = requestId
+
+		if (!searchTags || !workspacePath || !query) {
+			setResults([])
+			return
+		}
+
+		searchTags(query, workspacePath)
+			.then((nextResults) => {
+				if (requestIdRef.current === requestId) {
+					setResults(nextResults)
+				}
+			})
+			.catch((error) => {
+				if (requestIdRef.current === requestId) {
+					console.error("Failed to search tags:", error)
+					setResults([])
+				}
+			})
+	}, [query, searchTags, workspacePath])
+
+	return {
+		results,
+	}
+}

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -19,6 +19,7 @@
 		"./shared": "./src/shared/index.ts",
 		"./slash": "./src/slash/index.ts",
 		"./suggestion": "./src/suggestion/index.ts",
+		"./tag": "./src/tag/index.ts",
 		"./table": "./src/table/index.ts",
 		"./toc": "./src/toc/index.ts"
 	},

--- a/packages/editor/src/frontmatter/frontmatter-kit.ts
+++ b/packages/editor/src/frontmatter/frontmatter-kit.ts
@@ -9,6 +9,7 @@ export const FRONTMATTER_KEY = "frontmatter"
 
 export type FrontmatterHostDeps = {
 	onOpenWikiLink?: (target: string) => void | Promise<void>
+	onOpenTagSearch?: (query: string) => void | Promise<void>
 	getLinkWorkspaceState?: () => LinkWorkspaceState
 	resolveWikiLinkTarget?: (
 		rawTarget: string,
@@ -27,6 +28,7 @@ export function createFrontmatterPlugin({
 		createElement(FrontmatterElement, {
 			...props,
 			onOpenWikiLink: host?.onOpenWikiLink,
+			onOpenTagSearch: host?.onOpenTagSearch,
 			getLinkWorkspaceState: host?.getLinkWorkspaceState,
 			resolveWikiLinkTarget: host?.resolveWikiLinkTarget,
 		})

--- a/packages/editor/src/frontmatter/frontmatter-tag-utils.test.ts
+++ b/packages/editor/src/frontmatter/frontmatter-tag-utils.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+import {
+	applyFrontmatterKeyChange,
+	applyFrontmatterTypeChange,
+	formatFrontmatterTagLabel,
+	getFrontmatterPropertyTypeOptions,
+	getFrontmatterTagQuery,
+	isTagsFrontmatterKey,
+} from "./frontmatter-tag-utils"
+
+describe("frontmatter-tag-utils", () => {
+	it("detects the tags key case-insensitively", () => {
+		expect(isTagsFrontmatterKey("tags")).toBe(true)
+		expect(isTagsFrontmatterKey(" Tags ")).toBe(true)
+		expect(isTagsFrontmatterKey("aliases")).toBe(false)
+	})
+
+	it("promotes rows renamed to tags into the canonical tags type", () => {
+		expect(
+			applyFrontmatterKeyChange("tags", "string", "#Project, Area"),
+		).toEqual({
+			type: "tags",
+			value: ["Project", "Area"],
+		})
+	})
+
+	it("demotes tags rows renamed away from tags back to array", () => {
+		expect(
+			applyFrontmatterKeyChange("aliases", "tags", ["Project", "Area"]),
+		).toEqual({
+			type: "array",
+			value: ["Project", "Area"],
+		})
+	})
+
+	it("keeps the tags key pinned to the tags type", () => {
+		expect(applyFrontmatterTypeChange("tags", ["Project"], "array")).toEqual({
+			key: "tags",
+			type: "tags",
+			value: ["Project"],
+		})
+	})
+
+	it("renames the property key to tags when the dropdown selects tags", () => {
+		expect(
+			applyFrontmatterTypeChange("category", "#Project, Area", "tags"),
+		).toEqual({
+			key: "tags",
+			type: "tags",
+			value: ["Project", "Area"],
+		})
+	})
+
+	it("limits type options for canonical tags rows", () => {
+		expect(getFrontmatterPropertyTypeOptions("tags")).toEqual([
+			{ value: "tags", label: "Tags" },
+		])
+		expect(getFrontmatterPropertyTypeOptions("aliases")).toEqual(
+			expect.not.arrayContaining([{ value: "tags", label: "Tags" }]),
+		)
+	})
+
+	it("formats display labels and normalized queries for tag chips", () => {
+		expect(formatFrontmatterTagLabel("Project/Docs")).toBe("#Project/Docs")
+		expect(getFrontmatterTagQuery("#Project/Docs")).toBe("#project/docs")
+		expect(getFrontmatterTagQuery("bad tag")).toBeNull()
+	})
+})

--- a/packages/editor/src/frontmatter/frontmatter-tag-utils.ts
+++ b/packages/editor/src/frontmatter/frontmatter-tag-utils.ts
@@ -1,0 +1,134 @@
+import { normalizeTagQuery } from "../tag/tag-utils"
+import {
+	convertValueToType,
+	datePattern,
+	normalizeTagsValue,
+	type ValueType,
+} from "./frontmatter-value-utils"
+
+const DEFAULT_PROPERTY_TYPE_OPTIONS: ReadonlyArray<{
+	value: ValueType
+	label: string
+}> = [
+	{ value: "string", label: "Text" },
+	{ value: "number", label: "Number" },
+	{ value: "boolean", label: "Boolean" },
+	{ value: "date", label: "Date" },
+	{ value: "array", label: "Array" },
+]
+
+export function isTagsFrontmatterKey(key: string): boolean {
+	return key.trim().toLowerCase() === "tags"
+}
+
+export function getFrontmatterPropertyTypeOptions(key: string): ReadonlyArray<{
+	value: ValueType
+	label: string
+}> {
+	if (isTagsFrontmatterKey(key)) {
+		return [{ value: "tags", label: "Tags" }]
+	}
+
+	return DEFAULT_PROPERTY_TYPE_OPTIONS
+}
+
+export function normalizeFrontmatterTagValue(raw: string): string | null {
+	const trimmed = raw.trim()
+	if (!trimmed) return null
+
+	const withoutHash = trimmed.startsWith("#")
+		? trimmed.slice(1).trim()
+		: trimmed
+
+	return withoutHash || null
+}
+
+export function normalizeFrontmatterTagItems(value: unknown): string[] {
+	return normalizeTagsValue(value)
+		.map((item) => normalizeFrontmatterTagValue(item))
+		.filter((item): item is string => Boolean(item))
+}
+
+export function formatFrontmatterTagLabel(value: string): string {
+	const normalized = normalizeFrontmatterTagValue(value)
+	if (!normalized) {
+		return value.trim()
+	}
+
+	return `#${normalized}`
+}
+
+export function getFrontmatterTagQuery(value: string): string | null {
+	const normalized = normalizeFrontmatterTagValue(value)
+	if (!normalized) {
+		return null
+	}
+
+	return normalizeTagQuery(normalized)
+}
+
+export function detectFrontmatterValueType(
+	key: string,
+	value: unknown,
+): ValueType {
+	if (isTagsFrontmatterKey(key)) return "tags"
+	if (typeof value === "boolean") return "boolean"
+	if (typeof value === "number") return "number"
+	if (Array.isArray(value)) return "array"
+	if (
+		value instanceof Date ||
+		(typeof value === "string" &&
+			!Number.isNaN(Date.parse(value)) &&
+			datePattern.test(value))
+	) {
+		return "date"
+	}
+	return "string"
+}
+
+export function applyFrontmatterTypeChange(
+	key: string,
+	value: unknown,
+	nextType: ValueType,
+): { key: string; type: ValueType; value: unknown } {
+	if (nextType === "tags") {
+		return {
+			key: "tags",
+			type: "tags",
+			value: convertValueToType(value, "tags"),
+		}
+	}
+
+	const effectiveType = isTagsFrontmatterKey(key) ? "tags" : nextType
+
+	return {
+		key,
+		type: effectiveType,
+		value: convertValueToType(value, effectiveType),
+	}
+}
+
+export function applyFrontmatterKeyChange(
+	nextKey: string,
+	currentType: ValueType,
+	value: unknown,
+): { type: ValueType; value: unknown } {
+	if (isTagsFrontmatterKey(nextKey)) {
+		return {
+			type: "tags" as const,
+			value: convertValueToType(value, "tags"),
+		}
+	}
+
+	if (currentType === "tags") {
+		return {
+			type: "array" as const,
+			value: convertValueToType(value, "array"),
+		}
+	}
+
+	return {
+		type: currentType,
+		value,
+	}
+}

--- a/packages/editor/src/frontmatter/frontmatter-value-utils.test.ts
+++ b/packages/editor/src/frontmatter/frontmatter-value-utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+import { convertValueToType } from "./frontmatter-value-utils"
+
+describe("convertValueToType", () => {
+	it("normalizes tag strings into a trimmed yaml-safe list", () => {
+		expect(convertValueToType("#Project, Area/Sub, , #Docs", "tags")).toEqual([
+			"Project",
+			"Area/Sub",
+			"Docs",
+		])
+	})
+
+	it("normalizes tag arrays while preserving case", () => {
+		expect(
+			convertValueToType(["#Project/Docs", " Area ", "", 3], "tags"),
+		).toEqual(["Project/Docs", "Area", "3"])
+	})
+})

--- a/packages/editor/src/frontmatter/frontmatter-value-utils.ts
+++ b/packages/editor/src/frontmatter/frontmatter-value-utils.ts
@@ -1,4 +1,10 @@
-export type ValueType = "string" | "number" | "boolean" | "date" | "array"
+export type ValueType =
+	| "string"
+	| "number"
+	| "boolean"
+	| "date"
+	| "array"
+	| "tags"
 
 export const datePattern = /^\d{4}-\d{2}-\d{2}/
 
@@ -17,6 +23,19 @@ export function parseYMDToLocalDate(ymd: string) {
 		.map((n) => Number(n))
 	if (!year || !month || !day) return
 	return new Date(year, month - 1, day)
+}
+
+export function normalizeTagsValue(value: unknown): string[] {
+	const rawItems = Array.isArray(value)
+		? value
+		: String(value ?? "")
+				.split(",")
+				.map((item) => item.trim())
+
+	return rawItems
+		.map((item) => String(item ?? "").trim())
+		.map((item) => (item.startsWith("#") ? item.slice(1).trim() : item))
+		.filter(Boolean)
 }
 
 export function convertValueToType(
@@ -65,6 +84,9 @@ export function convertValueToType(
 			} catch {
 				return []
 			}
+		}
+		case "tags": {
+			return normalizeTagsValue(value)
 		}
 		case "string": {
 			return strValue

--- a/packages/editor/src/frontmatter/index.ts
+++ b/packages/editor/src/frontmatter/index.ts
@@ -13,11 +13,23 @@ export {
 	FrontmatterKit,
 	frontmatterPlugin,
 } from "./frontmatter-kit"
+export {
+	applyFrontmatterKeyChange,
+	applyFrontmatterTypeChange,
+	detectFrontmatterValueType,
+	formatFrontmatterTagLabel,
+	getFrontmatterPropertyTypeOptions,
+	getFrontmatterTagQuery,
+	isTagsFrontmatterKey,
+	normalizeFrontmatterTagItems,
+	normalizeFrontmatterTagValue,
+} from "./frontmatter-tag-utils"
 export { createDefaultFrontmatterRows, createRowId } from "./frontmatter-utils"
 export {
 	convertValueToType,
 	datePattern,
 	formatLocalDate,
+	normalizeTagsValue,
 	parseYMDToLocalDate,
 	type ValueType,
 } from "./frontmatter-value-utils"

--- a/packages/editor/src/frontmatter/node-frontmatter-array.tsx
+++ b/packages/editor/src/frontmatter/node-frontmatter-array.tsx
@@ -2,9 +2,25 @@ import { Command } from "@mdit/ui/components/command"
 import { Input } from "@mdit/ui/components/input"
 import { cn } from "@mdit/ui/lib/utils"
 import { XIcon } from "lucide-react"
-import { type KeyboardEvent, useMemo, useRef, useState } from "react"
+import {
+	type KeyboardEvent,
+	type MouseEvent,
+	useMemo,
+	useRef,
+	useState,
+} from "react"
 import type { LinkWorkspaceState } from "../link/link-kit-types"
 import { flattenWorkspaceFiles } from "../link/link-toolbar-utils"
+import {
+	handleTagClick,
+	handleTagMouseDown,
+	type TagHostDeps,
+} from "../tag/node-tag"
+import {
+	formatFrontmatterTagLabel,
+	getFrontmatterTagQuery,
+	normalizeFrontmatterTagItems,
+} from "./frontmatter-tag-utils"
 import { FrontmatterWikiInlinePreview } from "./frontmatter-wiki-inline-preview"
 import {
 	getActiveFrontmatterWikiQuery,
@@ -26,8 +42,10 @@ type FrontmatterArrayProps = {
 	value: unknown
 	onChange: (nextValue: string[]) => void
 	placeholder?: string
+	mode?: "array" | "tags"
 	focusRegistration?: FocusRegistration
 	onOpenWikiLink?: (target: string) => void | Promise<void>
+	onOpenTagSearch?: TagHostDeps["openTagSearch"]
 	getLinkWorkspaceState?: () => LinkWorkspaceState
 	resolveWikiLinkTarget?: ResolveFrontmatterWikiLinkTarget
 }
@@ -42,16 +60,19 @@ export function FrontmatterArray({
 	value,
 	onChange,
 	placeholder = "Type and press Enter",
+	mode = "array",
 	focusRegistration,
 	onOpenWikiLink,
+	onOpenTagSearch,
 	getLinkWorkspaceState,
 	resolveWikiLinkTarget,
 }: FrontmatterArrayProps) {
+	const isTagMode = mode === "tags"
 	const [draft, setDraft] = useState("")
 	const [cursorPosition, setCursorPosition] = useState(0)
 	const inputRef = useRef<HTMLInputElement | null>(null)
 	const wikiPopoverAnchorRef = useRef<HTMLDivElement | null>(null)
-	const linkWorkspaceState = getLinkWorkspaceState?.()
+	const linkWorkspaceState = isTagMode ? undefined : getLinkWorkspaceState?.()
 	const workspaceFiles = useMemo(
 		() =>
 			flattenWorkspaceFiles(
@@ -61,11 +82,15 @@ export function FrontmatterArray({
 		[linkWorkspaceState?.entries, linkWorkspaceState?.workspacePath],
 	)
 	const activeWikiQuery = useMemo(
-		() => getActiveFrontmatterWikiQuery(draft, cursorPosition),
-		[cursorPosition, draft],
+		() =>
+			isTagMode ? null : getActiveFrontmatterWikiQuery(draft, cursorPosition),
+		[cursorPosition, draft, isTagMode],
 	)
 
 	const items = useMemo(() => {
+		if (isTagMode) {
+			return normalizeFrontmatterTagItems(value)
+		}
 		if (Array.isArray(value)) {
 			return value.map((item) => String(item ?? "").trim()).filter(Boolean)
 		}
@@ -73,8 +98,11 @@ export function FrontmatterArray({
 			return parseItems(value)
 		}
 		return []
-	}, [value])
+	}, [isTagMode, value])
 	const excludedWikiTargetKeys = useMemo(() => {
+		if (isTagMode) {
+			return new Set<string>()
+		}
 		const targetKeys = new Set<string>()
 		for (const item of items) {
 			const key = getFrontmatterWikiSuggestionTargetKey(item)
@@ -83,9 +111,9 @@ export function FrontmatterArray({
 			}
 		}
 		return targetKeys
-	}, [items])
+	}, [isTagMode, items])
 	const wikiSuggestions = useMemo(() => {
-		if (!activeWikiQuery) return []
+		if (isTagMode || !activeWikiQuery) return []
 		return buildFrontmatterWikiSuggestions(
 			workspaceFiles,
 			activeWikiQuery.query,
@@ -93,16 +121,28 @@ export function FrontmatterArray({
 				excludeTargetKeys: excludedWikiTargetKeys,
 			},
 		)
-	}, [activeWikiQuery, excludedWikiTargetKeys, workspaceFiles])
+	}, [activeWikiQuery, excludedWikiTargetKeys, isTagMode, workspaceFiles])
 	const showWikiSuggestionPopover =
-		Boolean(activeWikiQuery) && wikiSuggestions.length > 0
+		!isTagMode && Boolean(activeWikiQuery) && wikiSuggestions.length > 0
+	const tagHost = useMemo<TagHostDeps | undefined>(
+		() =>
+			onOpenTagSearch
+				? {
+						openTagSearch: onOpenTagSearch,
+					}
+				: undefined,
+		[onOpenTagSearch],
+	)
 
 	const addItems = (raw: string) => {
 		const nextItems = parseItems(raw)
 		if (!nextItems.length) return
 		const applyItems = (resolvedItems: string[]) => {
+			const nextResolvedItems = isTagMode
+				? normalizeFrontmatterTagItems(resolvedItems)
+				: resolvedItems
 			const merged = [...items]
-			for (const item of resolvedItems) {
+			for (const item of nextResolvedItems) {
 				if (!merged.includes(item)) {
 					merged.push(item)
 				}
@@ -111,7 +151,7 @@ export function FrontmatterArray({
 			setDraft("")
 		}
 
-		if (!resolveWikiLinkTarget) {
+		if (isTagMode || !resolveWikiLinkTarget) {
 			applyItems(nextItems)
 			return
 		}
@@ -183,14 +223,48 @@ export function FrontmatterArray({
 				{items.map((item, index) => (
 					<span
 						key={`${item}-${index}`}
-						className="group inline-flex items-center gap-1 rounded-sm bg-muted px-2 py-1 text-sm text-foreground cursor-default"
+						className={cn(
+							"group inline-flex items-center gap-1 rounded-sm px-2 py-1 text-sm",
+							isTagMode && getFrontmatterTagQuery(item)
+								? "bg-brand/10 text-brand"
+								: "bg-muted text-foreground",
+						)}
 					>
-						<span className="max-w-[12rem] truncate" title={item}>
-							<FrontmatterWikiInlinePreview
-								value={item}
-								onOpenWikiLink={onOpenWikiLink}
-							/>
-						</span>
+						{isTagMode ? (
+							<button
+								type="button"
+								className={cn(
+									"max-w-[12rem] truncate rounded-sm text-left",
+									getFrontmatterTagQuery(item)
+										? "cursor-pointer hover:bg-brand/18"
+										: "cursor-default",
+								)}
+								title={formatFrontmatterTagLabel(item)}
+								onMouseDown={(event: MouseEvent<HTMLButtonElement>) =>
+									handleTagMouseDown(
+										event,
+										tagHost,
+										getFrontmatterTagQuery(item) ?? undefined,
+									)
+								}
+								onClick={(event: MouseEvent<HTMLButtonElement>) =>
+									handleTagClick(
+										event,
+										tagHost,
+										getFrontmatterTagQuery(item) ?? undefined,
+									)
+								}
+							>
+								{formatFrontmatterTagLabel(item)}
+							</button>
+						) : (
+							<span className="max-w-[12rem] truncate" title={item}>
+								<FrontmatterWikiInlinePreview
+									value={item}
+									onOpenWikiLink={onOpenWikiLink}
+								/>
+							</span>
+						)}
 						<button
 							type="button"
 							className="rounded-sm py-0.5 text-muted-foreground transition-colors hover:text-destructive cursor-pointer"

--- a/packages/editor/src/frontmatter/node-frontmatter-table.tsx
+++ b/packages/editor/src/frontmatter/node-frontmatter-table.tsx
@@ -25,6 +25,7 @@ import {
 	IconHash,
 	IconLetterCase,
 	IconList,
+	IconTags,
 	IconToggleLeft,
 	IconTrash,
 } from "@tabler/icons-react"
@@ -56,6 +57,12 @@ import {
 	takePendingFrontmatterFocusTarget,
 } from "./frontmatter-focus"
 import { areFrontmatterRowsEqual } from "./frontmatter-row-equality"
+import {
+	applyFrontmatterKeyChange,
+	applyFrontmatterTypeChange,
+	getFrontmatterPropertyTypeOptions,
+	isTagsFrontmatterKey,
+} from "./frontmatter-tag-utils"
 import {
 	convertValueToType,
 	datePattern,
@@ -111,6 +118,7 @@ type FrontmatterTableProps = {
 	data: KVRow[]
 	onChange: (data: KVRow[]) => void
 	onOpenWikiLink?: FrontmatterWikiLinkHandler
+	onOpenTagSearch?: (query: string) => void | Promise<void>
 	getLinkWorkspaceState?: () => LinkWorkspaceState
 	resolveWikiLinkTarget?: FrontmatterResolveWikiLinkTargetHandler
 }
@@ -124,26 +132,29 @@ const PROPERTY_ICONS: Record<
 	boolean: IconToggleLeft,
 	date: IconCalendar,
 	array: IconList,
+	tags: IconTags,
 }
 
 const PROPERTY_TYPE_OPTIONS: ReadonlyArray<{
 	value: ValueType
 	label: string
 }> = [
-	{ value: "string", label: "Text" },
-	{ value: "number", label: "Number" },
-	{ value: "boolean", label: "Boolean" },
-	{ value: "date", label: "Date" },
-	{ value: "array", label: "Array" },
+	...getFrontmatterPropertyTypeOptions("property"),
+	{ value: "tags", label: "Tags" },
 ]
 
 function TypeSelect({
 	value: currentType,
+	options,
 	onValueChange,
 	onRemove,
 	focusRegistration,
 }: {
 	value: ValueType
+	options: ReadonlyArray<{
+		value: ValueType
+		label: string
+	}>
 	onValueChange: (newType: ValueType) => void
 	onRemove: () => void
 	focusRegistration?: FocusRegistration
@@ -175,7 +186,7 @@ function TypeSelect({
 						<span>Property type</span>
 					</DropdownMenuSubTrigger>
 					<DropdownMenuSubContent>
-						{PROPERTY_TYPE_OPTIONS.map((option) => {
+						{options.map((option) => {
 							const OptionIcon = PROPERTY_ICONS[option.value]
 
 							return (
@@ -464,6 +475,7 @@ function ValueEditor({
 	onValueChange,
 	focusRegistration,
 	onOpenWikiLink,
+	onOpenTagSearch,
 	getLinkWorkspaceState,
 	resolveWikiLinkTarget,
 }: {
@@ -472,6 +484,7 @@ function ValueEditor({
 	onValueChange: (value: unknown) => void
 	focusRegistration?: FocusRegistration
 	onOpenWikiLink?: FrontmatterWikiLinkHandler
+	onOpenTagSearch?: (query: string) => void | Promise<void>
 	getLinkWorkspaceState?: () => LinkWorkspaceState
 	resolveWikiLinkTarget?: FrontmatterResolveWikiLinkTargetHandler
 }) {
@@ -550,6 +563,17 @@ function ValueEditor({
 					resolveWikiLinkTarget={resolveWikiLinkTarget}
 				/>
 			)
+		case "tags":
+			return (
+				<FrontmatterArray
+					value={value}
+					onChange={onValueChange}
+					mode="tags"
+					placeholder="Add a tag"
+					focusRegistration={focusRegistration}
+					onOpenTagSearch={onOpenTagSearch}
+				/>
+			)
 		case "number":
 			return (
 				<InlineEditableField
@@ -593,6 +617,7 @@ export function FrontmatterTable({
 	data,
 	onChange,
 	onOpenWikiLink,
+	onOpenTagSearch,
 	getLinkWorkspaceState,
 	resolveWikiLinkTarget,
 }: FrontmatterTableProps) {
@@ -679,13 +704,19 @@ export function FrontmatterTable({
 								item.id === row.original.id
 									? {
 											...item,
-											type: newType,
-											value: convertValueToType(item.value, newType),
+											...applyFrontmatterTypeChange(
+												row.original.key,
+												item.value,
+												newType,
+											),
 										}
 									: item,
 							),
 						)
 					}
+					const typeOptions = isTagsFrontmatterKey(row.original.key)
+						? getFrontmatterPropertyTypeOptions(row.original.key)
+						: PROPERTY_TYPE_OPTIONS
 
 					const removeRow = () => {
 						pendingDeleteFocusRef.current = {
@@ -699,6 +730,7 @@ export function FrontmatterTable({
 					return (
 						<TypeSelect
 							value={row.original.type}
+							options={typeOptions}
 							onValueChange={updateType}
 							onRemove={removeRow}
 							focusRegistration={createFocusRegistration(
@@ -715,7 +747,17 @@ export function FrontmatterTable({
 					const updateKey = (newKey: string) => {
 						updateTableData((items) =>
 							items.map((item) =>
-								item.id === row.original.id ? { ...item, key: newKey } : item,
+								item.id === row.original.id
+									? {
+											...item,
+											key: newKey,
+											...applyFrontmatterKeyChange(
+												newKey,
+												item.type,
+												item.value,
+											),
+										}
+									: item,
 							),
 						)
 					}
@@ -755,6 +797,7 @@ export function FrontmatterTable({
 							value={row.original.value}
 							onValueChange={updateValue}
 							onOpenWikiLink={onOpenWikiLink}
+							onOpenTagSearch={onOpenTagSearch}
 							getLinkWorkspaceState={getLinkWorkspaceState}
 							resolveWikiLinkTarget={resolveWikiLinkTarget}
 							focusRegistration={createFocusRegistration(
@@ -770,6 +813,7 @@ export function FrontmatterTable({
 			createFocusRegistration,
 			getDeleteFocusTargetRowId,
 			getLinkWorkspaceState,
+			onOpenTagSearch,
 			onOpenWikiLink,
 			resolveWikiLinkTarget,
 			updateTableData,

--- a/packages/editor/src/frontmatter/node-frontmatter.tsx
+++ b/packages/editor/src/frontmatter/node-frontmatter.tsx
@@ -20,6 +20,7 @@ export type TFrontmatterElement = {
 export function FrontmatterElement(
 	props: PlateElementProps<TFrontmatterElement> & {
 		onOpenWikiLink?: FrontmatterWikiLinkHandler
+		onOpenTagSearch?: (query: string) => void | Promise<void>
 		getLinkWorkspaceState?: () => LinkWorkspaceState
 		resolveWikiLinkTarget?: FrontmatterResolveWikiLinkTargetHandler
 	},
@@ -60,6 +61,7 @@ export function FrontmatterElement(
 					data={element.data}
 					onChange={handleDataChange}
 					onOpenWikiLink={props.onOpenWikiLink}
+					onOpenTagSearch={props.onOpenTagSearch}
 					getLinkWorkspaceState={props.getLinkWorkspaceState}
 					resolveWikiLinkTarget={props.resolveWikiLinkTarget}
 				/>

--- a/packages/editor/src/markdown/markdown-kit.test.ts
+++ b/packages/editor/src/markdown/markdown-kit.test.ts
@@ -193,6 +193,30 @@ describe("markdown-kit serialization", () => {
 		expect(markdown).toContain("E=mc^2")
 		expect(markdown).toContain("\\end{equation}")
 	})
+
+	it("serializes canonical tags rows as a yaml list", async () => {
+		const editor = createMarkdownEditor()
+		const value = [
+			{
+				type: "frontmatter",
+				data: [
+					{
+						id: "tags",
+						key: "tags",
+						type: "tags",
+						value: ["#Project", "Docs/Guide"],
+					},
+				],
+				children: [{ text: "" }],
+			},
+		]
+
+		const markdown = serializeMd(editor, { value })
+		expect(markdown).toContain("tags:")
+		expect(markdown).toContain("  - Project")
+		expect(markdown).toContain("  - Docs/Guide")
+		expect(markdown).not.toContain("#Project")
+	})
 })
 
 describe("markdown-kit deserialization", () => {
@@ -246,6 +270,26 @@ describe("markdown-kit deserialization", () => {
 					key: "title",
 					value: "Hello",
 					type: "string",
+				}),
+			]),
+		)
+	})
+
+	it("deserializes frontmatter tags into the canonical tags type", async () => {
+		const editor = createMarkdownEditor()
+		const value = deserializeMd(
+			editor,
+			"---\ntags:\n  - '#Project'\n  - Docs/Guide\n---\n\nBody",
+		)
+
+		const frontmatterNode = value[0] as any
+		expect(frontmatterNode?.type).toBe("frontmatter")
+		expect(frontmatterNode?.data).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					key: "tags",
+					value: ["Project", "Docs/Guide"],
+					type: "tags",
 				}),
 			]),
 		)

--- a/packages/editor/src/markdown/markdown-kit.ts
+++ b/packages/editor/src/markdown/markdown-kit.ts
@@ -18,9 +18,8 @@ import YAML from "yaml"
 import type { FrontmatterRow as KVRow } from "../frontmatter"
 import {
 	convertValueToType,
-	datePattern,
+	detectFrontmatterValueType,
 	FRONTMATTER_KEY,
-	type ValueType,
 } from "../frontmatter"
 import { hasParentTraversal, WINDOWS_ABSOLUTE_REGEX } from "../link/link-utils"
 
@@ -60,29 +59,19 @@ function rowsToRecord(
 	return {}
 }
 
-function detectValueType(value: unknown): ValueType {
-	if (typeof value === "boolean") return "boolean"
-	if (typeof value === "number") return "number"
-	if (Array.isArray(value)) return "array"
-	if (
-		value instanceof Date ||
-		(typeof value === "string" &&
-			!Number.isNaN(Date.parse(value)) &&
-			datePattern.test(value))
-	)
-		return "date"
-	return "string"
-}
-
 function toRowsFromRecord(value: unknown): KVRow[] {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return []
 
-	return Object.entries(value as Record<string, unknown>).map(([key, val]) => ({
-		id: createRowId(),
-		key,
-		value: val,
-		type: detectValueType(val),
-	}))
+	return Object.entries(value as Record<string, unknown>).map(([key, val]) => {
+		const type = detectFrontmatterValueType(key, val)
+
+		return {
+			id: createRowId(),
+			key,
+			value: type === "tags" ? convertValueToType(val, type) : val,
+			type,
+		}
+	})
 }
 
 function parseFrontmatterYaml(yamlSource: string): KVRow[] {

--- a/packages/editor/src/tag/index.ts
+++ b/packages/editor/src/tag/index.ts
@@ -1,0 +1,10 @@
+export { createTagLeaf, handleTagMouseDown, type TagHostDeps } from "./node-tag"
+export { createTagKit, createTagPlugin, TAG_KEY, TagKit } from "./tag-kit"
+export {
+	createTagDecoratedRanges,
+	findInlineTagMatches,
+	type InlineTagMatch,
+	normalizeTagQuery,
+	normalizeTagValue,
+	type TagDecoratedRange,
+} from "./tag-utils"

--- a/packages/editor/src/tag/node-tag.tsx
+++ b/packages/editor/src/tag/node-tag.tsx
@@ -1,0 +1,102 @@
+import { cn } from "@mdit/ui/lib/utils"
+import { PlateLeaf, type PlateLeafProps } from "platejs/react"
+import type { MouseEvent } from "react"
+
+export type TagHostDeps = {
+	openTagSearch: (query: string) => Promise<void> | void
+}
+
+type TagLeafText = {
+	tag?: boolean
+	tagLabel?: string
+	tagQuery?: string
+	text: string
+}
+
+type TagMouseEvent = Pick<
+	MouseEvent<HTMLElement>,
+	| "altKey"
+	| "button"
+	| "ctrlKey"
+	| "metaKey"
+	| "preventDefault"
+	| "shiftKey"
+	| "stopPropagation"
+>
+
+function canActivateTag(
+	event: Pick<
+		MouseEvent<HTMLElement>,
+		"altKey" | "button" | "ctrlKey" | "metaKey" | "shiftKey"
+	>,
+	host: TagHostDeps | undefined,
+	tagQuery: string | undefined,
+) {
+	return Boolean(
+		host &&
+			tagQuery &&
+			event.button === 0 &&
+			!event.altKey &&
+			!event.ctrlKey &&
+			!event.metaKey &&
+			!event.shiftKey,
+	)
+}
+
+export function handleTagMouseDown(
+	event: TagMouseEvent,
+	host: TagHostDeps | undefined,
+	tagQuery: string | undefined,
+) {
+	if (!canActivateTag(event, host, tagQuery)) {
+		return
+	}
+
+	event.preventDefault()
+	event.stopPropagation()
+}
+
+export function handleTagClick(
+	event: TagMouseEvent,
+	host: TagHostDeps | undefined,
+	tagQuery: string | undefined,
+) {
+	if (!canActivateTag(event, host, tagQuery)) {
+		return
+	}
+	if (!host || !tagQuery) {
+		return
+	}
+
+	event.preventDefault()
+	event.stopPropagation()
+	void Promise.resolve(host.openTagSearch(tagQuery)).catch((error) => {
+		console.error("Failed to open tag search:", error)
+	})
+}
+
+export function createTagLeaf(host?: TagHostDeps) {
+	return function TagLeaf(props: PlateLeafProps<TagLeafText>) {
+		const tagQuery = props.leaf.tagQuery
+		const isInteractive = Boolean(host && tagQuery)
+
+		return (
+			<PlateLeaf {...props}>
+				<span
+					className={cn(
+						"rounded-sm bg-brand/10 px-[0.18em] py-[0.04em] text-brand transition-colors",
+						isInteractive && "cursor-pointer hover:bg-brand/18",
+					)}
+					onMouseDown={(event: MouseEvent<HTMLSpanElement>) =>
+						handleTagMouseDown(event, host, tagQuery)
+					}
+					onClick={(event: MouseEvent<HTMLSpanElement>) =>
+						handleTagClick(event, host, tagQuery)
+					}
+				>
+					{props.children}
+				</span>
+			</PlateLeaf>
+		)
+	}
+}

--- a/packages/editor/src/tag/tag-kit.tsx
+++ b/packages/editor/src/tag/tag-kit.tsx
@@ -1,0 +1,69 @@
+import { KEYS } from "platejs"
+import { createPlatePlugin } from "platejs/react"
+import { FRONTMATTER_KEY } from "../frontmatter"
+import { createTagLeaf, type TagHostDeps } from "./node-tag"
+import { createTagDecoratedRanges } from "./tag-utils"
+
+export const TAG_KEY = "tag"
+
+type CreateTagKitOptions = {
+	host?: TagHostDeps
+}
+
+function hasBlockedAncestor(editor: any, path: number[]) {
+	const blockedTypes = new Set([
+		editor.getType(KEYS.codeBlock),
+		editor.getType(KEYS.link),
+		editor.getType(KEYS.img),
+		FRONTMATTER_KEY,
+	])
+
+	return Boolean(
+		editor.api.above({
+			at: path,
+			match: (node: { type?: string } | null | undefined) =>
+				typeof node?.type === "string" && blockedTypes.has(node.type),
+			mode: "lowest",
+		}),
+	)
+}
+
+export function createTagPlugin({ host }: CreateTagKitOptions = {}) {
+	return createPlatePlugin({
+		key: TAG_KEY,
+		node: {
+			isLeaf: true,
+		},
+		decorate: ({ editor, entry }) => {
+			const [node, path] = entry
+			if (
+				!node ||
+				typeof node !== "object" ||
+				typeof (node as { text?: unknown }).text !== "string"
+			) {
+				return
+			}
+
+			if ((node as { code?: boolean }).code) {
+				return
+			}
+
+			if (hasBlockedAncestor(editor, path)) {
+				return
+			}
+
+			const text = (node as { text: string }).text
+			if (!text.includes("#")) {
+				return
+			}
+
+			return createTagDecoratedRanges(text, [...path])
+		},
+	}).withComponent(createTagLeaf(host))
+}
+
+export const createTagKit = ({ host }: CreateTagKitOptions = {}) => [
+	createTagPlugin({ host }),
+]
+
+export const TagKit = createTagKit()

--- a/packages/editor/src/tag/tag-utils.test.ts
+++ b/packages/editor/src/tag/tag-utils.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest"
+import { handleTagClick, handleTagMouseDown } from "./node-tag"
+import {
+	createTagDecoratedRanges,
+	findInlineTagMatches,
+	normalizeTagQuery,
+} from "./tag-utils"
+
+describe("findInlineTagMatches", () => {
+	it("finds inline and nested tags while preserving source text", () => {
+		expect(findInlineTagMatches("See #Project and #Area/SubArea.")).toEqual([
+			{
+				value: "#Project",
+				query: "#project",
+				start: 4,
+				end: 12,
+			},
+			{
+				value: "#Area/SubArea",
+				query: "#area/subarea",
+				start: 17,
+				end: 30,
+			},
+		])
+	})
+
+	it("ignores malformed boundaries and url fragments", () => {
+		expect(
+			findInlineTagMatches("https://example.com/#anchor foo#bar #okay"),
+		).toEqual([
+			{
+				value: "#okay",
+				query: "#okay",
+				start: 36,
+				end: 41,
+			},
+		])
+	})
+})
+
+describe("createTagDecoratedRanges", () => {
+	it("creates decorate ranges for matched tags", () => {
+		expect(createTagDecoratedRanges("A #Tag", [0, 0])).toEqual([
+			{
+				anchor: { path: [0, 0], offset: 2 },
+				focus: { path: [0, 0], offset: 6 },
+				tag: true,
+				tagLabel: "#Tag",
+				tagQuery: "#tag",
+			},
+		])
+	})
+})
+
+describe("normalizeTagQuery", () => {
+	it("rejects invalid trailing separators", () => {
+		expect(normalizeTagQuery("#project/")).toBeNull()
+	})
+})
+
+describe("handleTagMouseDown", () => {
+	it("prevents focus-stealing pointer interactions", () => {
+		const openTagSearch = vi.fn()
+		const preventDefault = vi.fn()
+		const stopPropagation = vi.fn()
+
+		handleTagMouseDown(
+			{
+				button: 0,
+				altKey: false,
+				ctrlKey: false,
+				metaKey: false,
+				shiftKey: false,
+				preventDefault,
+				stopPropagation,
+			},
+			{ openTagSearch },
+			"#project/docs",
+		)
+
+		expect(preventDefault).toHaveBeenCalledOnce()
+		expect(stopPropagation).toHaveBeenCalledOnce()
+		expect(openTagSearch).not.toHaveBeenCalled()
+	})
+
+	it("does nothing for modified clicks", () => {
+		const openTagSearch = vi.fn()
+
+		handleTagMouseDown(
+			{
+				button: 0,
+				altKey: false,
+				ctrlKey: true,
+				metaKey: false,
+				shiftKey: false,
+				preventDefault: vi.fn(),
+				stopPropagation: vi.fn(),
+			},
+			{ openTagSearch },
+			"#project",
+		)
+
+		expect(openTagSearch).not.toHaveBeenCalled()
+	})
+})
+
+describe("handleTagClick", () => {
+	it("opens tag search with the normalized query", () => {
+		const openTagSearch = vi.fn()
+		const preventDefault = vi.fn()
+		const stopPropagation = vi.fn()
+
+		handleTagClick(
+			{
+				button: 0,
+				altKey: false,
+				ctrlKey: false,
+				metaKey: false,
+				shiftKey: false,
+				preventDefault,
+				stopPropagation,
+			},
+			{ openTagSearch },
+			"#project/docs",
+		)
+
+		expect(preventDefault).toHaveBeenCalledOnce()
+		expect(stopPropagation).toHaveBeenCalledOnce()
+		expect(openTagSearch).toHaveBeenCalledWith("#project/docs")
+	})
+})

--- a/packages/editor/src/tag/tag-utils.ts
+++ b/packages/editor/src/tag/tag-utils.ts
@@ -1,0 +1,110 @@
+const TAG_SEGMENT_REGEX = /^[\p{L}\p{N}_-]+$/u
+const TAG_BODY_CHAR_REGEX = /[\p{L}\p{N}_/-]/u
+const INLINE_TAG_REGEX = /#[\p{L}\p{N}_-]+(?:\/[\p{L}\p{N}_-]+)*/gu
+
+export type InlineTagMatch = {
+	value: string
+	query: string
+	start: number
+	end: number
+}
+
+export type TagDecoratedRange = {
+	anchor: {
+		path: number[]
+		offset: number
+	}
+	focus: {
+		path: number[]
+		offset: number
+	}
+	tag: true
+	tagLabel: string
+	tagQuery: string
+}
+
+export function normalizeTagValue(raw: string): string | null {
+	let value = raw.trim()
+	if (value.startsWith("#")) {
+		value = value.slice(1)
+	}
+
+	value = value.trim().toLowerCase()
+	if (!value) {
+		return null
+	}
+
+	const segments = value.split("/")
+	if (
+		segments.length === 0 ||
+		segments.some((segment) => !segment || !TAG_SEGMENT_REGEX.test(segment))
+	) {
+		return null
+	}
+
+	return segments.join("/")
+}
+
+export function normalizeTagQuery(raw: string): string | null {
+	const normalized = normalizeTagValue(raw)
+	return normalized ? `#${normalized}` : null
+}
+
+export function findInlineTagMatches(text: string): InlineTagMatch[] {
+	if (!text.includes("#")) {
+		return []
+	}
+
+	const matches: InlineTagMatch[] = []
+	for (const candidate of text.matchAll(INLINE_TAG_REGEX)) {
+		const value = candidate[0]
+		const start = candidate.index ?? -1
+		if (start < 0) {
+			continue
+		}
+
+		const end = start + value.length
+		const prevChar = start > 0 ? text[start - 1] : ""
+		const nextChar = end < text.length ? text[end] : ""
+
+		if (
+			(prevChar && TAG_BODY_CHAR_REGEX.test(prevChar)) ||
+			(nextChar && TAG_BODY_CHAR_REGEX.test(nextChar))
+		) {
+			continue
+		}
+
+		const query = normalizeTagQuery(value)
+		if (!query) {
+			continue
+		}
+
+		matches.push({
+			value,
+			query,
+			start,
+			end,
+		})
+	}
+
+	return matches
+}
+
+export function createTagDecoratedRanges(
+	text: string,
+	path: number[],
+): TagDecoratedRange[] {
+	return findInlineTagMatches(text).map((match) => ({
+		anchor: {
+			path,
+			offset: match.start,
+		},
+		focus: {
+			path,
+			offset: match.end,
+		},
+		tag: true,
+		tagLabel: match.value,
+		tagQuery: match.query,
+	}))
+}


### PR DESCRIPTION
## Summary
- add doc_tag storage and vault indexing support for inline/frontmatter tags
- wire desktop command menu tag search and seeded tag queries through the Tauri bridge
- add editor/frontmatter tag rendering, tag interactions, and focused tests

## Testing
- pnpm -C packages/command-menu test
- pnpm -C packages/editor test -- tag-utils markdown-kit frontmatter-tag-utils frontmatter-value-utils
- cargo test -p vault-indexing tag_scenarios --manifest-path Cargo.toml

## Notes
- follow-up: existing vaults likely need an explicit tag backfill or force-reindex path
- follow-up: frontmatter fence parsing around indented `---` should be tightened in a separate patch