### PR TITLE
feat(editor): support Obsidian callout markdown

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -63,6 +63,7 @@
 		"@platejs/suggestion": "^52.0.11",
 		"@platejs/table": "^52.0.11",
 		"@platejs/toc": "^52.0.11",
+		"@r4ai/remark-callout": "^0.6.2",
 		"@tabler/icons-react": "^3.37.1",
 		"@tanstack/react-table": "^8.21.3",
 		"@udecode/cn": "^49.0.15",

--- a/packages/editor/src/callout/index.ts
+++ b/packages/editor/src/callout/index.ts
@@ -1,2 +1,3 @@
 export { CalloutKit } from "./callout-kit"
 export { CalloutElement } from "./node-callout"
+export * from "./obsidian-callout"

--- a/packages/editor/src/callout/node-callout.tsx
+++ b/packages/editor/src/callout/node-callout.tsx
@@ -1,10 +1,71 @@
 import { Button } from "@mdit/ui/components/button"
 import { cn } from "@mdit/ui/lib/utils"
-import { useCalloutEmojiPicker } from "@platejs/callout/react"
-import { useEmojiDropdownMenuState } from "@platejs/emoji/react"
-import { PlateElement } from "platejs/react"
+import type { TElement } from "platejs"
+import {
+	PlateElement,
+	useEditorReadOnly,
+	useEditorRef,
+	useElement,
+} from "platejs/react"
+import { useState } from "react"
 
