### PR TITLE
feat: add obsidian image embed support

### DIFF
--- a/apps/desktop/src/components/dnd/editor-drop-handler.ts
+++ b/apps/desktop/src/components/dnd/editor-drop-handler.ts
@@ -109,9 +109,7 @@ function handleFileDropToEditor({
 		const imageNode = {
 			type: editor.getType(KEYS.img),
 			url: imageData.url,
-			...(imageData.wiki
-				? { wiki: true, wikiTarget: imageData.wikiTarget }
-				: {}),
+			...(imageData.embedTarget ? { embedTarget: imageData.embedTarget } : {}),
 			children: [{ text: "" }],
 		}
 

--- a/apps/desktop/src/components/editor/utils/image-link.ts
+++ b/apps/desktop/src/components/editor/utils/image-link.ts
@@ -9,28 +9,27 @@ import { isPathEqualOrDescendant } from "@/utils/path-utils"
 
 export type ImageLinkData = {
 	url: string
-	wiki: boolean
-	wikiTarget?: string
+	embedTarget?: string
 }
 
 export function buildImageLinkData(path: string): ImageLinkData {
 	if (!path) {
-		return { url: path, wiki: false }
+		return { url: path }
 	}
 
 	const trimmed = path.trim()
 	if (!trimmed || trimmed.startsWith("http")) {
-		return { url: path, wiki: false }
+		return { url: path }
 	}
 
 	const workspacePath = useStore.getState().workspacePath
 	if (!workspacePath) {
-		return { url: path, wiki: false }
+		return { url: path }
 	}
 
 	if (isAbsoluteLike(trimmed)) {
 		if (!isPathEqualOrDescendant(trimmed, workspacePath)) {
-			return { url: trimmed, wiki: false }
+			return { url: trimmed }
 		}
 
 		const relativePath = normalizePathSeparators(
@@ -38,18 +37,16 @@ export function buildImageLinkData(path: string): ImageLinkData {
 		)
 		return {
 			url: relativePath,
-			wiki: true,
-			wikiTarget: relativePath,
+			embedTarget: relativePath,
 		}
 	}
 
 	const normalized = normalizePathSeparators(trimmed)
 	if (hasParentTraversal(normalized)) {
-		return { url: normalized, wiki: false }
+		return { url: normalized }
 	}
 	return {
 		url: normalized,
-		wiki: true,
-		wikiTarget: normalized,
+		embedTarget: normalized,
 	}
 }

--- a/packages/editor/src/markdown/markdown-kit.test.ts
+++ b/packages/editor/src/markdown/markdown-kit.test.ts
@@ -2,6 +2,7 @@ import { deserializeMd, serializeMd } from "@platejs/markdown"
 import { createSlateEditor, KEYS } from "platejs"
 import { describe, expect, it } from "vitest"
 import { MarkdownKit, MarkdownKitNoMdx } from "./markdown-kit"
+import { OBSIDIAN_EMBED_KEY } from "./obsidian-embed-plugin"
 
 type LocalStorageLike = Pick<
 	Storage,
@@ -130,8 +131,8 @@ describe("markdown-kit serialization", () => {
 		const value = [
 			{
 				type: KEYS.img,
-				url: "./assets/pic.png",
-				wiki: true,
+				url: "assets/pic.png",
+				embedTarget: "assets/pic.png",
 				caption: [{ text: "Alt" }],
 				children: [{ text: "" }],
 			},
@@ -141,7 +142,24 @@ describe("markdown-kit serialization", () => {
 		expect(markdown).toContain("![[assets/pic.png]]")
 	})
 
-	it("serializes internal images as markdown when not wiki", async () => {
+	it("serializes internal image embeds with dimensions", async () => {
+		const editor = createMarkdownEditor()
+		const value = [
+			{
+				type: KEYS.img,
+				url: "assets/pic.png",
+				embedTarget: "assets/pic.png",
+				width: 300,
+				height: 200,
+				children: [{ text: "" }],
+			},
+		]
+
+		const markdown = serializeMd(editor, { value })
+		expect(markdown).toContain("![[assets/pic.png|300x200]]")
+	})
+
+	it("serializes internal images as markdown when not embed", async () => {
 		const editor = createMarkdownEditor()
 		const value = [
 			{
@@ -156,6 +174,27 @@ describe("markdown-kit serialization", () => {
 		expect(markdown).toContain("![Alt](")
 		expect(markdown).toContain("./assets/pic.png")
 		expect(markdown).not.toContain("![[assets/pic.png]]")
+	})
+
+	it("serializes hidden embeds as embed syntax", async () => {
+		const editor = createMarkdownEditor()
+		const value = [
+			{
+				type: KEYS.p,
+				children: [
+					{ text: "See " },
+					{
+						type: OBSIDIAN_EMBED_KEY,
+						embedTarget: "docs/guide",
+						children: [{ text: "" }],
+					},
+					{ text: " now." },
+				],
+			},
+		]
+
+		const markdown = serializeMd(editor, { value })
+		expect(markdown).toContain("See ![[docs/guide]] now.")
 	})
 
 	it("keeps external links in standard markdown", async () => {
@@ -253,8 +292,31 @@ describe("markdown-kit deserialization", () => {
 
 		expect(imageNode).toMatchObject({
 			url: "assets/pic.png",
-			wiki: true,
-			wikiTarget: "assets/pic.png",
+			embedTarget: "assets/pic.png",
+		})
+	})
+
+	it("deserializes image embeds with dimensions", async () => {
+		const editor = createMarkdownEditor()
+		const value = deserializeMd(editor, "![[assets/pic.png|300x200]]")
+		const imageNode = findNodeByType(value as any[], KEYS.img)
+
+		expect(imageNode).toMatchObject({
+			url: "assets/pic.png",
+			embedTarget: "assets/pic.png",
+			width: 300,
+			height: 200,
+		})
+	})
+
+	it("deserializes non-image embeds into hidden nodes", async () => {
+		const editor = createMarkdownEditor()
+		const value = deserializeMd(editor, "See ![[docs/guide]] now.")
+		const embedNode = findNodeByType(value as any[], OBSIDIAN_EMBED_KEY)
+
+		expect(embedNode).toMatchObject({
+			type: OBSIDIAN_EMBED_KEY,
+			embedTarget: "docs/guide",
 		})
 	})
 

--- a/packages/editor/src/markdown/markdown-kit.ts
+++ b/packages/editor/src/markdown/markdown-kit.ts
@@ -22,6 +22,10 @@ import {
 	FRONTMATTER_KEY,
 } from "../frontmatter"
 import { hasParentTraversal, WINDOWS_ABSOLUTE_REGEX } from "../link/link-utils"
+import {
+	OBSIDIAN_EMBED_KEY,
+	ObsidianEmbedPlugin,
+} from "./obsidian-embed-plugin"
 
 const EQUATION_ENVIRONMENT_REGEX =
 	/^\\begin\{([^}]+)\}[\r\n]+([\s\S]*?)[\r\n]+\\end\{\1\}\s*$/
@@ -35,6 +39,11 @@ type MdastNode = {
 	type?: string
 	children?: MdastNode[]
 	value?: string
+	data?: {
+		hName?: string
+		hProperties?: Record<string, unknown>
+		path?: string
+	}
 }
 
 function createRowId() {
@@ -93,12 +102,6 @@ function safelyDecodeUri(url: string): string {
 	}
 }
 
-function isInternalLink(url: string): boolean {
-	const trimmed = url.trim().toLowerCase()
-	if (!trimmed) return false
-	return !trimmed.startsWith("http://") && !trimmed.startsWith("https://")
-}
-
 function normalizeWikiTarget(url: string): string {
 	let value = safelyDecodeUri(url.trim())
 
@@ -151,6 +154,55 @@ function isEmptyParagraph(node: MdastNode | undefined): boolean {
 	})
 }
 
+function parsePositiveDimension(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+		return value
+	}
+
+	if (typeof value === "string" && /^\d+$/.test(value)) {
+		const parsed = Number.parseInt(value, 10)
+		return parsed > 0 ? parsed : undefined
+	}
+
+	return undefined
+}
+
+function getEmbedDimensions(mdastNode: MdastNode): {
+	width?: number
+	height?: number
+} {
+	const hProperties = mdastNode.data?.hProperties ?? {}
+	const width = parsePositiveDimension(hProperties["data-fs-width"])
+	const height = width
+		? parsePositiveDimension(hProperties["data-fs-height"])
+		: undefined
+
+	return { width, height }
+}
+
+function createEmbedNodeData(
+	width: unknown,
+	height: unknown,
+): {
+	hProperties?: Record<string, unknown>
+} {
+	const normalizedWidth = parsePositiveDimension(width)
+	const normalizedHeight = normalizedWidth
+		? parsePositiveDimension(height)
+		: undefined
+
+	if (!normalizedWidth) {
+		return {}
+	}
+
+	return {
+		hProperties: {
+			"data-fs-width": normalizedWidth,
+			...(normalizedHeight ? { "data-fs-height": normalizedHeight } : {}),
+		},
+	}
+}
+
 export type CreateMarkdownKitOptions = {
 	mdx?: boolean
 }
@@ -158,6 +210,7 @@ export type CreateMarkdownKitOptions = {
 export const createMarkdownKit = ({
 	mdx = true,
 }: CreateMarkdownKitOptions = {}) => [
+	ObsidianEmbedPlugin,
 	MarkdownPlugin.configure({
 		options: {
 			disallowedNodes: [KEYS.slashCommand],
@@ -271,26 +324,21 @@ export const createMarkdownKit = ({
 				[KEYS.img]: {
 					serialize: (node: any): any => {
 						const rawUrl = node.url ?? ""
-						const shouldSerializeWiki = Boolean(node.wiki || node.wikiTarget)
-						const wikiSource = node.wikiTarget || rawUrl
+						const embedTarget =
+							typeof node.embedTarget === "string"
+								? node.embedTarget.trim()
+								: ""
 
-						if (
-							shouldSerializeWiki &&
-							isInternalLink(wikiSource) &&
-							isWikiEmbedTargetSafe(wikiSource)
-						) {
-							const target = node.wikiTarget || normalizeWikiTarget(rawUrl)
-							if (target) {
-								return {
-									type: "paragraph",
-									children: [
-										{
-											type: "embed",
-											value: target,
-											data: {},
-										},
-									],
-								}
+						if (embedTarget) {
+							return {
+								type: "paragraph",
+								children: [
+									{
+										type: "embed",
+										value: embedTarget,
+										data: createEmbedNodeData(node.width, node.height),
+									},
+								],
 							}
 						}
 
@@ -313,32 +361,31 @@ export const createMarkdownKit = ({
 						}
 					},
 				},
+				[OBSIDIAN_EMBED_KEY]: {
+					serialize: (node: any) => {
+						const embedTarget =
+							typeof node.embedTarget === "string"
+								? node.embedTarget.trim()
+								: ""
+
+						if (!embedTarget) {
+							return { type: "text", value: "" }
+						}
+
+						return {
+							type: "embed",
+							value: embedTarget,
+							data: createEmbedNodeData(node.width, node.height),
+						}
+					},
+				},
 				embed: {
 					deserialize: (mdastNode, _deco, options) => {
 						const target = mdastNode.value || ""
-						if (!isWikiEmbedTargetSafe(target)) {
-							const hName = mdastNode.data?.hName
-							const hProperties = mdastNode.data?.hProperties ?? {}
-							if (hName === "img") {
-								const altText =
-									typeof hProperties.alt === "string" ? hProperties.alt : ""
-								return {
-									type: getPluginType(options.editor!, KEYS.img),
-									url: "",
-									caption: [{ text: altText }],
-									children: [{ text: "" }],
-								}
-							}
-							return {
-								type: getPluginType(options.editor!, KEYS.link),
-								url: "",
-								children: [{ text: target }],
-							}
-						}
-
 						const hName = mdastNode.data?.hName
 						const hProperties = mdastNode.data?.hProperties ?? {}
 						const url = hProperties.src || mdastNode.data?.path || target
+						const { width, height } = getEmbedDimensions(mdastNode)
 
 						if (hName === "img") {
 							const altText =
@@ -347,19 +394,20 @@ export const createMarkdownKit = ({
 							return {
 								type: getPluginType(options.editor!, KEYS.img),
 								url,
-								wiki: true,
-								wikiTarget: target,
+								embedTarget: target,
+								width,
+								height,
 								caption: [{ text: altText }],
 								children: [{ text: "" }],
 							}
 						}
 
 						return {
-							type: getPluginType(options.editor!, KEYS.link),
-							url,
-							wiki: true,
-							wikiTarget: target,
-							children: [{ text: target }],
+							type: getPluginType(options.editor!, OBSIDIAN_EMBED_KEY),
+							embedTarget: target,
+							width,
+							height,
+							children: [{ text: "" }],
 						}
 					},
 				},

--- a/packages/editor/src/markdown/obsidian-embed-plugin.tsx
+++ b/packages/editor/src/markdown/obsidian-embed-plugin.tsx
@@ -1,0 +1,33 @@
+import type { TElement } from "platejs"
+import { createPlatePlugin, type PlateElementProps } from "platejs/react"
+
+export const OBSIDIAN_EMBED_KEY = "obsidian_embed"
+
+export type TObsidianEmbedElement = TElement & {
+	type: typeof OBSIDIAN_EMBED_KEY
+	embedTarget: string
+	width?: number
+	height?: number
+}
+
+function ObsidianEmbedElement(props: PlateElementProps<TObsidianEmbedElement>) {
+	return (
+		<span
+			{...props.attributes}
+			contentEditable={false}
+			style={{ display: "none" }}
+		>
+			{props.children}
+		</span>
+	)
+}
+
+export const ObsidianEmbedPlugin = createPlatePlugin({
+	key: OBSIDIAN_EMBED_KEY,
+	node: {
+		component: ObsidianEmbedElement,
+		isElement: true,
+		isInline: true,
+		isVoid: true,
+	},
+})

--- a/packages/editor/src/media/media-image-mode-switch.tsx
+++ b/packages/editor/src/media/media-image-mode-switch.tsx
@@ -1,0 +1,57 @@
+import { Switch } from "@mdit/ui/components/switch"
+import type { TImageElement } from "platejs"
+import { useEditorRef, useElement } from "platejs/react"
+import {
+	buildImageModeUpdate,
+	isImageModeToggleDisabled,
+} from "./media-image-mode-utils"
+import type { MediaImageWorkspaceState } from "./node-media-image"
+
+type ImageElementWithEmbed = TImageElement & {
+	embedTarget?: string
+	height?: number
+}
+
+export function MediaImageModeSwitch({
+	workspaceState,
+}: {
+	workspaceState: MediaImageWorkspaceState
+}) {
+	const editor = useEditorRef()
+	const element = useElement() as ImageElementWithEmbed
+	const checked = Boolean(element.embedTarget)
+	const disabled = isImageModeToggleDisabled(element)
+
+	const handleCheckedChange = (nextChecked: boolean) => {
+		const path = editor.api.findPath(element)
+		if (!path) return
+
+		const nextNode = buildImageModeUpdate({
+			element,
+			mode: nextChecked ? "embed" : "markdown",
+			workspaceState,
+		})
+
+		if (!nextNode) return
+
+		if (!nextChecked) {
+			editor.tf.unsetNodes(["embedTarget"], { at: path })
+		}
+
+		editor.tf.setNodes(nextNode, { at: path })
+		editor.tf.focus()
+	}
+
+	return (
+		<div className="flex items-center gap-2 px-2 text-xs text-muted-foreground">
+			<span>Markdown</span>
+			<Switch
+				checked={checked}
+				disabled={disabled}
+				onCheckedChange={handleCheckedChange}
+				aria-label="Toggle image embed mode"
+			/>
+			<span>Embed</span>
+		</div>
+	)
+}

--- a/packages/editor/src/media/media-image-mode-utils.test.ts
+++ b/packages/editor/src/media/media-image-mode-utils.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+import {
+	buildImageModeUpdate,
+	isImageModeToggleDisabled,
+} from "./media-image-mode-utils"
+
+describe("media-image-mode-utils", () => {
+	it("disables embed toggling for external images", () => {
+		expect(
+			isImageModeToggleDisabled({ url: "https://example.com/image.png" }),
+		).toBe(true)
+		expect(isImageModeToggleDisabled({ url: "./assets/pic.png" })).toBe(false)
+	})
+
+	it("converts markdown image urls to embed targets", () => {
+		const result = buildImageModeUpdate({
+			element: { url: "./assets/pic.png" },
+			mode: "embed",
+			workspaceState: {
+				tabPath: "/workspace/notes/today.md",
+				workspacePath: "/workspace",
+			},
+		})
+
+		expect(result).toEqual({
+			url: "notes/assets/pic.png",
+			embedTarget: "notes/assets/pic.png",
+		})
+	})
+
+	it("converts embed targets back to markdown image urls", () => {
+		const result = buildImageModeUpdate({
+			element: {
+				url: "notes/assets/pic.png",
+				embedTarget: "notes/assets/pic.png",
+			},
+			mode: "markdown",
+			workspaceState: {
+				tabPath: "/workspace/notes/today.md",
+				workspacePath: "/workspace",
+			},
+		})
+
+		expect(result).toEqual({
+			url: "./assets/pic.png",
+		})
+	})
+
+	it("keeps existing embed targets stable when already embedded", () => {
+		const result = buildImageModeUpdate({
+			element: {
+				url: "notes/assets/pic.png",
+				embedTarget: "notes/assets/pic.png",
+			},
+			mode: "embed",
+			workspaceState: {
+				tabPath: "/workspace/notes/today.md",
+				workspacePath: "/workspace",
+			},
+		})
+
+		expect(result).toEqual({
+			url: "notes/assets/pic.png",
+			embedTarget: "notes/assets/pic.png",
+		})
+	})
+})

--- a/packages/editor/src/media/media-image-mode-utils.ts
+++ b/packages/editor/src/media/media-image-mode-utils.ts
@@ -1,0 +1,167 @@
+import { dirname, isAbsolute, join, relative } from "pathe"
+import type { TImageElement } from "platejs"
+import {
+	formatMarkdownPath,
+	isPathInsideWorkspaceRoot,
+	normalizePathSeparators,
+	safelyDecodeUrl,
+	startsWithHttpProtocol,
+	stripLeadingSlashes,
+	toWorkspaceRelativeWikiTarget,
+} from "../link"
+
+export type ImageLinkMode = "embed" | "markdown"
+
+export type ImageElementWithEmbed = TImageElement & {
+	embedTarget?: string
+	height?: number
+}
+
+type WorkspaceState = {
+	tabPath: string | null
+	workspacePath: string | null
+}
+
+function normalizeMarkdownImageUrl(
+	input: string,
+	workspaceState: WorkspaceState,
+): string {
+	const decoded = safelyDecodeUrl(input.trim())
+	if (!decoded) {
+		return ""
+	}
+
+	if (startsWithHttpProtocol(decoded) || decoded.startsWith("#")) {
+		return decoded
+	}
+
+	const [pathPart, hashPart] = decoded.split("#", 2)
+	let normalizedPath = normalizePathSeparators(pathPart)
+	const { tabPath, workspacePath } = workspaceState
+
+	if (!normalizedPath) {
+		return hashPart ? `#${hashPart}` : ""
+	}
+
+	if (workspacePath) {
+		const hasRootPrefix = normalizedPath.startsWith("/")
+		const isAbsolutePath = isAbsolute(normalizedPath)
+
+		if (hasRootPrefix || isAbsolutePath) {
+			const absolutePath = hasRootPrefix
+				? join(workspacePath, stripLeadingSlashes(normalizedPath))
+				: normalizedPath
+
+			if (isPathInsideWorkspaceRoot(absolutePath, workspacePath)) {
+				normalizedPath = normalizePathSeparators(
+					relative(tabPath ? dirname(tabPath) : workspacePath, absolutePath),
+				)
+			}
+		}
+	}
+
+	if (
+		!startsWithHttpProtocol(normalizedPath) &&
+		!isAbsolute(normalizedPath) &&
+		!normalizedPath.startsWith(".") &&
+		!normalizedPath.startsWith("/")
+	) {
+		normalizedPath = formatMarkdownPath(normalizedPath)
+	}
+
+	return hashPart ? `${normalizedPath}#${hashPart}` : normalizedPath
+}
+
+function convertEmbedTargetToMarkdownUrl(
+	input: string,
+	workspaceState: WorkspaceState,
+): string {
+	const decoded = safelyDecodeUrl(input.trim())
+	if (!decoded) {
+		return ""
+	}
+
+	if (startsWithHttpProtocol(decoded)) {
+		return decoded
+	}
+
+	const [pathPart, hashPart] = decoded.split("#", 2)
+	let normalizedPath = normalizePathSeparators(pathPart)
+
+	if (!normalizedPath) {
+		return hashPart ? `#${hashPart}` : ""
+	}
+
+	if (workspaceState.workspacePath && workspaceState.tabPath) {
+		const absolutePath = join(
+			workspaceState.workspacePath,
+			stripLeadingSlashes(normalizedPath),
+		)
+		normalizedPath = normalizePathSeparators(
+			relative(dirname(workspaceState.tabPath), absolutePath),
+		)
+	}
+
+	if (
+		!startsWithHttpProtocol(normalizedPath) &&
+		!isAbsolute(normalizedPath) &&
+		!normalizedPath.startsWith(".") &&
+		!normalizedPath.startsWith("/")
+	) {
+		normalizedPath = formatMarkdownPath(normalizedPath)
+	}
+
+	return hashPart ? `${normalizedPath}#${hashPart}` : normalizedPath
+}
+
+export function isImageModeToggleDisabled(
+	element: Pick<ImageElementWithEmbed, "embedTarget" | "url">,
+): boolean {
+	const rawValue = element.embedTarget || element.url || ""
+	return startsWithHttpProtocol(rawValue)
+}
+
+export function buildImageModeUpdate(options: {
+	element: Pick<ImageElementWithEmbed, "embedTarget" | "url">
+	mode: ImageLinkMode
+	workspaceState: WorkspaceState
+}): {
+	url: string
+	embedTarget?: string
+} | null {
+	const { element, mode, workspaceState } = options
+	const currentValue = (element.embedTarget || element.url || "").trim()
+
+	if (!currentValue) {
+		return null
+	}
+
+	if (mode === "embed") {
+		if (startsWithHttpProtocol(currentValue)) {
+			return null
+		}
+
+		const embedTarget =
+			element.embedTarget ||
+			toWorkspaceRelativeWikiTarget({
+				input: currentValue,
+				workspacePath: workspaceState.workspacePath,
+				currentTabPath: workspaceState.tabPath,
+			})
+
+		if (!embedTarget) {
+			return null
+		}
+
+		return {
+			url: embedTarget,
+			embedTarget,
+		}
+	}
+
+	return {
+		url: element.embedTarget
+			? convertEmbedTargetToMarkdownUrl(element.embedTarget, workspaceState)
+			: normalizeMarkdownImageUrl(currentValue, workspaceState),
+	}
+}

--- a/packages/editor/src/media/media-toolbar.tsx
+++ b/packages/editor/src/media/media-toolbar.tsx
@@ -1,15 +1,8 @@
 import { Button } from "@mdit/ui/components/button"
 import { Popover, PopoverContent } from "@mdit/ui/components/popover"
 import { Separator } from "@mdit/ui/components/separator"
-import {
-	FloatingMedia as FloatingMediaPrimitive,
-	FloatingMediaStore,
-	useFloatingMediaValue,
-	useImagePreviewValue,
-} from "@platejs/media/react"
-import { cva } from "class-variance-authority"
-import { Link, Trash2Icon } from "lucide-react"
-import type { WithRequiredKey } from "platejs"
+import { useImagePreviewValue } from "@platejs/media/react"
+import { Trash2Icon } from "lucide-react"
 import {
 	useEditorRef,
 	useEditorSelector,
@@ -19,21 +12,19 @@ import {
 	useRemoveNodeButton,
 	useSelected,
 } from "platejs/react"
-import { useEffect, useRef } from "react"
+import { useRef } from "react"
 import { CaptionButton } from "./caption"
-
-const inputVariants = cva(
-	"flex h-[28px] w-full rounded-md border-none bg-transparent px-1.5 py-1 text-base placeholder:text-muted-foreground focus-visible:ring-transparent focus-visible:outline-none md:text-sm",
-)
 
 export function MediaToolbar({
 	children,
-	plugin,
 	hide,
+	toolbarContent,
+	showCaption = true,
 }: {
 	children: React.ReactNode
-	plugin: WithRequiredKey
 	hide?: boolean
+	toolbarContent?: React.ReactNode
+	showCaption?: boolean
 }) {
 	const editor = useEditorRef()
 	const readOnly = useReadOnly()
@@ -51,22 +42,9 @@ export function MediaToolbar({
 		selectionCollapsed &&
 		!isImagePreviewOpen &&
 		!hide
-	const isEditing = useFloatingMediaValue("isEditing")
 	const anchorRef = useRef<HTMLDivElement>(null)
 	const element = useElement()
 	const { props: buttonProps } = useRemoveNodeButton({ element })
-
-	const isWikiMedia = Boolean(
-		(element as { wiki?: boolean; wikiTarget?: string }).wiki ||
-			(element as { wiki?: boolean; wikiTarget?: string }).wikiTarget,
-	)
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: true
-	useEffect(() => {
-		if (!open && isEditing) {
-			FloatingMediaStore.set("isEditing", false)
-		}
-	}, [open])
 
 	return (
 		<Popover open={open} modal={false}>
@@ -77,42 +55,22 @@ export function MediaToolbar({
 				className="w-auto p-1"
 				initialFocus={false}
 			>
-				{isEditing ? (
-					<div className="flex w-[330px] flex-col">
-						<div className="flex items-center">
-							<div className="flex items-center pr-1 pl-2 text-muted-foreground">
-								<Link className="size-4" />
-							</div>
+				<div className="box-content flex items-center gap-1">
+					{toolbarContent}
 
-							<FloatingMediaPrimitive.UrlInput
-								className={inputVariants()}
-								placeholder="Paste the embed link..."
-								options={{ plugin }}
-							/>
-						</div>
-					</div>
-				) : (
-					<div className="box-content flex items-center">
-						{/* <FloatingMediaPrimitive.EditButton
-              className={buttonVariants({ size: 'sm', variant: 'ghost' })}
-            >
-              Edit link
-            </FloatingMediaPrimitive.EditButton> */}
+					{showCaption && (
+						<>
+							<CaptionButton size="sm" variant="ghost">
+								Caption
+							</CaptionButton>
+							<Separator orientation="vertical" className="mx-1 h-6" />
+						</>
+					)}
 
-						{!isWikiMedia && (
-							<>
-								<CaptionButton size="sm" variant="ghost">
-									Caption
-								</CaptionButton>
-								<Separator orientation="vertical" className="mx-1 h-6" />
-							</>
-						)}
-
-						<Button size="sm" variant="ghost" {...buttonProps}>
-							<Trash2Icon />
-						</Button>
-					</div>
-				)}
+					<Button size="sm" variant="ghost" {...buttonProps}>
+						<Trash2Icon />
+					</Button>
+				</div>
 			</PopoverContent>
 		</Popover>
 	)

--- a/packages/editor/src/media/node-media-image.tsx
+++ b/packages/editor/src/media/node-media-image.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@mdit/ui/lib/utils"
-import { Image, ImagePlugin, useMediaState } from "@platejs/media/react"
+import { Image, useMediaState } from "@platejs/media/react"
 import { ResizableProvider, useResizableValue } from "@platejs/resizable"
 import { ImageOff } from "lucide-react"
 import { dirname, isAbsolute, resolve } from "pathe"
@@ -7,7 +7,10 @@ import type { NodeComponent, TImageElement } from "platejs"
 import type { PlateElementProps } from "platejs/react"
 import { PlateElement, withHOC } from "platejs/react"
 import { useMemo, useState } from "react"
+import { hasParentTraversal, WINDOWS_ABSOLUTE_REGEX } from "../link"
 import { Caption, CaptionTextarea } from "../media/caption"
+import { MediaImageModeSwitch } from "../media/media-image-mode-switch"
+import type { ImageElementWithEmbed } from "../media/media-image-mode-utils"
 import { MediaToolbar } from "../media/media-toolbar"
 import {
 	mediaResizeHandleVariants,
@@ -25,21 +28,28 @@ export type MediaImageHostDeps = {
 	toFileUrl: (absolutePath: string) => string
 }
 
-type ImageElementWithWiki = TImageElement & {
-	wiki?: boolean
-	wikiTarget?: string
+function isSafeEmbedTarget(path: string): boolean {
+	const normalized = path.trim()
+	if (!normalized) return false
+	if (normalized.startsWith("/")) return false
+	if (WINDOWS_ABSOLUTE_REGEX.test(normalized)) return false
+	return !hasParentTraversal(normalized)
 }
 
 function resolveImageSrc(
-	element: ImageElementWithWiki,
+	element: ImageElementWithEmbed,
 	workspaceState: MediaImageWorkspaceState,
 	toFileUrl: (absolutePath: string) => string,
 ): string {
 	const { tabPath, workspacePath } = workspaceState
-	const { url = "", wiki, wikiTarget } = element
-	const rawUrl = wikiTarget || url
+	const { url = "", embedTarget } = element
+	const rawUrl = embedTarget || url
 
 	if (!rawUrl) {
+		return ""
+	}
+
+	if (embedTarget && !isSafeEmbedTarget(embedTarget)) {
 		return ""
 	}
 
@@ -51,7 +61,7 @@ function resolveImageSrc(
 
 	if (isAbsolute(rawUrl)) {
 		baseSrc = rawUrl
-	} else if (wiki || wikiTarget) {
+	} else if (embedTarget) {
 		if (!workspacePath) {
 			return ""
 		}
@@ -78,16 +88,22 @@ export const createImageElement = (host: MediaImageHostDeps): NodeComponent =>
 			const width = useResizableValue("width")
 			const [hasError, setHasError] = useState(false)
 
-			const element = props.element as ImageElementWithWiki
+			const element = props.element as ImageElementWithEmbed
 			const src = useMemo(
 				() => resolveImageSrc(element, workspaceState, host.toFileUrl),
 				[element, workspaceState],
 			)
 
-			const isWikiImage = Boolean(element.wiki || element.wikiTarget)
+			const isEmbedImage = Boolean(element.embedTarget)
 
 			return (
-				<MediaToolbar plugin={ImagePlugin} hide={hasError}>
+				<MediaToolbar
+					hide={hasError}
+					toolbarContent={
+						<MediaImageModeSwitch workspaceState={workspaceState} />
+					}
+					showCaption={!isEmbedImage}
+				>
 					<PlateElement {...props} className="py-2.5">
 						{hasError ? (
 							<div
@@ -133,7 +149,7 @@ export const createImageElement = (host: MediaImageHostDeps): NodeComponent =>
 									/>
 								</Resizable>
 
-								{!isWikiImage && (
+								{!isEmbedImage && (
 									<Caption style={{ width }} align={align}>
 										<CaptionTextarea
 											readOnly={readOnly}

--- a/packages/editor/src/slash/node-slash.tsx
+++ b/packages/editor/src/slash/node-slash.tsx
@@ -62,12 +62,11 @@ function insertImageNode(
 		? resolveImageLink(path)
 		: {
 				url: path,
-				wiki: false,
 			}
 	const imageNode = {
 		type: editor.getType(KEYS.img),
 		url: imageData.url,
-		...(imageData.wiki ? { wiki: true, wikiTarget: imageData.wikiTarget } : {}),
+		...(imageData.embedTarget ? { embedTarget: imageData.embedTarget } : {}),
 		children: [{ text: "" }],
 	}
 

--- a/packages/editor/src/slash/slash-kit-types.ts
+++ b/packages/editor/src/slash/slash-kit-types.ts
@@ -2,8 +2,7 @@ import type { FrontmatterRow as KVRow } from "../frontmatter"
 
 export type SlashResolvedImageLink = {
 	url: string
-	wiki: boolean
-	wikiTarget?: string
+	embedTarget?: string
 }
 
 export type SlashHostDeps = {


### PR DESCRIPTION
## Summary
- add Obsidian embed parsing/serialization for editor image nodes
- add image mode toggle utilities and media toolbar support for markdown vs embed images
- wire desktop slash/drop image insertion to use embedTarget semantics

## Testing
- pnpm -C packages/editor test

## Follow-up
- handle unsafe embed targets with a visible fallback instead of hidden/broken nodes
- block embed mode for non-vault image paths
- avoid silent caption loss when toggling an image with caption content to embed mode