### PR TITLE
feat: add fixed tab number shortcuts

### DIFF
--- a/apps/desktop/src/components/hotkeys/hotkeys.test.ts
+++ b/apps/desktop/src/components/hotkeys/hotkeys.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+import { getTabIdForNumberShortcut } from "./hotkeys"
+
+describe("getTabIdForNumberShortcut", () => {
+	it("selects the first, second, and ninth tabs by number", () => {
+		const tabs = Array.from({ length: 9 }, (_, index) => ({
+			id: index + 101,
+		}))
+
+		expect(getTabIdForNumberShortcut(tabs, 1)).toBe(101)
+		expect(getTabIdForNumberShortcut(tabs, 2)).toBe(102)
+		expect(getTabIdForNumberShortcut(tabs, 9)).toBe(109)
+	})
+
+	it("returns null when the requested tab number does not exist", () => {
+		const tabs = [{ id: 11 }, { id: 22 }, { id: 33 }]
+
+		expect(getTabIdForNumberShortcut(tabs, 4)).toBeNull()
+		expect(getTabIdForNumberShortcut(tabs, 9)).toBeNull()
+	})
+
+	it("maps shortcut 9 to the ninth tab instead of the last tab", () => {
+		const tabs = Array.from({ length: 12 }, (_, index) => ({
+			id: index + 1,
+		}))
+
+		expect(getTabIdForNumberShortcut(tabs, 9)).toBe(9)
+	})
+})