-import { EmojiPicker, EmojiPopover } from "../emoji/emoji-toolbar-button"
+import { EmojiPopover } from "../emoji/emoji-toolbar-button"
+import {
+	normalizeObsidianCalloutData,
+	OBSIDIAN_CALLOUT_TYPES,
+	type ObsidianCalloutType,
+} from "./obsidian-callout"
+
+const EMOJI_FONT_FAMILY =
+	'"Apple Color Emoji", "Segoe UI Emoji", NotoColorEmoji, "Noto Color Emoji", "Segoe UI Symbol", "Android Emoji", EmojiSymbols'
+
+function CalloutTypePicker({
+	currentType,
+	onSelect,
+}: {
+	currentType: ObsidianCalloutType
+	onSelect: (type: ObsidianCalloutType) => void
+}) {
+	return (
+		<div
+			className="w-56 max-h-80 rounded-xl border bg-popover px-1.5 py-1.5 overflow-y-auto overscroll-none shadow-md"
+			contentEditable={false}
+		>
+			<div className="px-1 py-1 text-xs font-semibold text-muted-foreground">
+				Callout type
+			</div>
+			<div className="flex flex-col gap-0.5">
+				{OBSIDIAN_CALLOUT_TYPES.map(({ emoji, label, value }) => {
+					const selected = currentType === value
+
+					return (
+						<Button
+							key={value}
+							type="button"
+							variant="ghost"
+							className={cn(
+								"h-8 w-full justify-start gap-2 rounded-md px-2 py-1.5 text-sm font-normal",
+								selected && "bg-accent text-accent-foreground",
+							)}
+							aria-label={label}
+							aria-pressed={selected}
+							onMouseDown={(event) => event.preventDefault()}
+							onClick={() => onSelect(value)}
+						>
+							<span
+								className="text-base leading-none"
+								style={{ fontFamily: EMOJI_FONT_FAMILY }}
+							>
+								{emoji}
+							</span>
+							<span className="truncate">{label}</span>
+						</Button>
+					)
+				})}
+			</div>
+		</div>
+	)
+}
 
 export function CalloutElement({
 	attributes,
@@ -12,21 +73,39 @@ export function CalloutElement({
 	className,
 	...props
 }: React.ComponentProps<typeof PlateElement>) {
-	const { emojiPickerState, isOpen, setIsOpen } = useEmojiDropdownMenuState({
-		closeOnSelect: true,
-	})
+	const editor = useEditorRef()
+	const element = useElement() as TElement & {
+		backgroundColor?: string
+		calloutType?: string
+	}
+	const readOnly = useEditorReadOnly()
+	const [isOpen, setIsOpen] = useState(false)
+	const { calloutType: currentType, icon: currentEmoji } =
+		normalizeObsidianCalloutData(element)
 
-	const { emojiToolbarDropdownProps, props: calloutProps } =
-		useCalloutEmojiPicker({
-			isOpen,
-			setIsOpen,
+	const handleSelect = (type: ObsidianCalloutType) => {
+		const path = editor.api.findPath(element)
+		if (!path) return
+
+		const nextCallout = normalizeObsidianCalloutData({
+			...element,
+			calloutType: type,
 		})
+
+		editor.tf.setNodes(
+			{
+				calloutType: nextCallout.calloutType,
+			},
+			{ at: path },
+		)
+		setIsOpen(false)
+	}
 
 	return (
 		<PlateElement
-			className={cn("my-1 flex rounded-sm bg-muted p-4 pl-3", className)}
+			className={cn("my-1 flex rounded-sm bg-muted p-3", className)}
 			style={{
-				backgroundColor: props.element.backgroundColor as string,
+				backgroundColor: element.backgroundColor,
 			}}
 			attributes={{
 				...attributes,
@@ -34,24 +113,30 @@ export function CalloutElement({
 			}}
 			{...props}
 		>
-			<div className="flex w-full items-center gap-2 rounded-md">
+			<div className="flex w-full items-start gap-2 rounded-md">
 				<EmojiPopover
-					{...emojiToolbarDropdownProps}
+					isOpen={isOpen}
+					setIsOpen={(open) => {
+						if (!readOnly) setIsOpen(open)
+					}}
 					control={
 						<Button
 							variant="ghost"
-							className="size-6 p-1 text-[18px] select-none hover:bg-muted-foreground/15"
-							style={{
-								fontFamily:
-									'"Apple Color Emoji", "Segoe UI Emoji", NotoColorEmoji, "Noto Color Emoji", "Segoe UI Symbol", "Android Emoji", EmojiSymbols',
-							}}
+							className="mt-1 size-6 p-1 text-[18px] select-none hover:bg-muted-foreground/15"
+							style={{ fontFamily: EMOJI_FONT_FAMILY }}
 							contentEditable={false}
+							disabled={readOnly}
+							onMouseDown={(event) => event.preventDefault()}
+							aria-label="Select callout type"
 						>
-							{(props.element.icon as string) || "💡"}
+							{currentEmoji}
 						</Button>
 					}
 				>
-					<EmojiPicker {...emojiPickerState} {...calloutProps} />
+					<CalloutTypePicker
+						currentType={currentType}
+						onSelect={handleSelect}
+					/>
 				</EmojiPopover>
 				<div className="w-full">{children}</div>
 			</div>

--- a/packages/editor/src/callout/obsidian-callout.test.ts
+++ b/packages/editor/src/callout/obsidian-callout.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import {
+	formatObsidianCalloutDirective,
+	getObsidianCalloutEmoji,
+	getObsidianCalloutLabel,
+	getObsidianCalloutTypeByEmoji,
+	normalizeObsidianCalloutData,
+	normalizeObsidianCalloutType,
+	OBSIDIAN_CALLOUT_TYPES,
+	parseObsidianCalloutDirective,
+} from "./obsidian-callout"
+
+describe("obsidian callout helpers", () => {
+	it("preserves exact supported types", () => {
+		expect(normalizeObsidianCalloutType("faq")).toBe("faq")
+		expect(normalizeObsidianCalloutType("important")).toBe("important")
+	})
+
+	it("falls back unsupported types to note", () => {
+		expect(normalizeObsidianCalloutType("custom")).toBe("note")
+		expect(getObsidianCalloutLabel("custom")).toBe("Note")
+	})
+
+	it("maps callout types and emojis one-to-one", () => {
+		for (const { emoji, value } of OBSIDIAN_CALLOUT_TYPES) {
+			expect(getObsidianCalloutEmoji(value)).toBe(emoji)
+			expect(getObsidianCalloutTypeByEmoji(emoji)).toBe(value)
+		}
+		expect(getObsidianCalloutTypeByEmoji("🙂")).toBeUndefined()
+	})
+
+	it("normalizes shared callout node data", () => {
+		expect(
+			normalizeObsidianCalloutData({
+				calloutTitle: "  Heads up  ",
+				calloutType: "warning",
+				defaultFolded: 1 as never,
+				isFoldable: true,
+			}),
+		).toEqual({
+			calloutTitle: "Heads up",
+			calloutType: "warning",
+			defaultFolded: true,
+			icon: "⚠️",
+			isFoldable: true,
+		})
+	})
+
+	it("parses fold markers and custom titles", () => {
+		expect(parseObsidianCalloutDirective("[!faq]- Hidden")).toEqual({
+			rawType: "faq",
+			calloutTitle: "Hidden",
+			calloutType: "faq",
+			defaultFolded: true,
+			isFoldable: true,
+		})
+	})
+
+	it("formats canonical directives", () => {
+		expect(
+			formatObsidianCalloutDirective({
+				calloutTitle: "Heads up",
+				calloutType: "faq",
+				defaultFolded: false,
+				isFoldable: true,
+			}),
+		).toBe("[!faq]+ Heads up")
+	})
+})

--- a/packages/editor/src/callout/obsidian-callout.ts
+++ b/packages/editor/src/callout/obsidian-callout.ts
@@ -1,0 +1,208 @@
+export const OBSIDIAN_CALLOUT_TYPES = [
+	{ emoji: "📝", label: "Note", value: "note" },
+	{ emoji: "📄", label: "Abstract", value: "abstract" },
+	{ emoji: "ℹ️", label: "Info", value: "info" },
+	{ emoji: "📋", label: "Todo", value: "todo" },
+	{ emoji: "💡", label: "Tip", value: "tip" },
+	{ emoji: "✅", label: "Success", value: "success" },
+	{ emoji: "❓", label: "Question", value: "question" },
+	{ emoji: "⚠️", label: "Warning", value: "warning" },
+	{ emoji: "❌", label: "Failure", value: "failure" },
+	{ emoji: "🚨", label: "Danger", value: "danger" },
+	{ emoji: "🐞", label: "Bug", value: "bug" },
+	{ emoji: "🧪", label: "Example", value: "example" },
+	{ emoji: "💬", label: "Quote", value: "quote" },
+	{ emoji: "👀", label: "Attention", value: "attention" },
+	{ emoji: "⛔", label: "Caution", value: "caution" },
+	{ emoji: "✔️", label: "Check", value: "check" },
+	{ emoji: "📚", label: "Cite", value: "cite" },
+	{ emoji: "☑️", label: "Done", value: "done" },
+	{ emoji: "🛑", label: "Error", value: "error" },
+	{ emoji: "💥", label: "Fail", value: "fail" },
+	{ emoji: "🙋", label: "FAQ", value: "faq" },
+	{ emoji: "🆘", label: "Help", value: "help" },
+	{ emoji: "🧭", label: "Hint", value: "hint" },
+	{ emoji: "📌", label: "Important", value: "important" },
+	{ emoji: "🕳️", label: "Missing", value: "missing" },
+	{ emoji: "🗒️", label: "Summary", value: "summary" },
+	{ emoji: "✂️", label: "TL;DR", value: "tldr" },
+] as const
+
+export const DEFAULT_OBSIDIAN_CALLOUT_TYPE = "note"
+
+export type ObsidianCalloutDefinition = (typeof OBSIDIAN_CALLOUT_TYPES)[number]
+
+export type ObsidianCalloutType =
+	(typeof OBSIDIAN_CALLOUT_TYPES)[number]["value"]
+
+export type ObsidianCalloutData = {
+	calloutTitle?: string
+	calloutType?: string
+	defaultFolded?: boolean
+	isFoldable?: boolean
+}
+
+export type NormalizedObsidianCalloutData = {
+	calloutTitle?: string
+	calloutType: ObsidianCalloutType
+	defaultFolded: boolean
+	icon: string
+	isFoldable: boolean
+}
+
+const OBSIDIAN_CALLOUT_TYPE_SET = new Set<string>(
+	OBSIDIAN_CALLOUT_TYPES.map(({ value }) => value),
+)
+
+const OBSIDIAN_CALLOUT_TYPES_BY_EMOJI = Object.fromEntries(
+	OBSIDIAN_CALLOUT_TYPES.map(({ value, emoji }) => [emoji, value]),
+) as Record<string, ObsidianCalloutType>
+
+const OBSIDIAN_CALLOUT_DIRECTIVE_REGEX =
+	/^\[!(?<rawType>[^\]]+)\](?<fold>[+-])?(?:\s+(?<title>.*))?$/
+
+export type ParsedObsidianCalloutDirective = {
+	rawType: string
+	calloutTitle?: string
+	calloutType: ObsidianCalloutType
+	defaultFolded: boolean
+	isFoldable: boolean
+}
+
+function normalizeCalloutKey(value: unknown): string {
+	if (typeof value !== "string") return ""
+	return value.trim().toLowerCase()
+}
+
+function normalizeOptionalTitle(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined
+	const normalized = value.trim()
+	return normalized || undefined
+}
+
+export function isObsidianCalloutType(
+	value: unknown,
+): value is ObsidianCalloutType {
+	return OBSIDIAN_CALLOUT_TYPE_SET.has(normalizeCalloutKey(value))
+}
+
+export function normalizeObsidianCalloutType(
+	value: unknown,
+): ObsidianCalloutType {
+	const normalized = normalizeCalloutKey(value)
+
+	if (!normalized) return DEFAULT_OBSIDIAN_CALLOUT_TYPE
+	if (OBSIDIAN_CALLOUT_TYPE_SET.has(normalized)) {
+		return normalized as ObsidianCalloutType
+	}
+
+	return DEFAULT_OBSIDIAN_CALLOUT_TYPE
+}
+
+export function getObsidianCalloutDefinition(
+	value: unknown,
+): ObsidianCalloutDefinition {
+	const type = normalizeObsidianCalloutType(value)
+	return (
+		OBSIDIAN_CALLOUT_TYPES.find((definition) => definition.value === type) ??
+		OBSIDIAN_CALLOUT_TYPES[0]
+	)
+}
+
+export function normalizeObsidianCalloutData(
+	value: ObsidianCalloutData = {},
+): NormalizedObsidianCalloutData {
+	const definition = getObsidianCalloutDefinition(value.calloutType)
+
+	return {
+		calloutTitle: normalizeOptionalTitle(value.calloutTitle),
+		calloutType: definition.value,
+		defaultFolded: Boolean(value.defaultFolded),
+		icon: definition.emoji,
+		isFoldable: Boolean(value.isFoldable),
+	}
+}
+
+export function getObsidianCalloutLabel(value: unknown): string {
+	return getObsidianCalloutDefinition(value).label
+}
+
+export function getObsidianCalloutEmoji(value: unknown): string {
+	return getObsidianCalloutDefinition(value).emoji
+}
+
+export function getObsidianCalloutTypeByEmoji(
+	emoji: unknown,
+): ObsidianCalloutType | undefined {
+	if (typeof emoji !== "string") return undefined
+	return OBSIDIAN_CALLOUT_TYPES_BY_EMOJI[emoji]
+}
+
+export function getGeneratedCalloutTitle(rawType: string): string {
+	const normalized = normalizeCalloutKey(rawType)
+	if (!normalized) return ""
+
+	return normalized.charAt(0).toUpperCase() + normalized.slice(1).toLowerCase()
+}
+
+export function isGeneratedCalloutTitle(
+	title: string | undefined,
+	rawType: string,
+): boolean {
+	if (!title) return true
+	return title.trim() === getGeneratedCalloutTitle(rawType)
+}
+
+export function parseObsidianCalloutDirective(
+	value: string,
+): ParsedObsidianCalloutDirective | null {
+	const match = OBSIDIAN_CALLOUT_DIRECTIVE_REGEX.exec(value.trim())
+	const groups = match?.groups
+	const rawType = groups?.rawType?.trim()
+	if (!rawType) return null
+
+	const title = groups?.title?.trim()
+	const fold = groups?.fold
+	const normalized = normalizeObsidianCalloutData({
+		calloutTitle: title,
+		calloutType: rawType,
+		defaultFolded: fold === "-",
+		isFoldable: fold === "+" || fold === "-",
+	})
+
+	return {
+		rawType,
+		calloutTitle: normalized.calloutTitle,
+		calloutType: normalized.calloutType,
+		defaultFolded: normalized.defaultFolded,
+		isFoldable: normalized.isFoldable,
+	}
+}
+
+export function formatObsidianCalloutDirective({
+	calloutTitle,
+	calloutType,
+	defaultFolded,
+	isFoldable,
+}: {
+	calloutTitle?: string
+	calloutType?: string
+	defaultFolded?: boolean
+	isFoldable?: boolean
+}): string {
+	const normalized = normalizeObsidianCalloutData({
+		calloutTitle,
+		calloutType,
+		defaultFolded,
+		isFoldable,
+	})
+	const foldMarker = normalized.isFoldable
+		? normalized.defaultFolded
+			? "-"
+			: "+"
+		: ""
+
+	return normalized.calloutTitle
+		? `[!${normalized.calloutType}]${foldMarker} ${normalized.calloutTitle}`
+		: `[!${normalized.calloutType}]${foldMarker}`
+}

--- a/packages/editor/src/markdown/markdown-kit.test.ts
+++ b/packages/editor/src/markdown/markdown-kit.test.ts
@@ -197,6 +197,116 @@ describe("markdown-kit serialization", () => {
 		expect(markdown).toContain("See ![[docs/guide]] now.")
 	})
 
+	it("serializes callouts as Obsidian block syntax", async () => {
+		const editor = createMarkdownEditor()
+		const value = [
+			{
+				type: KEYS.callout,
+				calloutType: "tip",
+				defaultFolded: false,
+				isFoldable: true,
+				children: [
+					{
+						type: KEYS.p,
+						calloutTitle: true,
+						children: [{ text: "Heads up" }],
+					},
+					{
+						type: KEYS.p,
+						children: [{ text: "Details" }],
+					},
+				],
+			},
+		]
+
+		const markdown = serializeMd(editor, { value })
+		expect(markdown).toContain("> [!tip]+ Heads up")
+		expect(markdown).toContain("> Details")
+	})
+
+	it("serializes multiline callout bodies with quoted blank lines", async () => {
+		const editor = createMarkdownEditor()
+		const value = [
+			{
+				type: KEYS.callout,
+				calloutType: "warning",
+				children: [
+					{
+						type: KEYS.p,
+						children: [{ text: "First paragraph" }],
+					},
+					{
+						type: KEYS.p,
+						children: [{ text: "Second paragraph" }],
+					},
+				],
+			},
+		]
+
+		const markdown = serializeMd(editor, { value })
+		expect(markdown).toContain("> [!warning]")
+		expect(markdown).toContain("> First paragraph")
+		expect(markdown).toContain(">\n> Second paragraph")
+	})
+
+	it("serializes title-only callouts without inventing a body", async () => {
+		const editor = createMarkdownEditor()
+		const value = [
+			{
+				type: KEYS.callout,
+				calloutType: "info",
+				children: [
+					{
+						type: KEYS.p,
+						calloutTitle: true,
+						children: [{ text: "Read me" }],
+					},
+				],
+			},
+		]
+
+		const markdown = serializeMd(editor, { value })
+		expect(markdown).toBe("> [!info] Read me\n")
+	})
+
+	it("defaults callouts without a type to note", async () => {
+		const editor = createMarkdownEditor()
+		const value = [
+			{
+				type: KEYS.callout,
+				children: [
+					{
+						type: KEYS.p,
+						calloutTitle: true,
+						children: [{ text: "Fallback" }],
+					},
+				],
+			},
+		]
+
+		const markdown = serializeMd(editor, { value })
+		expect(markdown).toContain("> [!note] Fallback")
+	})
+
+	it("preserves exact supported types on serialization", async () => {
+		const editor = createMarkdownEditor()
+		const value = [
+			{
+				type: KEYS.callout,
+				calloutType: "faq",
+				children: [
+					{
+						type: KEYS.p,
+						children: [{ text: "" }],
+					},
+				],
+			},
+		]
+
+		const markdown = serializeMd(editor, { value })
+		expect(markdown).toContain("> [!faq]")
+	})
+
 	it("keeps external links in standard markdown", async () => {
 		const editor = createMarkdownEditor()
 		const value = [
@@ -371,6 +481,131 @@ describe("markdown-kit deserialization", () => {
 			texExpression: "E=mc^2",
 		})
 	})
+
+	it("deserializes Obsidian callouts into callout nodes", async () => {
+		const editor = createMarkdownEditor()
+		const value = deserializeMd(editor, "> [!warning] Watch out\n> Body")
+		const calloutNode = findNodeByType(value as any[], KEYS.callout)
+
+		expect(calloutNode).toMatchObject({
+			type: KEYS.callout,
+			calloutType: "warning",
+		})
+		expect(calloutNode?.children?.[0]).toMatchObject({
+			type: KEYS.p,
+			calloutTitle: true,
+		})
+		expect(extractText(calloutNode)).toContain("Body")
+	})
+
+	it("deserializes Obsidian callouts without MDX enabled", async () => {
+		const editor = createMarkdownEditor({ mdx: false })
+		const value = deserializeMd(editor, "> [!warning] Watch out\n> Body")
+		const calloutNode = findNodeByType(value as any[], KEYS.callout)
+
+		expect(calloutNode).toMatchObject({
+			type: KEYS.callout,
+			calloutType: "warning",
+		})
+		expect(calloutNode?.children?.[0]).toMatchObject({
+			type: KEYS.p,
+			calloutTitle: true,
+		})
+		expect(extractText(calloutNode)).toContain("Body")
+	})
+
+	it("preserves exact supported types on deserialize", async () => {
+		const editor = createMarkdownEditor()
+		const value = deserializeMd(editor, "> [!faq]\n> Body")
+		const calloutNode = findNodeByType(value as any[], KEYS.callout)
+
+		expect(calloutNode).toMatchObject({
+			type: KEYS.callout,
+			calloutType: "faq",
+		})
+	})
+
+	it("normalizes unsupported types to note", async () => {
+		const editor = createMarkdownEditor()
+		const value = deserializeMd(editor, "> [!custom-type]\n> Body")
+		const calloutNode = findNodeByType(value as any[], KEYS.callout)
+
+		expect(calloutNode).toMatchObject({
+			type: KEYS.callout,
+			calloutType: "note",
+		})
+	})
+
+	it("deserializes custom titles into callout children", async () => {
+		const editor = createMarkdownEditor()
+		const value = deserializeMd(
+			editor,
+			"> [!tip] Read this first\n> Then continue",
+		)
+		const calloutNode = findNodeByType(value as any[], KEYS.callout)
+
+		expect(calloutNode).toMatchObject({ calloutType: "tip" })
+		expect(calloutNode?.children?.[0]).toMatchObject({
+			type: KEYS.p,
+			calloutTitle: true,
+		})
+		expect(extractText(calloutNode?.children?.[0])).toBe("Read this first")
+		expect(extractText(calloutNode)).toContain("Then continue")
+	})
+
+	it("deserializes fold markers into foldable state", async () => {
+		const editor = createMarkdownEditor()
+		const value = deserializeMd(editor, "> [!warning]- Hidden\n> Body")
+		const calloutNode = findNodeByType(value as any[], KEYS.callout)
+
+		expect(calloutNode).toMatchObject({
+			calloutType: "warning",
+			defaultFolded: true,
+			isFoldable: true,
+		})
+		expect(calloutNode?.children?.[0]).toMatchObject({
+			type: KEYS.p,
+			calloutTitle: true,
+		})
+		expect(extractText(calloutNode?.children?.[0])).toBe("Hidden")
+		expect(extractText(calloutNode)).toContain("Body")
+	})
+
+	it("round-trips fold markers and titles", async () => {
+		const editor = createMarkdownEditor()
+		const value = deserializeMd(editor, "> [!warning]- Hidden\n> Body")
+
+		const markdown = serializeMd(editor, { value: value as any })
+		expect(markdown).toContain("> [!warning]- Hidden")
+		expect(markdown).toContain("> Body")
+	})
+
+	it("preserves nested callouts inside callout bodies", async () => {
+		const editor = createMarkdownEditor()
+		const value = [
+			{
+				type: KEYS.callout,
+				calloutType: "note",
+				children: [
+					{
+						type: KEYS.callout,
+						calloutType: "warning",
+						children: [
+							{
+								type: KEYS.p,
+								children: [{ text: "Nested body" }],
+							},
+						],
+					},
+				],
+			},
+		]
+
+		const markdown = serializeMd(editor, { value })
+		expect(markdown).toContain("> [!note]")
+		expect(markdown).toContain("> > [!warning]")
+		expect(markdown).toContain("> > Nested body")
+	})
 })
 
 describe("markdown-kit invalid mdx input", () => {
@@ -385,5 +620,17 @@ describe("markdown-kit invalid mdx input", () => {
 		const value = deserializeMd(editor, "<callout icon={>Broken</callout>")
 
 		expect(extractText(value[0] as any)).toContain("Broken")
+	})
+})
+
+describe("markdown-kit legacy mdx callout input", () => {
+	it("does not deserialize legacy mdx callout elements as callout nodes", async () => {
+		const editor = createMarkdownEditor()
+		const value = deserializeMd(editor, '<callout icon="💡">Body</callout>')
+		const calloutNode = findNodeByType(value as any[], KEYS.callout)
+
+		expect(calloutNode).toBeNull()
+		expect(extractText(value[0] as any)).toContain("callout")
+		expect(extractText(value[0] as any)).toContain("Body")
 	})
 })

--- a/packages/editor/src/markdown/markdown-kit.ts
+++ b/packages/editor/src/markdown/markdown-kit.ts
@@ -1,14 +1,11 @@
 import remarkWikiLink from "@flowershow/remark-wiki-link"
 import {
-	convertChildrenDeserialize,
 	convertNodesSerialize,
 	MarkdownPlugin,
-	type MdMdxJsxFlowElement,
-	parseAttributes,
-	propsToAttributes,
 	remarkMdx,
 	remarkMention,
 } from "@platejs/markdown"
+import remarkCallout from "@r4ai/remark-callout"
 import { phrasing } from "mdast-util-phrasing"
 import { getPluginType, KEYS, type TEquationElement } from "platejs"
 import remarkFrontmatter from "remark-frontmatter"
@@ -22,6 +19,12 @@ import {
 	FRONTMATTER_KEY,
 } from "../frontmatter"
 import { hasParentTraversal, WINDOWS_ABSOLUTE_REGEX } from "../link/link-utils"
+import { getPlainText } from "./markdown-utils"
+import {
+	calloutMarkdownRule,
+	remarkObsidianCalloutBridge,
+	remarkObsidianCalloutStringifyHandlers,
+} from "./obsidian-callout-markdown"
 import {
 	OBSIDIAN_EMBED_KEY,
 	ObsidianEmbedPlugin,
@@ -124,18 +127,6 @@ function normalizeWikiTarget(url: string): string {
 	return hashPart ? `${normalizedPath}#${hashPart}` : normalizedPath
 }
 
-function getPlainText(value: unknown): string {
-	if (value == null) return ""
-	if (typeof value === "string") return value
-	if (Array.isArray(value)) return value.map(getPlainText).join("")
-	if (typeof value === "object") {
-		const maybeText = value as { text?: string; children?: unknown }
-		if (typeof maybeText.text === "string") return maybeText.text
-		if (maybeText.children) return getPlainText(maybeText.children)
-	}
-	return ""
-}
-
 function isWikiEmbedTargetSafe(path: string): boolean {
 	const normalized = path.trim()
 	if (!normalized) return false
@@ -209,281 +200,263 @@ export type CreateMarkdownKitOptions = {
 
 export const createMarkdownKit = ({
 	mdx = true,
-}: CreateMarkdownKitOptions = {}) => [
-	ObsidianEmbedPlugin,
-	MarkdownPlugin.configure({
-		options: {
-			disallowedNodes: [KEYS.slashCommand],
-			remarkPlugins: [
-				remarkMath,
-				remarkGfm,
-				...(mdx ? [remarkMdx] : []),
-				remarkMention,
-				remarkFrontmatter,
-				remarkWikiLink,
-			],
-			remarkStringifyOptions: {
-				handlers: {
-					root: (node: MdastRoot, _parent: unknown, state: any, info: any) => {
-						const children = [...node.children]
-						while (children.length > 0 && isEmptyParagraph(children.at(-1))) {
-							children.pop()
-						}
+}: CreateMarkdownKitOptions = {}) => {
+	const remarkPlugins = [
+		remarkMath,
+		remarkGfm,
+		...(mdx ? [remarkMdx] : []),
+		remarkMention,
+		remarkFrontmatter,
+		remarkWikiLink,
+		remarkCallout,
+		remarkObsidianCalloutBridge,
+	] as any[]
 
-						const hasPhrasing = children.some(phrasing)
-						const container = hasPhrasing
-							? state.containerPhrasing
-							: state.containerFlow
-
-						return container.call(state, { ...node, children }, info)
-					},
-				},
-			},
-			rules: {
-				[FRONTMATTER_KEY]: {
-					serialize: (node) => {
-						const record = rowsToRecord(node?.data as any)
-						const yaml = YAML.stringify(record)
-						const value = `---\n${yaml === "{}\n" ? "" : yaml}---`
-						return { type: "html", value }
-					},
-				},
-				[KEYS.equation]: {
-					serialize: (node: TEquationElement) => {
-						const environment = node.environment || "equation"
-						const texExpression = node.texExpression ?? ""
-						const value = `\\begin{${environment}}\n${texExpression}\n\\end{${environment}}`
-
-						return {
-							type: "math",
-							value,
-						}
-					},
-					deserialize: (mdastNode: { value: string }) => {
-						const match = EQUATION_ENVIRONMENT_REGEX.exec(mdastNode.value)
-						if (!match)
-							return {
-								type: KEYS.equation,
-								texExpression: "",
-								environment: "equation",
-								children: [{ text: "" }],
+	return [
+		ObsidianEmbedPlugin,
+		MarkdownPlugin.configure({
+			options: {
+				disallowedNodes: [KEYS.slashCommand],
+				remarkPlugins,
+				remarkStringifyOptions: {
+					handlers: {
+						...remarkObsidianCalloutStringifyHandlers,
+						root: (
+							node: MdastRoot,
+							_parent: unknown,
+							state: any,
+							info: any,
+						) => {
+							const children = [...node.children]
+							while (children.length > 0 && isEmptyParagraph(children.at(-1))) {
+								children.pop()
 							}
 
-						const [, environment, body] = match
+							const hasPhrasing = children.some(phrasing)
+							const container = hasPhrasing
+								? state.containerPhrasing
+								: state.containerFlow
 
-						return {
-							type: KEYS.equation,
-							texExpression: body.trim(),
-							environment,
-							children: [{ text: "" }],
-						}
+							return container.call(state, { ...node, children }, info)
+						},
 					},
 				},
-				yaml: {
-					deserialize: (mdastNode) => {
-						return {
-							type: FRONTMATTER_KEY,
-							data: parseFrontmatterYaml(mdastNode.value),
-							children: [{ text: "" }],
-						}
+				rules: {
+					[FRONTMATTER_KEY]: {
+						serialize: (node) => {
+							const record = rowsToRecord(node?.data as any)
+							const yaml = YAML.stringify(record)
+							const value = `---\n${yaml === "{}\n" ? "" : yaml}---`
+							return { type: "html", value }
+						},
 					},
-				},
-				[KEYS.link]: {
-					serialize: (node: any, options): any => {
-						const rawUrl = node.url ?? ""
-						const shouldSerializeWiki = Boolean(node.wiki || node.wikiTarget)
+					[KEYS.equation]: {
+						serialize: (node: TEquationElement) => {
+							const environment = node.environment || "equation"
+							const texExpression = node.texExpression ?? ""
+							const value = `\\begin{${environment}}\n${texExpression}\n\\end{${environment}}`
 
-						if (shouldSerializeWiki) {
-							const target = node.wikiTarget || normalizeWikiTarget(rawUrl)
-
-							if (!target) {
+							return {
+								type: "math",
+								value,
+							}
+						},
+						deserialize: (mdastNode: { value: string }) => {
+							const match = EQUATION_ENVIRONMENT_REGEX.exec(mdastNode.value)
+							if (!match)
 								return {
-									type: "link",
-									url: rawUrl,
-									children: convertNodesSerialize(node.children, options),
+									type: KEYS.equation,
+									texExpression: "",
+									environment: "equation",
+									children: [{ text: "" }],
+								}
+
+							const [, environment, body] = match
+
+							return {
+								type: KEYS.equation,
+								texExpression: body.trim(),
+								environment,
+								children: [{ text: "" }],
+							}
+						},
+					},
+					yaml: {
+						deserialize: (mdastNode) => {
+							return {
+								type: FRONTMATTER_KEY,
+								data: parseFrontmatterYaml(mdastNode.value),
+								children: [{ text: "" }],
+							}
+						},
+					},
+					[KEYS.link]: {
+						serialize: (node: any, options): any => {
+							const rawUrl = node.url ?? ""
+							const shouldSerializeWiki = Boolean(node.wiki || node.wikiTarget)
+
+							if (shouldSerializeWiki) {
+								const target = node.wikiTarget || normalizeWikiTarget(rawUrl)
+
+								if (!target) {
+									return {
+										type: "link",
+										url: rawUrl,
+										children: convertNodesSerialize(node.children, options),
+									}
+								}
+
+								const text = getPlainText(node.children).trim()
+								const alias = text && text !== target ? text : undefined
+
+								return {
+									type: "wikiLink",
+									value: target,
+									data: alias ? { alias } : {},
 								}
 							}
 
-							const text = getPlainText(node.children).trim()
-							const alias = text && text !== target ? text : undefined
-
 							return {
-								type: "wikiLink",
-								value: target,
-								data: alias ? { alias } : {},
+								type: "link",
+								url: rawUrl,
+								children: convertNodesSerialize(node.children, options),
 							}
-						}
-
-						return {
-							type: "link",
-							url: rawUrl,
-							children: convertNodesSerialize(node.children, options),
-						}
+						},
 					},
-				},
-				[KEYS.img]: {
-					serialize: (node: any): any => {
-						const rawUrl = node.url ?? ""
-						const embedTarget =
-							typeof node.embedTarget === "string"
-								? node.embedTarget.trim()
-								: ""
+					[KEYS.img]: {
+						serialize: (node: any): any => {
+							const rawUrl = node.url ?? ""
+							const embedTarget =
+								typeof node.embedTarget === "string"
+									? node.embedTarget.trim()
+									: ""
 
-						if (embedTarget) {
+							if (embedTarget) {
+								return {
+									type: "paragraph",
+									children: [
+										{
+											type: "embed",
+											value: embedTarget,
+											data: createEmbedNodeData(node.width, node.height),
+										},
+									],
+								}
+							}
+
+							const captionText = node.caption
+								? node.caption
+										.map((c: { text?: string }) => c.text ?? "")
+										.join("")
+								: undefined
+
 							return {
 								type: "paragraph",
 								children: [
 									{
-										type: "embed",
-										value: embedTarget,
-										data: createEmbedNodeData(node.width, node.height),
+										alt: captionText,
+										title: captionText,
+										type: "image",
+										url: rawUrl,
 									},
 								],
 							}
-						}
-
-						const captionText = node.caption
-							? node.caption
-									.map((c: { text?: string }) => c.text ?? "")
-									.join("")
-							: undefined
-
-						return {
-							type: "paragraph",
-							children: [
-								{
-									alt: captionText,
-									title: captionText,
-									type: "image",
-									url: rawUrl,
-								},
-							],
-						}
+						},
 					},
-				},
-				[OBSIDIAN_EMBED_KEY]: {
-					serialize: (node: any) => {
-						const embedTarget =
-							typeof node.embedTarget === "string"
-								? node.embedTarget.trim()
-								: ""
+					[OBSIDIAN_EMBED_KEY]: {
+						serialize: (node: any) => {
+							const embedTarget =
+								typeof node.embedTarget === "string"
+									? node.embedTarget.trim()
+									: ""
 
-						if (!embedTarget) {
-							return { type: "text", value: "" }
-						}
-
-						return {
-							type: "embed",
-							value: embedTarget,
-							data: createEmbedNodeData(node.width, node.height),
-						}
-					},
-				},
-				embed: {
-					deserialize: (mdastNode, _deco, options) => {
-						const target = mdastNode.value || ""
-						const hName = mdastNode.data?.hName
-						const hProperties = mdastNode.data?.hProperties ?? {}
-						const url = hProperties.src || mdastNode.data?.path || target
-						const { width, height } = getEmbedDimensions(mdastNode)
-
-						if (hName === "img") {
-							const altText =
-								typeof hProperties.alt === "string" ? hProperties.alt : ""
+							if (!embedTarget) {
+								return { type: "text", value: "" }
+							}
 
 							return {
-								type: getPluginType(options.editor!, KEYS.img),
-								url,
+								type: "embed",
+								value: embedTarget,
+								data: createEmbedNodeData(node.width, node.height),
+							}
+						},
+					},
+					embed: {
+						deserialize: (mdastNode, _deco, options) => {
+							const target = mdastNode.value || ""
+							const hName = mdastNode.data?.hName
+							const hProperties = mdastNode.data?.hProperties ?? {}
+							const url = hProperties.src || mdastNode.data?.path || target
+							const { width, height } = getEmbedDimensions(mdastNode)
+
+							if (hName === "img") {
+								const altText =
+									typeof hProperties.alt === "string" ? hProperties.alt : ""
+
+								return {
+									type: getPluginType(options.editor!, KEYS.img),
+									url,
+									embedTarget: target,
+									width,
+									height,
+									caption: [{ text: altText }],
+									children: [{ text: "" }],
+								}
+							}
+
+							return {
+								type: getPluginType(options.editor!, OBSIDIAN_EMBED_KEY),
 								embedTarget: target,
 								width,
 								height,
-								caption: [{ text: altText }],
 								children: [{ text: "" }],
 							}
-						}
-
-						return {
-							type: getPluginType(options.editor!, OBSIDIAN_EMBED_KEY),
-							embedTarget: target,
-							width,
-							height,
-							children: [{ text: "" }],
-						}
+						},
 					},
-				},
-				callout: {
-					deserialize: (mdastNode, deco, options) => {
-						const props = parseAttributes(mdastNode.attributes)
-						return {
-							children: convertChildrenDeserialize(
-								mdastNode.children,
-								deco,
-								options,
-							),
-							type: getPluginType(options.editor!, KEYS.callout),
-							...props,
-						}
-					},
-					serialize(slateNode, options): MdMdxJsxFlowElement {
-						const { icon, backgroundColor, variant } = slateNode
-						const attributes = propsToAttributes({
-							icon,
-							backgroundColor,
-							variant,
-						}).filter((attribute) => attribute.value !== "null")
-						return {
-							attributes,
-							children: convertNodesSerialize(
-								slateNode.children,
-								options,
-							) as any,
-							name: "callout",
-							type: "mdxJsxFlowElement",
-						}
-					},
-				},
-				wikiLink: {
-					serialize: (node) => {
-						const target = node.wikiTarget || node.url || ""
-						const text = getPlainText(node.children).trim()
-						if (text && text !== target) {
+					callout: calloutMarkdownRule,
+					wikiLink: {
+						serialize: (node) => {
+							const target = node.wikiTarget || node.url || ""
+							const text = getPlainText(node.children).trim()
+							if (text && text !== target) {
+								return {
+									type: "wikiLink",
+									value: target,
+									data: {
+										alias: text,
+									},
+								}
+							}
 							return {
 								type: "wikiLink",
 								value: target,
-								data: {
-									alias: text,
-								},
+								data: {},
 							}
-						}
-						return {
-							type: "wikiLink",
-							value: target,
-							data: {},
-						}
-					},
-					deserialize: (mdastNode) => {
-						const target = mdastNode.value || ""
-						const alias = mdastNode.data?.alias
-						if (!isWikiEmbedTargetSafe(target)) {
+						},
+						deserialize: (mdastNode) => {
+							const target = mdastNode.value || ""
+							const alias = mdastNode.data?.alias
+							if (!isWikiEmbedTargetSafe(target)) {
+								return {
+									type: KEYS.link,
+									url: "",
+									children: [{ text: alias || target }],
+								}
+							}
 							return {
 								type: KEYS.link,
-								url: "",
+								url: target,
+								wiki: true,
+								wikiTarget: target,
 								children: [{ text: alias || target }],
 							}
-						}
-						return {
-							type: KEYS.link,
-							url: target,
-							wiki: true,
-							wikiTarget: target,
-							children: [{ text: alias || target }],
-						}
+						},
 					},
 				},
 			},
-		},
-	}),
-]
+		}),
+	]
+}
 
 export const MarkdownKit = createMarkdownKit()
 export const MarkdownKitNoMdx = createMarkdownKit({ mdx: false })

--- a/packages/editor/src/markdown/markdown-utils.ts
+++ b/packages/editor/src/markdown/markdown-utils.ts
@@ -1,0 +1,16 @@
+export function getPlainText(value: unknown): string {
+	if (value == null) return ""
+	if (typeof value === "string") return value
+	if (Array.isArray(value)) return value.map(getPlainText).join("")
+	if (typeof value === "object") {
+		const maybeText = value as {
+			children?: unknown
+			text?: string
+			value?: string
+		}
+		if (typeof maybeText.text === "string") return maybeText.text
+		if (typeof maybeText.value === "string") return maybeText.value
+		if (maybeText.children) return getPlainText(maybeText.children)
+	}
+	return ""
+}

--- a/packages/editor/src/markdown/obsidian-callout-markdown.ts
+++ b/packages/editor/src/markdown/obsidian-callout-markdown.ts
@@ -1,0 +1,335 @@
+import {
+	convertChildrenDeserialize,
+	convertNodesSerialize,
+	type MdDecoration,
+	type MdRootContent,
+} from "@platejs/markdown"
+import { type Descendant, getPluginType, KEYS } from "platejs"
+import {
+	formatObsidianCalloutDirective,
+	isGeneratedCalloutTitle,
+	normalizeObsidianCalloutData,
+	type ObsidianCalloutData,
+} from "../callout/obsidian-callout"
+import { getPlainText } from "./markdown-utils"
+
+type MdastRoot = {
+	type: "root"
+	children: MdastNode[]
+}
+
+type MdastNode = {
+	type?: string
+	name?: string
+	children?: MdastNode[]
+	calloutTitle?: string
+	value?: string
+	calloutType?: string
+	defaultFolded?: boolean
+	isFoldable?: boolean
+	data?: {
+		alias?: string
+		hName?: string
+		hProperties?: Record<string, unknown>
+		path?: string
+	}
+}
+
+type MdastCalloutNode = {
+	type: "callout"
+	children: MdastNode[]
+	calloutTitle?: string
+	calloutType?: string
+	defaultFolded?: boolean
+	isFoldable?: boolean
+}
+
+type SlateCalloutChildNode = Descendant & {
+	calloutTitle?: boolean
+	children?: Descendant[]
+	text?: string
+	type?: string
+}
+
+type SlateCalloutNode = ObsidianCalloutData & {
+	children?: SlateCalloutChildNode[]
+}
+
+function createEmptyParagraphNode(): MdastNode {
+	return {
+		type: "paragraph",
+		children: [{ type: "text", value: "" }],
+	}
+}
+
+function ensureCalloutBodyChildren(
+	children: MdastNode[] | undefined,
+): MdastNode[] {
+	if (children && children.length > 0) return children
+	return [createEmptyParagraphNode()]
+}
+
+function getCalloutTitleChildren(node: MdastNode | undefined): MdastNode[] {
+	if (!node) return []
+	if (node.type === "paragraph") return [...(node.children ?? [])]
+
+	if (
+		node.type === "blockquote" &&
+		node.children?.length === 1 &&
+		node.children[0]?.type === "paragraph"
+	) {
+		return [...(node.children[0].children ?? [])]
+	}
+
+	return []
+}
+
+function getCalloutBodyNodes(node: MdastNode | undefined): MdastNode[] {
+	if (!node) return []
+	if (node.type === "blockquote") return [...(node.children ?? [])]
+	return [node]
+}
+
+function isMdastCalloutBodyEmpty(children: MdastNode[] | undefined): boolean {
+	if (!children || children.length === 0) return true
+
+	return children.every((child) => {
+		if (child.type !== "paragraph") return false
+		if (!child.children || child.children.length === 0) return true
+
+		return child.children.every((grandchild: MdastNode) => {
+			if (grandchild.type !== "text") return false
+			const value = typeof grandchild.value === "string" ? grandchild.value : ""
+			return value.trim().length === 0
+		})
+	})
+}
+
+function isSlateCalloutBodyEmpty(children: Descendant[] | undefined): boolean {
+	if (!children || children.length === 0) return true
+
+	return children.every((child) => {
+		if (!child || typeof child !== "object") return false
+		const element = child as { type?: string; children?: unknown[] }
+		if (element.type !== KEYS.p) return false
+		if (!Array.isArray(element.children) || element.children.length === 0)
+			return true
+
+		return element.children.every((leaf) => {
+			if (!leaf || typeof leaf !== "object") return false
+			const text = (leaf as { text?: string }).text
+			return typeof text === "string" && text.trim().length === 0
+		})
+	})
+}
+
+function createSlateCalloutTitleNode(
+	type: string,
+	title: string,
+): SlateCalloutChildNode {
+	return {
+		calloutTitle: true,
+		children: [{ text: title }],
+		type,
+	}
+}
+
+function splitSlateCalloutTitle(
+	children: SlateCalloutChildNode[] | undefined,
+): {
+	bodyChildren: SlateCalloutChildNode[]
+	calloutTitle?: string
+} {
+	if (!children || children.length === 0) {
+		return { bodyChildren: [] }
+	}
+
+	const [firstChild, ...restChildren] = children
+	if (!firstChild?.calloutTitle) {
+		return {
+			bodyChildren: children,
+		}
+	}
+
+	const title = getPlainText(firstChild.children).trim()
+	return {
+		bodyChildren: restChildren,
+		calloutTitle: title || undefined,
+	}
+}
+
+function isObsidianCalloutNode(node: MdastNode | undefined): boolean {
+	return Boolean(node?.data?.hProperties?.dataCallout)
+}
+
+function getNormalizedCalloutNodeData(
+	node: ObsidianCalloutData | undefined,
+): ObsidianCalloutData {
+	const normalized = normalizeObsidianCalloutData(node)
+
+	return {
+		calloutTitle: normalized.calloutTitle,
+		calloutType: normalized.calloutType,
+		defaultFolded: normalized.defaultFolded,
+		isFoldable: normalized.isFoldable,
+	}
+}
+
+function normalizeObsidianCalloutBlockquotes(tree: MdastRoot) {
+	const visitChildren = (children: MdastNode[] | undefined) => {
+		if (!children) return
+
+		for (const [index, child] of children.entries()) {
+			if (isObsidianCalloutNode(child)) {
+				const rawCalloutType =
+					typeof child.data?.hProperties?.dataCalloutType === "string"
+						? child.data.hProperties.dataCalloutType
+						: "note"
+				const [titleNode, bodyNode, ...rest] = child.children ?? []
+				const title = getPlainText(getCalloutTitleChildren(titleNode)).trim()
+				const nextChildren = [...getCalloutBodyNodes(bodyNode), ...rest]
+				const isFoldable = child.data?.hName === "details"
+				const defaultFolded = isFoldable
+					? child.data?.hProperties?.open !== true
+					: false
+				const callout = getNormalizedCalloutNodeData({
+					calloutTitle: isGeneratedCalloutTitle(title, rawCalloutType)
+						? undefined
+						: title,
+					calloutType: rawCalloutType,
+					defaultFolded,
+					isFoldable,
+				})
+
+				visitChildren(nextChildren)
+
+				children[index] = {
+					type: "callout",
+					calloutTitle: callout.calloutTitle,
+					calloutType: callout.calloutType,
+					defaultFolded: callout.defaultFolded,
+					isFoldable: callout.isFoldable,
+					children: isMdastCalloutBodyEmpty(nextChildren)
+						? []
+						: ensureCalloutBodyChildren(nextChildren),
+				}
+				continue
+			}
+
+			visitChildren(child.children)
+		}
+	}
+
+	visitChildren(tree.children)
+}
+
+function calloutLineMap(line: string, _index: number, blank: boolean): string {
+	return `>${blank ? "" : " "}${line}`
+}
+
+export function remarkObsidianCalloutBridge() {
+	return (tree: MdastRoot) => {
+		normalizeObsidianCalloutBlockquotes(tree)
+	}
+}
+
+export const remarkObsidianCalloutStringifyHandlers = {
+	callout: (
+		node: MdastCalloutNode,
+		_parent: unknown,
+		state: any,
+		info: any,
+	) => {
+		const bodyChildren = node.children ?? []
+		const exit = state.enter("blockquote")
+		const tracker = state.createTracker(info)
+
+		tracker.move("> ")
+		tracker.shift(2)
+		const directive = formatObsidianCalloutDirective({
+			calloutTitle: node.calloutTitle,
+			calloutType: node.calloutType,
+			defaultFolded: node.defaultFolded,
+			isFoldable: node.isFoldable,
+		})
+
+		const body = !isMdastCalloutBodyEmpty(bodyChildren)
+			? state.indentLines(
+					state.containerFlow(
+						{
+							type: "root",
+							children: bodyChildren,
+						},
+						tracker.current(),
+					),
+					calloutLineMap,
+				)
+			: ""
+
+		exit()
+		return body ? `> ${directive}\n${body}` : `> ${directive}`
+	},
+}
+
+export const calloutMarkdownRule = {
+	deserialize: (mdastNode: MdastNode, deco: MdDecoration, options: any) => {
+		if (mdastNode.type !== "callout") {
+			return {
+				type: getPluginType(options.editor!, KEYS.p),
+				children: [
+					{ text: `<${mdastNode.name ?? "callout"}>\n` },
+					...convertChildrenDeserialize(
+						(mdastNode.children ?? []) as MdRootContent[],
+						deco,
+						options,
+					),
+					{ text: `\n</${mdastNode.name ?? "callout"}>` },
+				],
+			}
+		}
+
+		const paragraphType = getPluginType(options.editor!, KEYS.p)
+		const bodyChildren =
+			mdastNode.calloutTitle || !isMdastCalloutBodyEmpty(mdastNode.children)
+				? (mdastNode.children ?? [])
+				: ensureCalloutBodyChildren(mdastNode.children)
+		const deserializedChildren = convertChildrenDeserialize(
+			bodyChildren as MdRootContent[],
+			deco,
+			options,
+		) as SlateCalloutChildNode[]
+		const children = mdastNode.calloutTitle
+			? [
+					createSlateCalloutTitleNode(paragraphType, mdastNode.calloutTitle),
+					...deserializedChildren,
+				]
+			: deserializedChildren
+		const callout = getNormalizedCalloutNodeData(mdastNode)
+
+		return {
+			children,
+			type: getPluginType(options.editor!, KEYS.callout),
+			calloutType: callout.calloutType,
+			defaultFolded: callout.defaultFolded,
+			isFoldable: callout.isFoldable,
+		}
+	},
+	serialize: (slateNode: SlateCalloutNode, options: any) => {
+		const { bodyChildren, calloutTitle } = splitSlateCalloutTitle(
+			slateNode.children,
+		)
+		const children = isSlateCalloutBodyEmpty(bodyChildren)
+			? []
+			: convertNodesSerialize(bodyChildren, options)
+		const callout = getNormalizedCalloutNodeData(slateNode)
+
+		return {
+			calloutTitle,
+			calloutType: callout.calloutType,
+			defaultFolded: callout.defaultFolded,
+			isFoldable: callout.isFoldable,
+			children: children as any,
+			type: "callout",
+		}
+	},
+}

--- a/packages/editor/src/slash/node-slash.tsx
+++ b/packages/editor/src/slash/node-slash.tsx
@@ -210,7 +210,7 @@ function createSlashGroups(host: SlashHostDeps): Group[] {
 				{
 					description: "Insert a highlighted block.",
 					icon: <LightbulbIcon />,
-					keywords: ["note"],
+					keywords: ["note", "callout", "obsidian", "[!"],
 					label: "Callout",
 					value: KEYS.callout,
 				},

--- a/packages/editor/src/slash/transforms.ts
+++ b/packages/editor/src/slash/transforms.ts
@@ -1,4 +1,3 @@
-import { insertCallout } from "@platejs/callout"
 import { insertCodeBlock, toggleCodeBlock } from "@platejs/code-block"
 import { insertCodeDrawing } from "@platejs/code-drawing"
 import { insertDate } from "@platejs/date"
@@ -21,6 +20,7 @@ import {
 	type TElement,
 } from "platejs"
 import type { PlateEditor } from "platejs/react"
+import { normalizeObsidianCalloutData } from "../callout/obsidian-callout"
 import { CODE_DRAWING_KEY } from "../code/code-drawing-kit"
 
 const ACTION_THREE_COLUMNS = "action_three_columns"
@@ -46,7 +46,21 @@ const insertBlockMap: Record<
 	[ACTION_THREE_COLUMNS]: (editor) =>
 		insertColumnGroup(editor, { columns: 3, select: true }),
 	[KEYS.audio]: (editor) => insertAudioPlaceholder(editor, { select: true }),
-	[KEYS.callout]: (editor) => insertCallout(editor, { select: true }),
+	[KEYS.callout]: (editor) => {
+		const callout = normalizeObsidianCalloutData()
+
+		editor.tf.insertNodes(
+			{
+				calloutTitle: callout.calloutTitle,
+				calloutType: callout.calloutType,
+				defaultFolded: callout.defaultFolded,
+				isFoldable: callout.isFoldable,
+				children: [{ text: "" }],
+				type: editor.getType(KEYS.callout),
+			},
+			{ select: true },
+		)
+	},
 	[KEYS.codeBlock]: (editor) => insertCodeBlock(editor, { select: true }),
 	[CODE_DRAWING_KEY]: (editor) => {
 		const codeDrawingType = editor.getType(CODE_DRAWING_KEY) || CODE_DRAWING_KEY

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -680,6 +680,9 @@ importers:
       '@platejs/toc':
         specifier: ^52.0.11
         version: 52.0.11(platejs@52.0.17(@types/react@19.2.14)(immer@10.2.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(scheduler@0.27.0)(use-sync-external-store@1.6.0(react@19.2.4)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@r4ai/remark-callout':
+        specifier: ^0.6.2
+        version: 0.6.2
       '@tabler/icons-react':
         specifier: ^3.37.1
         version: 3.37.1(react@19.2.4)
@@ -2482,6 +2485,10 @@ packages:
       '@types/react': ^18.0.0 || ^19.0.0
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
+
+  '@r4ai/remark-callout@0.6.2':
+    resolution: {integrity: sha512-yRj0dzEqdGYquJqTcr68CtAAh47AamWGMbZwiXBTeH6tf2MAh3Rc8C3xYhsRHKX91j9h5JZPTV2YLv+zL08AHQ==}
+    engines: {node: '>=16'}
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -7970,6 +7977,11 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  '@r4ai/remark-callout@0.6.2':
+    dependencies:
+      defu: 6.1.4
+      unist-util-visit: 5.1.0
 
   '@radix-ui/primitive@1.1.3': {}
 


### PR DESCRIPTION
## Summary
- add Obsidian-style `[!type]` callout parsing and serialization in `@mdit/editor`
- keep imported callout titles visible in the editor by representing them as the first callout child block
- add regression coverage for callout type normalization, fold markers, nested callouts, and markdown round-trips

## Testing
- `pnpm -C packages/editor exec tsc --noEmit`
- `pnpm -C packages/editor test -- --runInBand markdown-kit obsidian-callout`
- `pnpm -C /Users/hyeongjin/Workspace/Mdit lint:fix`

## Notes
- callout titles from Obsidian directives are stored in Slate as the first child paragraph with a `calloutTitle` marker, then serialized back into the directive line
- legacy MDX `<callout>` compatibility is not addressed in this change