### PR TITLE
refactor: split vault indexing and embedding refresh

### DIFF
--- a/apps/desktop/src/components/command-menu/command-menu.tsx
+++ b/apps/desktop/src/components/command-menu/command-menu.tsx
@@ -5,7 +5,7 @@ import {
 	CommandMenu as SharedCommandMenu,
 } from "@mdit/command-menu"
 import { invoke } from "@tauri-apps/api/core"
-import { useCallback, useEffect } from "react"
+import { useCallback } from "react"
 import { useShallow } from "zustand/shallow"
 import { useStore } from "@/store"
 import { searchMarkdownContent } from "./utils/note-content-search"
@@ -32,7 +32,6 @@ export function CommandMenu() {
 		isCommandMenuOpen,
 		commandMenuInitialQuery,
 		setCommandMenuOpen,
-		getIndexingConfig,
 	} = useStore(
 		useShallow((state) => ({
 			entries: state.entries,
@@ -41,19 +40,8 @@ export function CommandMenu() {
 			isCommandMenuOpen: state.isCommandMenuOpen,
 			commandMenuInitialQuery: state.commandMenuInitialQuery,
 			setCommandMenuOpen: state.setCommandMenuOpen,
-			getIndexingConfig: state.getIndexingConfig,
 		})),
 	)
-
-	useEffect(() => {
-		if (!workspacePath) {
-			return
-		}
-
-		getIndexingConfig(workspacePath).catch((error) => {
-			console.error("Failed to load indexing config:", error)
-		})
-	}, [getIndexingConfig, workspacePath])
 
 	const handleSelectNote = useCallback(
 		(notePath: string) => {

--- a/apps/desktop/src/components/editor/header/info-button.tsx
+++ b/apps/desktop/src/components/editor/header/info-button.tsx
@@ -52,26 +52,17 @@ export function InfoButton() {
 	const [backlinks, setBacklinks] = useState<BacklinkEntry[]>([])
 	const [relatedNotes, setRelatedNotes] = useState<RelatedNoteEntry[]>([])
 
-	const {
-		tab,
-		workspacePath,
-		openTab,
-		getIndexingConfig,
-		isNoteInfoOpen,
-		setNoteInfoOpen,
-	} = useStore(
-		useShallow((s) => ({
-			tab: s.tab,
-			workspacePath: s.workspacePath,
-			openTab: s.openTab,
-			getIndexingConfig: s.getIndexingConfig,
-			isNoteInfoOpen: s.isNoteInfoOpen,
-			setNoteInfoOpen: s.setNoteInfoOpen,
-		})),
-	)
-	const indexingConfig = useStore((s) =>
-		workspacePath ? (s.configs[workspacePath] ?? null) : null,
-	)
+	const { tab, workspacePath, openTab, isNoteInfoOpen, setNoteInfoOpen } =
+		useStore(
+			useShallow((s) => ({
+				tab: s.tab,
+				workspacePath: s.workspacePath,
+				openTab: s.openTab,
+				isNoteInfoOpen: s.isNoteInfoOpen,
+				setNoteInfoOpen: s.setNoteInfoOpen,
+			})),
+		)
+	const indexingConfig = useStore((s) => s.config)
 	const hasEmbeddingConfig = Boolean(
 		indexingConfig?.embeddingProvider && indexingConfig?.embeddingModel,
 	)
@@ -114,16 +105,6 @@ export function InfoButton() {
 			cancelled = true
 		}
 	}, [isNoteInfoOpen, workspacePath, tab?.path])
-
-	useEffect(() => {
-		if (!isNoteInfoOpen || !workspacePath) {
-			return
-		}
-
-		getIndexingConfig(workspacePath).catch((error) => {
-			console.error("Failed to load indexing config:", error)
-		})
-	}, [isNoteInfoOpen, workspacePath, getIndexingConfig])
 
 	useEffect(() => {
 		if (

--- a/apps/desktop/src/components/settings/hooks/use-indexing-meta-polling.ts
+++ b/apps/desktop/src/components/settings/hooks/use-indexing-meta-polling.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react"
+import { useStore } from "@/store"
+
+const INDEXING_META_POLL_INTERVAL_MS = 5000
+
+export function useIndexingMetaPolling(
+	workspacePath: string | null,
+	enabled: boolean,
+) {
+	const loadIndexingMeta = useStore((state) => state.loadIndexingMeta)
+
+	useEffect(() => {
+		if (!workspacePath) {
+			return
+		}
+
+		void loadIndexingMeta(workspacePath)
+
+		if (!enabled) {
+			return
+		}
+
+		const intervalId = window.setInterval(() => {
+			void useStore.getState().loadIndexingMeta(workspacePath)
+		}, INDEXING_META_POLL_INTERVAL_MS)
+
+		return () => {
+			window.clearInterval(intervalId)
+		}
+	}, [workspacePath, enabled, loadIndexingMeta])
+}

--- a/apps/desktop/src/components/settings/hooks/use-indexing-model-change.ts
+++ b/apps/desktop/src/components/settings/hooks/use-indexing-model-change.ts
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useShallow } from "zustand/shallow"
+import { useStore } from "@/store"
+import {
+	isModelChanging,
+	parseEmbeddingModelValue,
+	shouldShowModelChangeWarning,
+} from "@/store/indexing/helpers/indexing-utils"
+import type { IndexingConfig } from "@/store/indexing/indexing-types"
+
+type PendingModelChange = {
+	provider: string
+	model: string
+}
+
+export function useIndexingModelChange(
+	workspacePath: string | null,
+	currentConfig: IndexingConfig | null,
+	indexedDocCount: number,
+) {
+	const { setIndexingConfig, refreshWorkspaceEmbeddings, loadIndexingMeta } =
+		useStore(
+			useShallow((state) => ({
+				setIndexingConfig: state.setIndexingConfig,
+				refreshWorkspaceEmbeddings: state.refreshWorkspaceEmbeddings,
+				loadIndexingMeta: state.loadIndexingMeta,
+			})),
+		)
+	const [isDialogOpen, setIsDialogOpen] = useState(false)
+	const [pendingModelChange, setPendingModelChange] =
+		useState<PendingModelChange | null>(null)
+	const requestIdRef = useRef(0)
+	const previousWorkspacePathRef = useRef<string | null>(workspacePath)
+
+	const clearPendingModelChange = useCallback(() => {
+		requestIdRef.current += 1
+		setPendingModelChange(null)
+		setIsDialogOpen(false)
+	}, [])
+
+	useEffect(() => {
+		if (previousWorkspacePathRef.current === workspacePath) {
+			return
+		}
+
+		previousWorkspacePathRef.current = workspacePath
+		clearPendingModelChange()
+	}, [workspacePath, clearPendingModelChange])
+
+	const requestModelChange = useCallback(
+		async (value: string | null) => {
+			if (!workspacePath || !value) {
+				return
+			}
+
+			const parsed = parseEmbeddingModelValue(value)
+			if (!parsed) {
+				return
+			}
+
+			const { provider, model } = parsed
+			if (!isModelChanging(currentConfig, provider, model)) {
+				return
+			}
+
+			if (shouldShowModelChangeWarning(true, indexedDocCount)) {
+				setPendingModelChange({ provider, model })
+				setIsDialogOpen(true)
+				return
+			}
+
+			try {
+				await setIndexingConfig(workspacePath, provider, model)
+			} catch (error) {
+				console.error("Failed to update embedding model:", error)
+			}
+		},
+		[workspacePath, currentConfig, indexedDocCount, setIndexingConfig],
+	)
+
+	const confirmModelChange = useCallback(async () => {
+		if (!workspacePath || !pendingModelChange) {
+			return
+		}
+
+		const requestId = requestIdRef.current + 1
+		requestIdRef.current = requestId
+
+		try {
+			await setIndexingConfig(
+				workspacePath,
+				pendingModelChange.provider,
+				pendingModelChange.model,
+			)
+			await refreshWorkspaceEmbeddings(workspacePath)
+			await loadIndexingMeta(workspacePath)
+		} catch (error) {
+			console.error("Failed to confirm embedding model change:", error)
+		} finally {
+			if (requestIdRef.current === requestId) {
+				setPendingModelChange(null)
+				setIsDialogOpen(false)
+			}
+		}
+	}, [
+		workspacePath,
+		pendingModelChange,
+		setIndexingConfig,
+		refreshWorkspaceEmbeddings,
+		loadIndexingMeta,
+	])
+
+	return {
+		isDialogOpen,
+		requestModelChange,
+		confirmModelChange,
+		cancelModelChange: clearPendingModelChange,
+	}
+}

--- a/apps/desktop/src/components/settings/ui/embedding-model-change-dialog.tsx
+++ b/apps/desktop/src/components/settings/ui/embedding-model-change-dialog.tsx
@@ -10,26 +10,24 @@ import {
 
 type EmbeddingModelChangeDialogProps = {
 	open: boolean
-	onOpenChange: (open: boolean) => void
+	onCancel: () => void
 	onConfirm: () => void
 }
 
 export function EmbeddingModelChangeDialog({
 	open,
-	onOpenChange,
+	onCancel,
 	onConfirm,
 }: EmbeddingModelChangeDialogProps) {
-	const handleConfirm = () => {
-		onConfirm()
-		onOpenChange(false)
-	}
-
-	const handleCancel = () => {
-		onOpenChange(false)
-	}
-
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
+		<Dialog
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (!nextOpen) {
+					onCancel()
+				}
+			}}
+		>
 			<DialogContent>
 				<DialogHeader>
 					<DialogTitle>Change Embedding Model</DialogTitle>
@@ -41,10 +39,10 @@ export function EmbeddingModelChangeDialog({
 					</DialogDescription>
 				</DialogHeader>
 				<DialogFooter>
-					<Button variant="outline" onClick={handleCancel}>
+					<Button variant="outline" onClick={onCancel}>
 						Cancel
 					</Button>
-					<Button onClick={handleConfirm}>Confirm</Button>
+					<Button onClick={onConfirm}>Confirm</Button>
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>

--- a/apps/desktop/src/components/settings/ui/indexing-tab.tsx
+++ b/apps/desktop/src/components/settings/ui/indexing-tab.tsx
@@ -8,11 +8,13 @@ import {
 	FieldSet,
 } from "@mdit/ui/components/field"
 import { Loader2Icon, RefreshCcwIcon } from "lucide-react"
-import { useCallback, useEffect, useMemo } from "react"
+import { useMemo } from "react"
 import { useShallow } from "zustand/shallow"
 import { useStore } from "@/store"
 import { calculateIndexingProgress } from "@/store/indexing/helpers/indexing-utils"
 import type { WorkspaceEntry } from "@/store/workspace/workspace-slice"
+import { useIndexingMetaPolling } from "../hooks/use-indexing-meta-polling"
+import { useIndexingModelChange } from "../hooks/use-indexing-model-change"
 import { useOllamaModelRefresh } from "../hooks/use-ollama-model-refresh"
 import { EmbeddingModelChangeDialog } from "./embedding-model-change-dialog"
 import { INDEXING_MODEL_CONTROL_STATE } from "./indexing-ui-state"
@@ -32,17 +34,10 @@ export function IndexingTab() {
 		ollamaEmbeddingModels,
 		fetchOllamaModels,
 		indexVaultDocuments,
-		indexingState,
-		configs,
+		isIndexing,
+		config,
 		indexedDocCount,
 		isMetaLoading,
-		showModelChangeDialog,
-		loadIndexingMeta,
-		startIndexingMetaPolling,
-		stopIndexingMetaPolling,
-		handleModelChangeRequest,
-		confirmModelChange,
-		cancelModelChange,
 	} = useStore(
 		useShallow((state) => ({
 			workspacePath: state.workspacePath,
@@ -50,33 +45,23 @@ export function IndexingTab() {
 			ollamaEmbeddingModels: state.ollamaEmbeddingModels,
 			fetchOllamaModels: state.fetchOllamaModels,
 			indexVaultDocuments: state.indexVaultDocuments,
-			indexingState: state.indexingState,
-			configs: state.configs,
+			isIndexing: state.isIndexing,
+			config: state.config,
 			indexedDocCount: state.indexedDocCount,
 			isMetaLoading: state.isMetaLoading,
-			showModelChangeDialog: state.showModelChangeDialog,
-			loadIndexingMeta: state.loadIndexingMeta,
-			startIndexingMetaPolling: state.startIndexingMetaPolling,
-			stopIndexingMetaPolling: state.stopIndexingMetaPolling,
-			handleModelChangeRequest: state.handleModelChangeRequest,
-			confirmModelChange: state.confirmModelChange,
-			cancelModelChange: state.cancelModelChange,
 		})),
 	)
 
-	const isIndexing = workspacePath
-		? (indexingState[workspacePath] ?? false)
-		: false
 	const { isRefreshingModels, refreshOllamaModels } =
 		useOllamaModelRefresh(fetchOllamaModels)
-
-	// Get current config from store
-	const currentConfig = useMemo(() => {
-		if (!workspacePath) {
-			return null
-		}
-		return configs[workspacePath] ?? null
-	}, [workspacePath, configs])
+	const currentConfig = config
+	useIndexingMetaPolling(workspacePath, isIndexing)
+	const {
+		isDialogOpen,
+		requestModelChange,
+		confirmModelChange,
+		cancelModelChange,
+	} = useIndexingModelChange(workspacePath, currentConfig, indexedDocCount)
 
 	const embeddingProvider = currentConfig?.embeddingProvider ?? ""
 	const embeddingModel = currentConfig?.embeddingModel ?? ""
@@ -87,74 +72,6 @@ export function IndexingTab() {
 		() => calculateIndexingProgress(indexedDocCount, totalFiles),
 		[indexedDocCount, totalFiles],
 	)
-
-	// Load config when workspace changes
-	useEffect(() => {
-		if (!workspacePath) {
-			return
-		}
-
-		const { getIndexingConfig } = useStore.getState()
-		getIndexingConfig(workspacePath)
-	}, [workspacePath])
-
-	// Load indexing meta and start polling when workspace changes
-	useEffect(() => {
-		if (!workspacePath) {
-			return
-		}
-
-		loadIndexingMeta(workspacePath)
-	}, [workspacePath, loadIndexingMeta])
-
-	// Start/stop polling based on indexing state
-	useEffect(() => {
-		if (!workspacePath) {
-			stopIndexingMetaPolling(true)
-			return
-		}
-
-		if (!isIndexing) {
-			stopIndexingMetaPolling()
-			return
-		}
-
-		startIndexingMetaPolling(workspacePath)
-		return () => stopIndexingMetaPolling()
-	}, [
-		workspacePath,
-		isIndexing,
-		startIndexingMetaPolling,
-		stopIndexingMetaPolling,
-	])
-
-	const handleEmbeddingModelChange = useCallback(
-		async (value: string | null) => {
-			if (!workspacePath || !value) {
-				return
-			}
-
-			await handleModelChangeRequest(
-				value,
-				workspacePath,
-				currentConfig,
-				indexedDocCount,
-			)
-		},
-		[workspacePath, currentConfig, indexedDocCount, handleModelChangeRequest],
-	)
-
-	const handleConfirmModelChange = useCallback(async () => {
-		if (!workspacePath) {
-			return
-		}
-
-		await confirmModelChange(workspacePath, true)
-	}, [workspacePath, confirmModelChange])
-
-	const handleDialogCancel = useCallback(() => {
-		cancelModelChange()
-	}, [cancelModelChange])
 
 	const isEmbeddingModelConfigured = embeddingModel !== ""
 	const isEmbeddingModelAvailable =
@@ -178,7 +95,7 @@ export function IndexingTab() {
 
 		try {
 			await indexVaultDocuments(workspacePath, forceReindex)
-			await loadIndexingMeta(workspacePath)
+			await useStore.getState().loadIndexingMeta(workspacePath)
 		} catch (error) {
 			console.error("Failed to index vault documents:", error)
 		}
@@ -193,15 +110,9 @@ export function IndexingTab() {
 	return (
 		<>
 			<EmbeddingModelChangeDialog
-				open={showModelChangeDialog}
-				onOpenChange={(open) => {
-					if (open) {
-						// Dialog is controlled by store, shouldn't open manually
-					} else {
-						handleDialogCancel()
-					}
-				}}
-				onConfirm={handleConfirmModelChange}
+				open={isDialogOpen}
+				onCancel={cancelModelChange}
+				onConfirm={confirmModelChange}
 			/>
 			<div className="flex-1 overflow-y-auto p-12">
 				<FieldSet>
@@ -220,7 +131,7 @@ export function IndexingTab() {
 							<div className="flex items-center gap-2">
 								<Select
 									value={selectedEmbeddingModel ?? undefined}
-									onValueChange={handleEmbeddingModelChange}
+									onValueChange={requestModelChange}
 									disabled={modelControlState.disabled}
 								>
 									<SettingsSelectTrigger className="w-[240px]">

--- a/apps/desktop/src/hooks/use-auto-indexing.ts
+++ b/apps/desktop/src/hooks/use-auto-indexing.ts
@@ -6,27 +6,17 @@ const AUTO_INDEX_INTERVAL_MS = 30 * 60 * 1000 // 30 minutes
 
 export function useAutoIndexing(workspacePath: string | null) {
 	const {
-		getIndexingConfig,
 		indexVaultDocuments,
 		refreshWorkspaceEmbeddings,
 		isMigrationsComplete,
 	} = useStore(
 		useShallow((state) => ({
-			getIndexingConfig: state.getIndexingConfig,
 			indexVaultDocuments: state.indexVaultDocuments,
 			refreshWorkspaceEmbeddings: state.refreshWorkspaceEmbeddings,
 			isMigrationsComplete: state.isMigrationsComplete,
 		})),
 	)
 	const intervalRef = useRef<number | null>(null)
-
-	useEffect(() => {
-		if (workspacePath) {
-			getIndexingConfig(workspacePath).catch((error) => {
-				console.error("Failed to load indexing config:", error)
-			})
-		}
-	}, [workspacePath, getIndexingConfig])
 
 	useEffect(() => {
 		// Clear any existing interval
@@ -40,8 +30,7 @@ export function useAutoIndexing(workspacePath: string | null) {
 			return
 		}
 
-		const isIndexingRunning = () =>
-			Boolean(useStore.getState().indexingState[workspacePath])
+		const isIndexingRunning = () => useStore.getState().isIndexing
 
 		const runInitialIndex = async () => {
 			if (isIndexingRunning()) {

--- a/apps/desktop/src/store/indexing/indexing-slice.test.ts
+++ b/apps/desktop/src/store/indexing/indexing-slice.test.ts
@@ -4,6 +4,10 @@ import { createTauriIndexingPort, type InvokeFunction } from "./indexing-ports"
 import { type IndexingSlice, prepareIndexingSlice } from "./indexing-slice"
 
 type TestStoreState = IndexingSlice & { ollamaEmbeddingModels: string[] }
+type ConfigResolver = (value: {
+	embeddingProvider: string
+	embeddingModel: string
+}) => void
 
 function createIndexingStore({
 	invoke = vi.fn().mockResolvedValue({}) as unknown as InvokeFunction,
@@ -15,11 +19,6 @@ function createIndexingStore({
 	const createSlice = prepareIndexingSlice({
 		createIndexingPort: (workspacePath) =>
 			createTauriIndexingPort(invoke, workspacePath),
-		timerUtils: {
-			setInterval: vi.fn().mockReturnValue(1),
-			clearInterval: vi.fn(),
-			Date,
-		},
 	})
 
 	const store = createStore<TestStoreState>()((set, get, api) => ({
@@ -51,7 +50,7 @@ describe("indexing-slice config", () => {
 			embeddingProvider: "ollama",
 			embeddingModel: "mxbai-embed-large",
 		})
-		expect(store.getState().configs["/ws"]).toEqual({
+		expect(store.getState().config).toEqual({
 			embeddingProvider: "ollama",
 			embeddingModel: "mxbai-embed-large",
 		})
@@ -77,10 +76,39 @@ describe("indexing-slice config", () => {
 			embeddingProvider: "ollama",
 			embeddingModel: "mxbai-embed-large",
 		})
-		expect(store.getState().configs["/ws"]).toEqual({
+		expect(store.getState().config).toEqual({
 			embeddingProvider: "ollama",
 			embeddingModel: "mxbai-embed-large",
 		})
+	})
+
+	it("ignores late config responses after reset", async () => {
+		let resolveConfig: ConfigResolver | undefined
+		const invoke = vi.fn().mockImplementation((command: string) => {
+			if (command === "get_vault_embedding_config_command") {
+				return new Promise<{
+					embeddingProvider: string
+					embeddingModel: string
+				}>((resolve) => {
+					resolveConfig = resolve
+				})
+			}
+			return Promise.resolve({})
+		}) as unknown as InvokeFunction
+		const { store } = createIndexingStore({ invoke })
+
+		const configPromise = store.getState().getIndexingConfig("/ws")
+		store.getState().resetIndexingState()
+		resolveConfig?.({
+			embeddingProvider: "ollama",
+			embeddingModel: "mxbai-embed-large",
+		})
+
+		await expect(configPromise).resolves.toEqual({
+			embeddingProvider: "ollama",
+			embeddingModel: "mxbai-embed-large",
+		})
+		expect(store.getState().config).toBeNull()
 	})
 })
 
@@ -95,7 +123,7 @@ describe("indexing-slice indexVaultDocuments", () => {
 			workspacePath: "/ws",
 			forceReindex: true,
 		})
-		expect(store.getState().indexingState["/ws"]).toBe(false)
+		expect(store.getState().isIndexing).toBe(false)
 	})
 
 	it("sends expected invoke payload for embedding-only workspace refresh", async () => {
@@ -110,42 +138,27 @@ describe("indexing-slice indexVaultDocuments", () => {
 				workspacePath: "/ws",
 			},
 		)
-		expect(store.getState().indexingState["/ws"]).toBe(false)
+		expect(store.getState().isIndexing).toBe(false)
 	})
 
-	it("reindexes after model confirmation without forcing a full reset", async () => {
-		const invoke = vi.fn().mockResolvedValue({}) as unknown as InvokeFunction
-		const { store } = createIndexingStore({ invoke })
+	it("resetIndexingState clears current workspace state", () => {
+		const { store } = createIndexingStore()
 
 		store.setState({
-			pendingModelChange: {
-				provider: "ollama",
-				model: "mxbai-embed-large",
-			},
-		})
-
-		await store.getState().confirmModelChange("/ws", true)
-
-		expect(invoke).toHaveBeenNthCalledWith(
-			1,
-			"set_vault_embedding_config_command",
-			{
-				workspacePath: "/ws",
+			config: {
 				embeddingProvider: "ollama",
 				embeddingModel: "mxbai-embed-large",
 			},
-		)
-		expect(invoke).toHaveBeenNthCalledWith(
-			2,
-			"refresh_workspace_embeddings_command",
-			{
-				workspacePath: "/ws",
-			},
-		)
-		expect(invoke).toHaveBeenNthCalledWith(3, "get_indexing_meta_command", {
-			workspacePath: "/ws",
+			isIndexing: true,
+			indexedDocCount: 42,
+			isMetaLoading: true,
 		})
-		expect(store.getState().showModelChangeDialog).toBe(false)
-		expect(store.getState().pendingModelChange).toBeNull()
+
+		store.getState().resetIndexingState()
+
+		expect(store.getState().config).toBeNull()
+		expect(store.getState().isIndexing).toBe(false)
+		expect(store.getState().indexedDocCount).toBe(0)
+		expect(store.getState().isMetaLoading).toBe(false)
 	})
 })

--- a/apps/desktop/src/store/indexing/indexing-slice.ts
+++ b/apps/desktop/src/store/indexing/indexing-slice.ts
@@ -1,23 +1,7 @@
 import { invoke as tauriInvoke } from "@tauri-apps/api/core"
 import type { StateCreator } from "zustand"
-import {
-	isModelChanging,
-	parseEmbeddingModelValue,
-	shouldShowModelChangeWarning,
-} from "./helpers/indexing-utils"
 import { createTauriIndexingPort, type IndexingPort } from "./indexing-ports"
-import type {
-	IndexingConfig,
-	IndexingMeta,
-	WorkspaceIndexSummary,
-} from "./indexing-types"
-
-type IndexingState = Record<string, boolean>
-
-type PendingModelChange = {
-	provider: string
-	model: string
-}
+import type { IndexingConfig, WorkspaceIndexSummary } from "./indexing-types"
 
 type EmbeddingModelsState = {
 	ollamaEmbeddingModels: string[]
@@ -25,14 +9,13 @@ type EmbeddingModelsState = {
 
 export type IndexingSlice = {
 	// State
-	indexingState: IndexingState
-	configs: Record<string, IndexingConfig>
+	config: IndexingConfig | null
+	isIndexing: boolean
 	indexedDocCount: number
 	isMetaLoading: boolean
-	showModelChangeDialog: boolean
-	pendingModelChange: PendingModelChange | null
 
 	// Existing actions
+	resetIndexingState: () => void
 	getIndexingConfig: (
 		workspacePath: string | null,
 	) => Promise<IndexingConfig | null>
@@ -50,318 +33,156 @@ export type IndexingSlice = {
 	) => Promise<WorkspaceIndexSummary>
 
 	loadIndexingMeta: (workspacePath: string) => Promise<void>
-	startIndexingMetaPolling: (workspacePath: string) => void
-	stopIndexingMetaPolling: (clearWorkspacePath?: boolean) => void
-	handleModelChangeRequest: (
-		value: string,
-		workspacePath: string,
-		currentConfig: IndexingConfig | null,
-		indexedCount: number,
-	) => Promise<void>
-	confirmModelChange: (
-		workspacePath: string,
-		forceReindex: boolean,
-	) => Promise<void>
-	cancelModelChange: () => void
-}
-
-type TimerUtils = {
-	setInterval: (handler: TimerHandler, timeout?: number) => number
-	clearInterval: (id: number) => void
-	Date: typeof Date
 }
 
 type IndexingSliceDependencies = {
 	createIndexingPort: (path: string) => IndexingPort
-	timerUtils?: TimerUtils
 }
 
-const defaultTimerUtils: TimerUtils = {
-	setInterval: (handler: TimerHandler, timeout?: number) =>
-		window.setInterval(handler, timeout),
-	clearInterval: (id: number) => window.clearInterval(id),
-	Date,
+const buildStoredConfig = (
+	embeddingProvider: string | null | undefined,
+	embeddingModel: string | null | undefined,
+): IndexingConfig | null => {
+	const normalizedModel = embeddingModel?.trim() ?? ""
+	if (!normalizedModel) {
+		return null
+	}
+
+	const normalizedProvider = embeddingProvider?.trim() || "ollama"
+	return {
+		embeddingProvider: normalizedProvider,
+		embeddingModel: normalizedModel,
+	}
 }
+
+const buildInitialIndexingState = () => ({
+	config: null,
+	isIndexing: false,
+	indexedDocCount: 0,
+	isMetaLoading: false,
+})
 
 export const prepareIndexingSlice = ({
 	createIndexingPort,
-	timerUtils = defaultTimerUtils,
 }: IndexingSliceDependencies): StateCreator<
 	IndexingSlice & EmbeddingModelsState,
 	[],
 	[],
 	IndexingSlice
 > => {
-	let pollingIntervalId: number | null = null
-	let currentWorkspacePath: string | null = null
+	let workspaceSessionId = 0
 
-	return (set, get) => ({
-		indexingState: {},
-		configs: {},
-		indexedDocCount: 0,
-		isMetaLoading: false,
-		showModelChangeDialog: false,
-		pendingModelChange: null,
+	return (set, get) => {
+		const isSessionActive = (sessionId: number) =>
+			workspaceSessionId === sessionId
 
-		getIndexingConfig: async (workspacePath: string | null) => {
-			if (!workspacePath) {
-				return null
+		const runExclusiveIndexingTask = async <T>(
+			workspacePath: string,
+			task: (indexingPort: IndexingPort) => Promise<T>,
+		): Promise<T> => {
+			const sessionId = workspaceSessionId
+			if (get().isIndexing) {
+				throw new Error("Indexing is already running for this workspace")
 			}
 
-			const state = get()
-			if (state.configs[workspacePath]) {
-				return state.configs[workspacePath]
+			if (isSessionActive(sessionId)) {
+				set({ isIndexing: true })
 			}
 
-			const indexingPort = createIndexingPort(workspacePath)
-			const dbConfig = await indexingPort.getIndexingConfig()
+			try {
+				return await task(createIndexingPort(workspacePath))
+			} finally {
+				if (isSessionActive(sessionId)) {
+					set({ isIndexing: false })
+				}
+			}
+		}
 
-			if (dbConfig) {
-				const config: IndexingConfig = {
-					embeddingProvider: dbConfig.embeddingProvider ?? "",
-					embeddingModel: dbConfig.embeddingModel ?? "",
+		return {
+			...buildInitialIndexingState(),
+
+			resetIndexingState: () => {
+				workspaceSessionId += 1
+				set(buildInitialIndexingState())
+			},
+
+			getIndexingConfig: async (workspacePath: string | null) => {
+				if (!workspacePath) {
+					return null
 				}
 
-				set((state) => ({
-					configs: {
-						...state.configs,
-						[workspacePath]: config,
-					},
-				}))
+				const state = get()
+				if (state.config) {
+					return state.config
+				}
+
+				const sessionId = workspaceSessionId
+				const indexingPort = createIndexingPort(workspacePath)
+				const dbConfig = await indexingPort.getIndexingConfig()
+				const config = buildStoredConfig(
+					dbConfig?.embeddingProvider,
+					dbConfig?.embeddingModel,
+				)
+
+				if (workspaceSessionId === sessionId) {
+					set({ config })
+				}
 
 				return config
-			}
+			},
 
-			set((state) => {
-				const nextConfigs = { ...state.configs }
-				delete nextConfigs[workspacePath]
-				return { configs: nextConfigs }
-			})
-
-			return null
-		},
-
-		setIndexingConfig: async (
-			workspacePath: string,
-			embeddingProvider: string,
-			embeddingModel: string,
-		) => {
-			const indexingPort = createIndexingPort(workspacePath)
-			await indexingPort.setIndexingConfig(embeddingProvider, embeddingModel)
-			const trimmedModel = embeddingModel.trim()
-
-			if (!trimmedModel) {
-				set((state) => {
-					const nextConfigs = { ...state.configs }
-					delete nextConfigs[workspacePath]
-					return { configs: nextConfigs }
-				})
-				return
-			}
-
-			const trimmedProvider = embeddingProvider.trim()
-			const normalizedProvider = trimmedProvider || "ollama"
-			const newConfig: IndexingConfig = {
-				embeddingProvider: normalizedProvider,
-				embeddingModel: trimmedModel,
-			}
-
-			set((state) => ({
-				configs: {
-					...state.configs,
-					[workspacePath]: newConfig,
-				},
-			}))
-		},
-
-		indexVaultDocuments: async (
-			workspacePath: string,
-			forceReindex: boolean,
-		) => {
-			const isRunning = get().indexingState[workspacePath]
-			if (isRunning) {
-				throw new Error("Indexing is already running for this workspace")
-			}
-
-			set((state) => ({
-				indexingState: {
-					...state.indexingState,
-					[workspacePath]: true,
-				},
-			}))
-
-			try {
+			setIndexingConfig: async (
+				workspacePath: string,
+				embeddingProvider: string,
+				embeddingModel: string,
+			) => {
+				const sessionId = workspaceSessionId
 				const indexingPort = createIndexingPort(workspacePath)
-				const result = await indexingPort.indexVaultDocuments(forceReindex)
-				return result
-			} finally {
-				set((state) => ({
-					indexingState: {
-						...state.indexingState,
-						[workspacePath]: false,
-					},
-				}))
-			}
-		},
-
-		refreshWorkspaceEmbeddings: async (workspacePath: string) => {
-			const isRunning = get().indexingState[workspacePath]
-			if (isRunning) {
-				throw new Error("Indexing is already running for this workspace")
-			}
-
-			set((state) => ({
-				indexingState: {
-					...state.indexingState,
-					[workspacePath]: true,
-				},
-			}))
-
-			try {
-				const indexingPort = createIndexingPort(workspacePath)
-				return await indexingPort.refreshWorkspaceEmbeddings()
-			} finally {
-				set((state) => ({
-					indexingState: {
-						...state.indexingState,
-						[workspacePath]: false,
-					},
-				}))
-			}
-		},
-
-		loadIndexingMeta: async (workspacePath: string) => {
-			currentWorkspacePath = workspacePath
-			set({ isMetaLoading: true })
-
-			try {
-				const indexingPort = createIndexingPort(workspacePath)
-				const meta = await indexingPort.getIndexingMeta()
-
-				// Only update if we're still viewing the same workspace
-				if (currentWorkspacePath === workspacePath) {
-					set({ indexedDocCount: meta.indexedDocCount ?? 0 })
+				await indexingPort.setIndexingConfig(embeddingProvider, embeddingModel)
+				if (workspaceSessionId !== sessionId) {
+					return
 				}
-			} catch {
-				if (currentWorkspacePath === workspacePath) {
-					set({ indexedDocCount: 0 })
-				}
-			} finally {
-				if (currentWorkspacePath === workspacePath) {
-					set({ isMetaLoading: false })
-				}
-			}
-		},
 
-		startIndexingMetaPolling: (workspacePath: string) => {
-			// Clear any existing interval
-			if (pollingIntervalId !== null) {
-				timerUtils.clearInterval(pollingIntervalId)
-				pollingIntervalId = null
-			}
-
-			currentWorkspacePath = workspacePath
-
-			// Load immediately and start polling
-			const poll = () => {
-				const indexingPort = createIndexingPort(workspacePath)
-				indexingPort
-					.getIndexingMeta()
-					.then((meta: IndexingMeta) => {
-						if (currentWorkspacePath === workspacePath) {
-							set({ indexedDocCount: meta.indexedDocCount ?? 0 })
-						}
-					})
-					.catch(() => {
-						if (currentWorkspacePath === workspacePath) {
-							set({ indexedDocCount: 0 })
-						}
-					})
-			}
-
-			poll()
-			pollingIntervalId = timerUtils.setInterval(poll, 5000)
-		},
-
-		stopIndexingMetaPolling: (clearWorkspacePath = false) => {
-			if (pollingIntervalId !== null) {
-				timerUtils.clearInterval(pollingIntervalId)
-				pollingIntervalId = null
-			}
-			if (clearWorkspacePath) {
-				currentWorkspacePath = null
-			}
-		},
-
-		handleModelChangeRequest: async (
-			value: string,
-			workspacePath: string,
-			currentConfig: IndexingConfig | null,
-			indexedCount: number,
-		) => {
-			const parsed = parseEmbeddingModelValue(value)
-			if (!parsed) {
-				return
-			}
-
-			const { provider, model } = parsed
-
-			const isChanging = isModelChanging(currentConfig, provider, model)
-			const shouldShowWarning = shouldShowModelChangeWarning(
-				isChanging,
-				indexedCount,
-			)
-
-			if (shouldShowWarning) {
 				set({
-					pendingModelChange: { provider, model },
-					showModelChangeDialog: true,
+					config: buildStoredConfig(embeddingProvider, embeddingModel),
 				})
-				return
-			}
+			},
 
-			// No warning needed, update model directly
-			await get().setIndexingConfig(workspacePath, provider, model)
-		},
+			indexVaultDocuments: (workspacePath: string, forceReindex: boolean) =>
+				runExclusiveIndexingTask(workspacePath, (indexingPort) =>
+					indexingPort.indexVaultDocuments(forceReindex),
+				),
 
-		confirmModelChange: async (
-			workspacePath: string,
-			forceReindex: boolean,
-		) => {
-			const pending = get().pendingModelChange
-			if (!pending) {
-				return
-			}
+			refreshWorkspaceEmbeddings: (workspacePath: string) =>
+				runExclusiveIndexingTask(workspacePath, (indexingPort) =>
+					indexingPort.refreshWorkspaceEmbeddings(),
+				),
 
-			const { provider, model } = pending
-
-			// Update model first
-			await get().setIndexingConfig(workspacePath, provider, model)
-
-			// Then run indexing if needed
-			if (forceReindex) {
-				try {
-					// Model changes refresh embeddings without wiping docs, links, or tags.
-					await get().refreshWorkspaceEmbeddings(workspacePath)
-					await get().loadIndexingMeta(workspacePath)
-				} catch {
-					// Error handling is done by caller or can be improved
+			loadIndexingMeta: async (workspacePath: string) => {
+				const sessionId = workspaceSessionId
+				if (workspaceSessionId === sessionId) {
+					set({ isMetaLoading: true })
 				}
-			}
 
-			set({
-				pendingModelChange: null,
-				showModelChangeDialog: false,
-			})
-		},
+				try {
+					const indexingPort = createIndexingPort(workspacePath)
+					const meta = await indexingPort.getIndexingMeta()
 
-		cancelModelChange: () => {
-			set({
-				pendingModelChange: null,
-				showModelChangeDialog: false,
-			})
-		},
-	})
+					if (workspaceSessionId === sessionId) {
+						set({ indexedDocCount: meta.indexedDocCount ?? 0 })
+					}
+				} catch {
+					if (workspaceSessionId === sessionId) {
+						set({ indexedDocCount: 0 })
+					}
+				} finally {
+					if (workspaceSessionId === sessionId) {
+						set({ isMetaLoading: false })
+					}
+				}
+			},
+		}
+	}
 }
 
 export const createIndexingSlice = prepareIndexingSlice({

--- a/apps/desktop/src/store/workspace/lifecycle/actions.test.ts
+++ b/apps/desktop/src/store/workspace/lifecycle/actions.test.ts
@@ -16,7 +16,8 @@ describe("lifecycle-actions", () => {
 	})
 
 	it("setWorkspace unwatches existing watcher when workspace path changes", async () => {
-		const { context, deps, setState, getState } = createActionTestContext()
+		const { context, deps, ports, setState, getState } =
+			createActionTestContext()
 		const actions = createLifecycleActions(context)
 		const unwatch = vi.fn()
 		setState({
@@ -34,6 +35,8 @@ describe("lifecycle-actions", () => {
 		expect(unwatch).toHaveBeenCalledTimes(1)
 		expect(deps.historyRepository.touchWorkspace).toHaveBeenCalledWith("/new")
 		expect(deps.historyRepository.listWorkspacePaths).toHaveBeenCalled()
+		expect(ports.indexing.resetIndexingState).toHaveBeenCalledTimes(1)
+		expect(ports.indexing.getIndexingConfig).toHaveBeenCalledWith("/new")
 		expect(getState().workspacePath).toBe("/new")
 		expect(getState().unwatchFn).toBeNull()
 	})
@@ -58,7 +61,8 @@ describe("lifecycle-actions", () => {
 	})
 
 	it("clearWorkspace unwatches existing watcher", async () => {
-		const { context, deps, setState, getState } = createActionTestContext()
+		const { context, deps, ports, setState, getState } =
+			createActionTestContext()
 		const actions = createLifecycleActions(context)
 		const unwatch = vi.fn()
 		setState({
@@ -72,12 +76,14 @@ describe("lifecycle-actions", () => {
 
 		expect(unwatch).toHaveBeenCalledTimes(1)
 		expect(deps.historyRepository.removeWorkspace).toHaveBeenCalledWith("/old")
+		expect(ports.indexing.resetIndexingState).toHaveBeenCalledTimes(1)
 		expect(getState().workspacePath).toBeNull()
 		expect(getState().unwatchFn).toBeNull()
 	})
 
 	it("initializeWorkspace unwatches existing watcher when workspace path changes", async () => {
-		const { context, deps, setState, getState } = createActionTestContext()
+		const { context, deps, ports, setState, getState } =
+			createActionTestContext()
 		const actions = createLifecycleActions(context)
 		const unwatch = vi.fn()
 		setState({
@@ -90,8 +96,34 @@ describe("lifecycle-actions", () => {
 		await actions.initializeWorkspace()
 
 		expect(unwatch).toHaveBeenCalledTimes(1)
+		expect(ports.indexing.resetIndexingState).toHaveBeenCalledTimes(1)
+		expect(ports.indexing.getIndexingConfig).toHaveBeenCalledWith("/new")
 		expect(getState().workspacePath).toBe("/new")
 		expect(getState().unwatchFn).toBeNull()
+	})
+
+	it("initializeWorkspace does not fail when indexing preload fails", async () => {
+		const { context, deps, ports, getState } = createActionTestContext()
+		const actions = createLifecycleActions(context)
+		const preloadError = new Error("preload failed")
+
+		deps.historyRepository.listWorkspacePaths.mockResolvedValue(["/ws"])
+		deps.fileSystemRepository.isExistingDirectory.mockResolvedValue(true)
+		ports.indexing.getIndexingConfig.mockRejectedValue(preloadError)
+
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+		await actions.initializeWorkspace()
+
+		expect(getState().workspacePath).toBe("/ws")
+		expect(getState().isTreeLoading).toBe(false)
+		expect(ports.indexing.getIndexingConfig).toHaveBeenCalledWith("/ws")
+		expect(errorSpy).toHaveBeenCalledWith(
+			"Failed to preload indexing config:",
+			preloadError,
+		)
+
+		errorSpy.mockRestore()
 	})
 
 	it("initializeWorkspace preserves watcher when workspace path is unchanged", async () => {

--- a/apps/desktop/src/store/workspace/lifecycle/actions.ts
+++ b/apps/desktop/src/store/workspace/lifecycle/actions.ts
@@ -130,6 +130,9 @@ const bootstrapWorkspace = async (
 			},
 		})
 		ctx.set({ isTreeLoading: false })
+		void ctx.ports.indexing.getIndexingConfig(workspacePath).catch((error) => {
+			console.error("Failed to preload indexing config:", error)
+		})
 
 		if (options?.restoreLastOpenedFiles) {
 			await restoreLastOpenedFileHistoryFromSettings(
@@ -178,6 +181,7 @@ export const createLifecycleActions = (
 				ctx,
 				workspacePath,
 			)
+			ctx.ports.indexing.resetIndexingState()
 
 			ctx.set(
 				buildWorkspaceState({
@@ -205,6 +209,7 @@ export const createLifecycleActions = (
 				}),
 			)
 			ctx.ports.collection.resetCollectionPath()
+			ctx.ports.indexing.resetIndexingState()
 		}
 	},
 
@@ -229,6 +234,7 @@ export const createLifecycleActions = (
 			}
 
 			ctx.ports.tab.clearHistory()
+			ctx.ports.indexing.resetIndexingState()
 
 			await ctx.deps.historyRepository.touchWorkspace(path)
 			const updatedHistory =
@@ -246,7 +252,6 @@ export const createLifecycleActions = (
 			ctx.ports.collection.resetCollectionPath()
 
 			await ctx.ports.gitSync.initGitSync(path)
-
 			await bootstrapWorkspace(ctx, path)
 		} catch (error) {
 			console.error("Failed to set workspace:", error)
@@ -283,6 +288,7 @@ export const createLifecycleActions = (
 			return
 		}
 
+		ctx.ports.indexing.resetIndexingState()
 		await ctx.deps.fileSystemRepository.moveToTrash(workspacePath)
 
 		const activeTabPath = ctx.ports.tab.getActiveTabPath()

--- a/apps/desktop/src/store/workspace/shared/action-test-helpers.ts
+++ b/apps/desktop/src/store/workspace/shared/action-test-helpers.ts
@@ -100,6 +100,10 @@ export function createActionTestContext() {
 		gitSync: {
 			initGitSync: vi.fn().mockResolvedValue(undefined),
 		},
+		indexing: {
+			resetIndexingState: vi.fn(),
+			getIndexingConfig: vi.fn().mockResolvedValue(null),
+		},
 	}
 
 	state = {
@@ -156,6 +160,7 @@ export function createActionTestContext() {
 			}
 		}),
 		refreshWorkspaceEntries: vi.fn().mockResolvedValue(undefined),
+		getIndexingConfig: vi.fn().mockResolvedValue(null),
 	}
 
 	const set: WorkspaceActionContext["set"] = (partial) => {

--- a/apps/desktop/src/store/workspace/workspace-ports.ts
+++ b/apps/desktop/src/store/workspace/workspace-ports.ts
@@ -1,5 +1,6 @@
 import type { CollectionSlice } from "../collection/collection-slice"
 import type { GitSyncSlice } from "../git-sync/git-sync-slice"
+import type { IndexingSlice } from "../indexing/indexing-slice"
 import type { TabSlice } from "../tab/tab-slice"
 
 export type WorkspacePorts = {
@@ -26,9 +27,13 @@ export type WorkspacePorts = {
 		| "getCurrentCollectionPath"
 	>
 	gitSync: Pick<GitSyncSlice, "initGitSync">
+	indexing: Pick<IndexingSlice, "resetIndexingState" | "getIndexingConfig">
 }
 
-type WorkspacePortSource = TabSlice & CollectionSlice & GitSyncSlice
+type WorkspacePortSource = TabSlice &
+	CollectionSlice &
+	GitSyncSlice &
+	IndexingSlice
 
 export const createWorkspacePorts = (
 	get: () => WorkspacePortSource,
@@ -56,5 +61,9 @@ export const createWorkspacePorts = (
 	},
 	gitSync: {
 		initGitSync: (...args) => get().initGitSync(...args),
+	},
+	indexing: {
+		resetIndexingState: () => get().resetIndexingState(),
+		getIndexingConfig: (...args) => get().getIndexingConfig(...args),
 	},
 })

--- a/apps/desktop/src/store/workspace/workspace-slice.ts
+++ b/apps/desktop/src/store/workspace/workspace-slice.ts
@@ -16,6 +16,7 @@ import {
 } from "@/utils/frontmatter-utils"
 import type { CollectionSlice } from "../collection/collection-slice"
 import type { GitSyncSlice } from "../git-sync/git-sync-slice"
+import type { IndexingSlice } from "../indexing/indexing-slice"
 import type { TabSlice } from "../tab/tab-slice"
 import {
 	createDirectoryUiActions,
@@ -57,7 +58,8 @@ export type WorkspaceSlice = WorkspaceState & WorkspaceActions
 type WorkspaceSliceStoreState = WorkspaceSlice &
 	TabSlice &
 	CollectionSlice &
-	GitSyncSlice
+	GitSyncSlice &
+	IndexingSlice
 
 export const prepareWorkspaceSlice =
 	(


### PR DESCRIPTION
## Summary
- split desktop indexing settings state into dedicated hooks to isolate metadata polling and model-change handling
- wire session_id tracking through workspace action lifecycle for indexing + embedding refresh race avoidance
- simplify lifecycle and command/menu/editor wiring around indexing state transitions
- keep behavior aligned while reducing duplicated logic across indexing/reindex flows

## Notes
- Existing formatter/lint checks were run via pre-commit hook on commit.
- Tests were not run as part of PR creation in this step.