--- a/apps/desktop/src/components/hotkeys/hotkeys.tsx
+++ b/apps/desktop/src/components/hotkeys/hotkeys.tsx
@@ -43,7 +43,6 @@ export function Hotkeys() {
 		isEditMode,
 		closeActiveTab,
 		openFolderPicker,
-		tabs,
 		activateTabById,
 		activatePreviousTab,
 		activateNextTab,
@@ -70,7 +69,6 @@ export function Hotkeys() {
 			isEditMode: s.isEditMode,
 			closeActiveTab: s.closeActiveTab,
 			openFolderPicker: s.openFolderPicker,
-			tabs: s.tabs,
 			activateTabById: s.activateTabById,
 			activatePreviousTab: s.activatePreviousTab,
 			activateNextTab: s.activateNextTab,
@@ -102,14 +100,17 @@ export function Hotkeys() {
 
 	const handleActivateTabByNumber = useCallback(
 		(digit: number) => {
-			const targetTabId = getTabIdForNumberShortcut(tabs, digit)
+			const targetTabId = getTabIdForNumberShortcut(
+				useStore.getState().tabs,
+				digit,
+			)
 			if (targetTabId === null) {
 				return
 			}
 
 			activateTabById(targetTabId)
 		},
-		[activateTabById, tabs],
+		[activateTabById],
 	)
 
 	const actionHandlers = useMemo<Record<AppHotkeyActionId, () => void>>(

--- a/apps/desktop/src/components/hotkeys/hotkeys.tsx
+++ b/apps/desktop/src/components/hotkeys/hotkeys.tsx
@@ -1,6 +1,7 @@
 import {
 	APP_HOTKEY_DEFINITIONS,
 	type AppHotkeyActionId,
+	FIXED_TAB_SHORTCUT_DIGITS,
 } from "@mdit/store/hotkeys"
 import { useHotkey } from "@tanstack/react-hotkeys"
 import { useCallback, useMemo } from "react"
@@ -9,7 +10,6 @@ import { closeTabOrHideWindow } from "@/lib/close-tab-or-hide-window"
 import { useStore } from "@/store"
 
 const HOTKEY_OPTIONS = { preventDefault: true } as const
-
 type HotkeyBindingProps = {
 	binding: string
 	onTrigger: () => void
@@ -24,6 +24,17 @@ function HotkeyBinding({ binding, onTrigger }: HotkeyBindingProps) {
 	return null
 }
 
+export function getTabIdForNumberShortcut<T extends { id: number }>(
+	tabs: readonly T[],
+	digit: number,
+): number | null {
+	if (!Number.isInteger(digit) || digit < 1 || digit > 9) {
+		return null
+	}
+
+	return tabs[digit - 1]?.id ?? null
+}
+
 export function Hotkeys() {
 	const {
 		hotkeys,
@@ -32,6 +43,8 @@ export function Hotkeys() {
 		isEditMode,
 		closeActiveTab,
 		openFolderPicker,
+		tabs,
+		activateTabById,
 		activatePreviousTab,
 		activateNextTab,
 		workspacePath,
@@ -57,6 +70,8 @@ export function Hotkeys() {
 			isEditMode: s.isEditMode,
 			closeActiveTab: s.closeActiveTab,
 			openFolderPicker: s.openFolderPicker,
+			tabs: s.tabs,
+			activateTabById: s.activateTabById,
 			activatePreviousTab: s.activatePreviousTab,
 			activateNextTab: s.activateNextTab,
 			workspacePath: s.workspacePath,
@@ -84,6 +99,18 @@ export function Hotkeys() {
 			closeActiveTab,
 		})
 	}, [activeTabId, closeActiveTab, isEditMode])
+
+	const handleActivateTabByNumber = useCallback(
+		(digit: number) => {
+			const targetTabId = getTabIdForNumberShortcut(tabs, digit)
+			if (targetTabId === null) {
+				return
+			}
+
+			activateTabById(targetTabId)
+		},
+		[activateTabById, tabs],
+	)
 
 	const actionHandlers = useMemo<Record<AppHotkeyActionId, () => void>>(
 		() => ({
@@ -183,6 +210,13 @@ export function Hotkeys() {
 					/>
 				)
 			})}
+			{FIXED_TAB_SHORTCUT_DIGITS.map((digit) => (
+				<HotkeyBinding
+					key={`fixed-tab-shortcut-${digit}`}
+					binding={`Mod+${digit}`}
+					onTrigger={() => handleActivateTabByNumber(digit)}
+				/>
+			))}
 		</>
 	)
 }

--- a/packages/store/src/core.ts
+++ b/packages/store/src/core.ts
@@ -40,10 +40,12 @@ export {
 	APP_HOTKEY_CATEGORY_LABELS,
 	APP_HOTKEY_DEFINITIONS,
 	createDefaultAppHotkeys,
+	FIXED_TAB_SHORTCUT_DIGITS,
 	findHotkeyConflict,
 	hotkeyToDisplayTokens,
 	hotkeyToMenuAccelerator,
 	isAppHotkeyActionId,
+	isReservedAppHotkeyBinding,
 	mergeWithDefaultHotkeys,
 	normalizeHotkeyBinding,
 } from "./hotkeys/hotkey-utils"

--- a/packages/store/src/hotkeys/hotkey-utils.ts
+++ b/packages/store/src/hotkeys/hotkey-utils.ts
@@ -30,6 +30,8 @@ export type AppHotkeyDefinition = {
 
 export type AppHotkeyMap = Record<AppHotkeyActionId, string>
 
+export const FIXED_TAB_SHORTCUT_DIGITS = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const
+
 export const APP_HOTKEY_DEFINITIONS: readonly AppHotkeyDefinition[] = [
 	{
 		id: "create-note",
@@ -250,6 +252,17 @@ export function findHotkeyConflict(
 	}
 
 	return null
+}
+
+export function isReservedAppHotkeyBinding(binding: string): boolean {
+	const normalizedBinding = normalizeHotkeyBinding(binding)
+	if (!normalizedBinding) {
+		return false
+	}
+
+	return FIXED_TAB_SHORTCUT_DIGITS.some(
+		(digit) => normalizedBinding === `Mod+${digit}`,
+	)
 }
 
 export function hotkeyToMenuAccelerator(binding: string): string | undefined {

--- a/packages/store/src/hotkeys/hotkeys-slice.test.ts
+++ b/packages/store/src/hotkeys/hotkeys-slice.test.ts
@@ -81,6 +81,18 @@ describe("hotkeys-slice", () => {
 		expect(storage.save).not.toHaveBeenCalled()
 	})
 
+	it("rejects fixed tab shortcut bindings", async () => {
+		const store = createHotkeysStore(storage)
+
+		const result = await store
+			.getState()
+			.setHotkeyBinding("create-note", "mod+1")
+
+		expect(result.success).toBe(false)
+		expect(result.error).toBe("Shortcut is reserved for tab switching")
+		expect(storage.save).not.toHaveBeenCalled()
+	})
+
 	it("allows unassigned hotkeys", async () => {
 		const store = createHotkeysStore(storage)
 

--- a/packages/store/src/hotkeys/hotkeys-slice.ts
+++ b/packages/store/src/hotkeys/hotkeys-slice.ts
@@ -5,6 +5,7 @@ import {
 	type AppHotkeyMap,
 	createDefaultAppHotkeys,
 	findHotkeyConflict,
+	isReservedAppHotkeyBinding,
 	normalizeHotkeyBinding,
 } from "./hotkey-utils"
 
@@ -72,6 +73,13 @@ export const prepareHotkeysSlice =
 					return {
 						success: false,
 						error: validationResult.errors[0] ?? "Invalid hotkey format",
+					}
+				}
+
+				if (isReservedAppHotkeyBinding(normalizedBinding)) {
+					return {
+						success: false,
+						error: "Shortcut is reserved for tab switching",
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- add fixed Mod+1 through Mod+9 tab switching shortcuts in the desktop hotkey layer
- reserve those bindings in the store hotkey utilities and reject them in hotkey settings
- add coverage for tab-number resolution and reserved-binding validation

## Testing
- pnpm test:packages
- pnpm ts:check:desktop
- pnpm lint:fix

## Notes
- existing saved custom Mod+1 through Mod+9 bindings are not migrated in this patch