### PR TITLE
feat(editor): add inline image overlay controls

### DIFF
--- a/packages/editor/src/markdown/markdown-kit.test.ts
+++ b/packages/editor/src/markdown/markdown-kit.test.ts
@@ -159,6 +159,22 @@ describe("markdown-kit serialization", () => {
 		expect(markdown).toContain("![[assets/pic.png|300x200]]")
 	})
 
+	it("serializes internal image embeds with width only", async () => {
+		const editor = createMarkdownEditor()
+		const value = [
+			{
+				type: KEYS.img,
+				url: "assets/pic.png",
+				embedTarget: "assets/pic.png",
+				width: 300,
+				children: [{ text: "" }],
+			},
+		]
+
+		const markdown = serializeMd(editor, { value })
+		expect(markdown).toContain("![[assets/pic.png|300]]")
+	})
+
 	it("serializes internal images as markdown when not embed", async () => {
 		const editor = createMarkdownEditor()
 		const value = [
@@ -174,6 +190,24 @@ describe("markdown-kit serialization", () => {
 		expect(markdown).toContain("![Alt](")
 		expect(markdown).toContain("./assets/pic.png")
 		expect(markdown).not.toContain("![[assets/pic.png]]")
+	})
+
+	it("does not serialize markdown images with resize dimensions", async () => {
+		const editor = createMarkdownEditor()
+		const value = [
+			{
+				type: KEYS.img,
+				url: "./assets/pic.png",
+				width: 300,
+				caption: [{ text: "Alt" }],
+				children: [{ text: "" }],
+			},
+		]
+
+		const markdown = serializeMd(editor, { value })
+		expect(markdown).toContain("![Alt](")
+		expect(markdown).toContain("./assets/pic.png")
+		expect(markdown).not.toContain("|300")
 	})
 
 	it("serializes hidden embeds as embed syntax", async () => {
@@ -417,6 +451,44 @@ describe("markdown-kit deserialization", () => {
 			width: 300,
 			height: 200,
 		})
+	})
+
+	it("deserializes image embeds with width only", async () => {
+		const editor = createMarkdownEditor()
+		const value = deserializeMd(editor, "![[assets/pic.png|300]]")
+		const imageNode = findNodeByType(value as any[], KEYS.img)
+
+		expect(imageNode).toMatchObject({
+			url: "assets/pic.png",
+			embedTarget: "assets/pic.png",
+			width: 300,
+		})
+		expect(imageNode?.height).toBeUndefined()
+	})
+
+	it("round-trips width-only image embeds", async () => {
+		const editor = createMarkdownEditor()
+		const initialValue = [
+			{
+				type: KEYS.img,
+				url: "assets/pic.png",
+				embedTarget: "assets/pic.png",
+				width: 300,
+				children: [{ text: "" }],
+			},
+		]
+
+		const markdown = serializeMd(editor, { value: initialValue })
+		const deserializedValue = deserializeMd(editor, markdown)
+		const imageNode = findNodeByType(deserializedValue as any[], KEYS.img)
+
+		expect(markdown).toContain("![[assets/pic.png|300]]")
+		expect(imageNode).toMatchObject({
+			url: "assets/pic.png",
+			embedTarget: "assets/pic.png",
+			width: 300,
+		})
+		expect(imageNode?.height).toBeUndefined()
 	})
 
 	it("deserializes non-image embeds into hidden nodes", async () => {

--- a/packages/editor/src/media/media-image-mode-switch.tsx
+++ b/packages/editor/src/media/media-image-mode-switch.tsx
@@ -1,10 +1,12 @@
-import { Switch } from "@mdit/ui/components/switch"
+import { cn } from "@mdit/ui/lib/utils"
+import { FileText, ImageIcon } from "lucide-react"
 import type { TImageElement } from "platejs"
 import { useEditorRef, useElement } from "platejs/react"
 import {
 	buildImageModeUpdate,
 	isImageModeToggleDisabled,
 } from "./media-image-mode-utils"
+import { MediaOverlayButton } from "./media-overlay-button"
 import type { MediaImageWorkspaceState } from "./node-media-image"
 
 type ImageElementWithEmbed = TImageElement & {
@@ -14,8 +16,10 @@ type ImageElementWithEmbed = TImageElement & {
 
 export function MediaImageModeSwitch({
 	workspaceState,
+	className,
 }: {
 	workspaceState: MediaImageWorkspaceState
+	className?: string
 }) {
 	const editor = useEditorRef()
 	const element = useElement() as ImageElementWithEmbed
@@ -43,15 +47,24 @@ export function MediaImageModeSwitch({
 	}
 
 	return (
-		<div className="flex items-center gap-2 px-2 text-xs text-muted-foreground">
-			<span>Markdown</span>
-			<Switch
-				checked={checked}
-				disabled={disabled}
-				onCheckedChange={handleCheckedChange}
-				aria-label="Toggle image embed mode"
-			/>
-			<span>Embed</span>
-		</div>
+		<MediaOverlayButton
+			className={cn(
+				checked && "bg-background text-foreground shadow-xs",
+				className,
+			)}
+			disabled={disabled}
+			aria-label={
+				checked
+					? "Convert image to markdown mode"
+					: "Convert image to embed mode"
+			}
+			aria-pressed={checked}
+			onMouseDown={(e) => {
+				e.preventDefault()
+			}}
+			onClick={() => handleCheckedChange(!checked)}
+		>
+			{checked ? <ImageIcon /> : <FileText />}
+		</MediaOverlayButton>
 	)
 }

--- a/packages/editor/src/media/media-image-overlay.tsx
+++ b/packages/editor/src/media/media-image-overlay.tsx
@@ -1,0 +1,98 @@
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@mdit/ui/components/tooltip"
+import { cn } from "@mdit/ui/lib/utils"
+import { useCaptionButton, useCaptionButtonState } from "@platejs/caption/react"
+import { Trash2Icon, TypeIcon } from "lucide-react"
+import type { ComponentProps, MouseEventHandler } from "react"
+import { MediaImageModeSwitch } from "./media-image-mode-switch"
+import { MediaOverlayButton } from "./media-overlay-button"
+import type { MediaImageWorkspaceState } from "./node-media-image"
+
+type MediaImageOverlayProps = {
+	isEmbedImage: boolean
+	overlayVisible: boolean
+	workspaceState: MediaImageWorkspaceState
+	onDeleteMouseDown?: MouseEventHandler<HTMLButtonElement>
+	deleteButtonProps?: Omit<
+		ComponentProps<typeof MediaOverlayButton>,
+		"children" | "className" | "onMouseDown" | "type"
+	>
+}
+
+function MediaImageCaptionButton({ isEmbedImage }: { isEmbedImage: boolean }) {
+	const state = useCaptionButtonState()
+	const captionButton = useCaptionButton(state)
+
+	return (
+		<MediaOverlayButton
+			disabled={isEmbedImage}
+			aria-label="Caption"
+			{...captionButton.props}
+		>
+			<TypeIcon />
+		</MediaOverlayButton>
+	)
+}
+
+export function MediaImageOverlay({
+	deleteButtonProps,
+	isEmbedImage,
+	onDeleteMouseDown,
+	overlayVisible,
+	workspaceState,
+}: MediaImageOverlayProps) {
+	return (
+		<TooltipProvider delayDuration={150}>
+			<div
+				className={cn(
+					"pointer-events-none absolute top-1 right-1 z-50 flex items-center gap-0.5 rounded-md border bg-background p-0.5 shadow-sm backdrop-blur-sm transition-opacity",
+					"group-hover/media:pointer-events-auto group-hover/media:opacity-100",
+					overlayVisible ? "pointer-events-auto opacity-100" : "opacity-0",
+				)}
+			>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<div>
+							<MediaImageModeSwitch workspaceState={workspaceState} />
+						</div>
+					</TooltipTrigger>
+					<TooltipContent side="top" sideOffset={8}>
+						{isEmbedImage
+							? "Convert to markdown image"
+							: "Convert to embedded image"}
+					</TooltipContent>
+				</Tooltip>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<div>
+							<MediaImageCaptionButton isEmbedImage={isEmbedImage} />
+						</div>
+					</TooltipTrigger>
+					<TooltipContent side="top" sideOffset={8}>
+						{isEmbedImage
+							? "Captions are unavailable in embed mode"
+							: "Caption"}
+					</TooltipContent>
+				</Tooltip>
+
+				<div className="mx-0.5 h-3.5 w-px bg-border" />
+
+				<MediaOverlayButton
+					aria-label="Delete image"
+					onMouseDown={(e) => {
+						e.preventDefault()
+						onDeleteMouseDown?.(e)
+					}}
+					{...deleteButtonProps}
+				>
+					<Trash2Icon />
+				</MediaOverlayButton>
+			</div>
+		</TooltipProvider>
+	)
+}

--- a/packages/editor/src/media/media-overlay-button.tsx
+++ b/packages/editor/src/media/media-overlay-button.tsx
@@ -1,0 +1,20 @@
+import { Button as BaseButton } from "@base-ui/react/button"
+import { cn } from "@mdit/ui/lib/utils"
+import type { ComponentProps } from "react"
+
+export function MediaOverlayButton({
+	className,
+	type = "button",
+	...props
+}: ComponentProps<typeof BaseButton>) {
+	return (
+		<BaseButton
+			type={type}
+			className={cn(
+				"inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-3.5 [&_svg]:shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+				className,
+			)}
+			{...props}
+		/>
+	)
+}

--- a/packages/editor/src/media/node-media-image.tsx
+++ b/packages/editor/src/media/node-media-image.tsx
@@ -5,13 +5,12 @@ import { ImageOff } from "lucide-react"
 import { dirname, isAbsolute, resolve } from "pathe"
 import type { NodeComponent, TImageElement } from "platejs"
 import type { PlateElementProps } from "platejs/react"
-import { PlateElement, withHOC } from "platejs/react"
+import { PlateElement, useRemoveNodeButton, withHOC } from "platejs/react"
 import { useMemo, useState } from "react"
 import { hasParentTraversal, WINDOWS_ABSOLUTE_REGEX } from "../link"
 import { Caption, CaptionTextarea } from "../media/caption"
-import { MediaImageModeSwitch } from "../media/media-image-mode-switch"
 import type { ImageElementWithEmbed } from "../media/media-image-mode-utils"
-import { MediaToolbar } from "../media/media-toolbar"
+import { MediaImageOverlay } from "../media/media-image-overlay"
 import {
 	mediaResizeHandleVariants,
 	Resizable,
@@ -89,83 +88,90 @@ export const createImageElement = (host: MediaImageHostDeps): NodeComponent =>
 			const [hasError, setHasError] = useState(false)
 
 			const element = props.element as ImageElementWithEmbed
+			const { props: removeButtonProps } = useRemoveNodeButton({ element })
+			const { onMouseDown: removeButtonMouseDown, ...removeButtonRestProps } =
+				removeButtonProps
 			const src = useMemo(
 				() => resolveImageSrc(element, workspaceState, host.toFileUrl),
 				[element, workspaceState],
 			)
 
 			const isEmbedImage = Boolean(element.embedTarget)
+			const overlayVisible = focused && selected
 
 			return (
-				<MediaToolbar
-					hide={hasError}
-					toolbarContent={
-						<MediaImageModeSwitch workspaceState={workspaceState} />
-					}
-					showCaption={!isEmbedImage}
-				>
-					<PlateElement {...props} className="py-2.5">
-						{hasError ? (
-							<div
-								className={cn(
-									"flex flex-col items-center justify-center w-full min-h-[200px] bg-muted rounded-sm borderpx-4 py-8 cursor-default",
-									focused && selected && "ring-2 ring-ring ring-offset-2",
-								)}
-								contentEditable={false}
+				<PlateElement {...props} className="py-2.5">
+					{hasError ? (
+						<div
+							className={cn(
+								"flex flex-col items-center justify-center w-full min-h-[200px] bg-muted rounded-sm border px-4 py-8 cursor-default",
+								focused && selected && "ring-2 ring-ring ring-offset-2",
+							)}
+							contentEditable={false}
+						>
+							<ImageOff className="w-12 h-12 text-muted-foreground/50 mb-3" />
+							<p className="text-sm text-muted-foreground text-center">
+								Failed to load image. Please check the file path.
+							</p>
+						</div>
+					) : (
+						<figure className="group/media m-0" contentEditable={false}>
+							<Resizable
+								align={align}
+								className="group/image-resizable relative"
+								options={{
+									align,
+									readOnly,
+								}}
 							>
-								<ImageOff className="w-12 h-12 text-muted-foreground/50 mb-3" />
-								<p className="text-sm text-muted-foreground text-center">
-									Failed to load image. Please check the file path.
-								</p>
-							</div>
-						) : (
-							<figure className="group relative m-0" contentEditable={false}>
-								<Resizable
-									align={align}
-									options={{
-										align,
-										readOnly,
-									}}
-								>
-									<ResizeHandle
-										className={mediaResizeHandleVariants({ direction: "left" })}
-										options={{ direction: "left" }}
+								{!readOnly && (
+									<MediaImageOverlay
+										deleteButtonProps={removeButtonRestProps}
+										isEmbedImage={isEmbedImage}
+										onDeleteMouseDown={removeButtonMouseDown}
+										overlayVisible={overlayVisible}
+										workspaceState={workspaceState}
 									/>
-									<Image
-										className={cn(
-											"block w-full max-w-full cursor-pointer object-cover px-0",
-											"rounded-sm",
-											focused && selected && "ring-2 ring-ring ring-offset-2",
-										)}
-										alt={props.attributes.alt as string | undefined}
-										src={src}
-										onError={() => setHasError(true)}
-									/>
-									<ResizeHandle
-										className={mediaResizeHandleVariants({
-											direction: "right",
-										})}
-										options={{ direction: "right" }}
-									/>
-								</Resizable>
-
-								{!isEmbedImage && (
-									<Caption style={{ width }} align={align}>
-										<CaptionTextarea
-											readOnly={readOnly}
-											onFocus={(e) => {
-												e.preventDefault()
-											}}
-											placeholder="Write a caption..."
-										/>
-									</Caption>
 								)}
-							</figure>
-						)}
 
-						{props.children}
-					</PlateElement>
-				</MediaToolbar>
+								<ResizeHandle
+									className={mediaResizeHandleVariants({ direction: "left" })}
+									options={{ direction: "left" }}
+								/>
+								<Image
+									className={cn(
+										"block w-full max-w-full cursor-pointer object-cover px-0",
+										"rounded-sm",
+										focused && selected && "ring-2 ring-brand/75 ring-offset-2",
+									)}
+									alt={props.attributes.alt as string | undefined}
+									src={src}
+									onError={() => setHasError(true)}
+								/>
+								<ResizeHandle
+									className={mediaResizeHandleVariants({
+										direction: "right",
+									})}
+									options={{ direction: "right" }}
+								/>
+							</Resizable>
+
+							{!isEmbedImage && (
+								<Caption style={{ width }} align={align}>
+									<CaptionTextarea
+										readOnly={readOnly}
+										onFocus={(e) => {
+											e.preventDefault()
+										}}
+										placeholder="Write a caption..."
+									/>
+								</Caption>
+							)}
+						</figure>
+					)}
+
+					{props.children}
+				</PlateElement>
 			)
 		},
 	)

--- a/packages/editor/src/shared/resize-handle.tsx
+++ b/packages/editor/src/shared/resize-handle.tsx
@@ -16,8 +16,8 @@ export const mediaResizeHandleVariants = cva(
 	{
 		variants: {
 			direction: {
-				left: "-left-3 -ml-3 pl-3",
-				right: "-right-3 -mr-3 items-end pr-3",
+				left: "left-1",
+				right: "right-1 items-end",
 			},
 		},
 	},


### PR DESCRIPTION
## Summary
- replace the image popover toolbar with an inline overlay for mode switch, caption, and delete actions
- add shared overlay button primitives and wire image deletion through the new overlay
- extend markdown image embed tests to cover width-only resize serialization and round-trips

## Testing
- pnpm -C packages/editor test -- markdown-kit.test.ts